### PR TITLE
Fix detection of CST816 with autosleep

### DIFF
--- a/drivers/touch/cst8xx.py
+++ b/drivers/touch/cst8xx.py
@@ -43,10 +43,10 @@ class CST8XX():
 
         self._bus = bus
         self._address = address
-        if self._read(_REG_CHIP_ID)[0] not in (_CST816S_ID, _CST816T_ID, _CST816D_ID, _CST820_ID, _CST826_ID):
-            raise ValueError("Error:  CST8xx not detected.")
         self.rst = Pin(rst_pin, Pin.OUT) if isinstance(rst_pin, int) else rst_pin
         self.reset()
+        if self._read(_REG_CHIP_ID)[0] not in (_CST816S_ID, _CST816T_ID, _CST816D_ID, _CST820_ID, _CST826_ID):
+            raise ValueError("Error:  CST8xx not detected.")
         self.disable_autosleep()
 
         self.irq = Pin(irq_pin, Pin.IN, Pin.PULL_UP) if isinstance(irq_pin, int) else irq_pin


### PR DESCRIPTION
CST816 touch controller has an autosleep feature enabled by default and will not appear as a I2C device unless recently touched or reset. 

The driver needs to do the supported device test after sending a reset to ensure device is detectable, currently init() fails on device detection unless the unit was recently powered up or hard (not soft) reset.

This was /really/ confusing for me when trying to get my code running on a T-Display Touch, (lost an hr debugging as an I2C issue.. fortunately I'd run esp-ide examples where touch did work, so I persisted)



ref:
https://github.com/espressif/esp-bsp/issues/178#issuecomment-1588817982
https://github.com/fbiego/CST816S/tree/main?tab=readme-ov-file#auto-sleep-control
