### PR TITLE
Implemented Joystick Device + some extras

### DIFF
--- a/board_configs/busdisplay/spi/esp32_wrover_e_st7789_joystick/board_config.py
+++ b/board_configs/busdisplay/spi/esp32_wrover_e_st7789_joystick/board_config.py
@@ -1,0 +1,53 @@
+"""ESP32 WROVER E with ST7789 display, and joystick instead of touchscreen"""
+
+from gpiojoystick import GPIOJoystick
+from spibus import SPIBus
+from st7789 import ST7789
+from eventsys import devices
+from machine import ADC, Pin
+
+display_bus = SPIBus(
+    id=1,
+    sck=14,
+    mosi=12,
+    dc=13,
+    cs=15,
+)
+
+display_drv = ST7789(
+    display_bus,
+    width=240,
+    height=240,
+    colstart=0,
+    rowstart=0,
+    rotation=0,
+    mirrored=True,
+    color_depth=16,
+    bgr=True,
+    reverse_bytes_in_word=True,
+    invert=False,
+    brightness=1.0,
+    backlight_pin=None,
+    backlight_on_high=True,
+)
+
+joystick_driver = GPIOJoystick(
+    instance_id=1,
+    axes=[
+        ADC(Pin(39), atten=ADC.ATTN_11DB),
+        ADC(Pin(36), atten=ADC.ATTN_11DB)
+    ],
+    buttons=[
+        Pin(4, Pin.IN, Pin.PULL_UP),
+        Pin(25, Pin.IN, Pin.PULL_UP),
+        Pin(26, Pin.IN, Pin.PULL_UP)
+    ],
+)
+
+broker = devices.Broker()
+
+joystick_dev = broker.create_device(
+    type=devices.types.JOYSTICK,
+    joystick_driver=joystick_driver,
+    emulate_digital=[(0,1)]
+)

--- a/board_configs/busdisplay/spi/esp32_wrover_e_st7789_joystick/package.json
+++ b/board_configs/busdisplay/spi/esp32_wrover_e_st7789_joystick/package.json
@@ -1,0 +1,11 @@
+{
+    "urls": [
+      ["board_config.py", "github:PyDevices/pydisplay/board_configs/busdisplay/spi/esp32_wrover_e_st7789_joystick/board_config.py"],
+      ["st7789.py", "github:PyDevices/pydisplay/drivers/display/st7789.py"],
+      ["gpiojoystick.py", "github:PyDevices/pydisplay/drivers/joystick/gpiojoystick.py"]
+    ],
+    "deps": [
+      ["github:PyDevices/pydisplay/packages/spibus.json", "main"]
+    ],
+    "version": "0.1"
+  }

--- a/drivers/joystick/gpiojoystick.py
+++ b/drivers/joystick/gpiojoystick.py
@@ -10,7 +10,7 @@ class GPIOJoystick(JoystickDriver):
         axes: A list of ADC objects for the axes.
         buttons: A list of Pin objects for the buttons.
         button_high: True if logic high when button is pressed.
-        hats: A list of tuples of Pin objects for the hats. A hat is a 4-way switch, like a d-pad. 4 pins: left, right, up, down.
+        hats: A list of tuples of Pin objects for the hats. A hat is a 4-way switch, like a d-pad. 4 pins: left, right, down, up.
     """
     def __init__(
         self,
@@ -47,7 +47,7 @@ class GPIOJoystick(JoystickDriver):
         return self._buttons[button].value() == cmp
 
     def get_hat(self, hat):
-        l, r, u, d = self._hats[hat]
+        l, r, d, u = self._hats[hat]
         cmp = 1 if self._button_high else 0
         if (l.value() == cmp and r.value() == cmp) or (u.value() == cmp and d.value() == cmp):
             raise ValueError("Hat is in an invalid position")

--- a/drivers/joystick/gpiojoystick.py
+++ b/drivers/joystick/gpiojoystick.py
@@ -1,0 +1,58 @@
+from eventsys.joystick import JoystickDriver
+from machine import ADC,Pin
+
+class GPIOJoystick(JoystickDriver):
+    """
+    A driver for a joystick that uses GPIO inputs.
+
+    Args:
+        instance_id: The instance ID of the joystick. (pygame joystick index)
+        axes: A list of ADC objects for the axes.
+        buttons: A list of Pin objects for the buttons.
+        button_high: True if logic high when button is pressed.
+        hats: A list of tuples of Pin objects for the hats. A hat is a 4-way switch, like a d-pad. 4 pins: left, right, up, down.
+    """
+    def __init__(
+        self,
+        instance_id: int,
+        axes: list[ADC],
+        buttons: list[Pin] = [],
+        button_high: bool = False,
+        hats: list[(Pin, Pin, Pin, Pin)] = [],
+
+    ):
+        self._instance_id = instance_id
+        self._axes = axes
+        self._buttons = buttons
+        self._hats = hats
+        self._button_high = button_high
+    
+    def get_instance_id(self):
+        return self._instance_id
+
+    def get_numaxes(self):
+        return len(self._axes)
+
+    def get_numbuttons(self):
+        return len(self._buttons)
+    
+    def get_numhats(self):
+        return len(self._hats)
+
+    def get_axis(self, axis):
+        return self._axes[axis].read_u16() / 32767.5 - 1
+
+    def get_button(self, button):
+        cmp = 1 if self._button_high else 0
+        return self._buttons[button].value() == cmp
+
+    def get_hat(self, hat):
+        l, r, u, d = self._hats[hat]
+        cmp = 1 if self._button_high else 0
+        if (l.value() == cmp and r.value() == cmp) or (u.value() == cmp and d.value() == cmp):
+            raise ValueError("Hat is in an invalid position")
+        
+        return (-1 if l.value() == cmp else 1 if r.value() == cmp else 0, -1 if d.value() == cmp else 1 if u.value() == cmp else 0)
+
+    def get_numballs(self):
+        return 0

--- a/packages/eventsys.json
+++ b/packages/eventsys.json
@@ -11,6 +11,10 @@
     [
       "eventsys/keys.py",
       "github:PyDevices/pydisplay/src/lib/eventsys/keys.py"
+    ],
+    [
+      "eventsys/joystick.py",
+      "github:PyDevices/pydisplay/src/lib/eventsys/joystick.py"
     ]
   ],
   "deps": [],

--- a/src/add_ons/joystick_keypad.py
+++ b/src/add_ons/joystick_keypad.py
@@ -1,0 +1,52 @@
+"""
+A class to make a joystick act like a keypad. Taks a mapping from joystick controls to keys.
+
+Example joymap:
+{
+    1: { # joystick instance_id
+        'hats': {
+            0: [Keys.K_LEFT, Keys.K_RIGHT, Keys.K_DOWN, Keys.K_UP] # hat index, list of keys to map to
+        },
+        'buttons': {
+            0: Keys.K_RETURN, # button index, key to map to
+            1: Keys.K_d,
+            2: Keys.K_f,
+        }
+    }
+}
+
+"""
+
+from eventsys import events
+
+class JoystickKeypad:
+    def __init__(self, broker, joymap):
+        self._broker = broker
+        self._joymap = joymap
+        self._state = {}
+        for j in joymap.values():
+            for h in j['hats'].values():
+                for key in h:
+                    self._state[key] = False
+            for b in j['buttons'].values():
+                self._state[b] = False
+        self._broker.subscribe(self.callback, event_types=[events.JOYHATMOTION, events.JOYBUTTONDOWN, events.JOYBUTTONUP])
+
+    def callback(self, event):
+        if event.type == events.JOYHATMOTION:
+            if j := self._joymap.get(event.instance_id):
+                if h := j['hats'].get(event.hat):
+                    x,y = event.value
+                    self._state[h[0]] = x == -1
+                    self._state[h[1]] = x == 1
+                    self._state[h[2]] = y == -1
+                    self._state[h[3]] = y == 1
+                    return
+        if event.type in [events.JOYBUTTONDOWN, events.JOYBUTTONUP]:
+            if j := self._joymap.get(event.instance_id):
+                if b := j['buttons'].get(event.button):
+                    self._state[b] = event.type == events.JOYBUTTONDOWN
+                    return
+    
+    def read(self):
+        return [k for k, v in self._state.items() if v]

--- a/src/add_ons/pdwidgets/__init__.py
+++ b/src/add_ons/pdwidgets/__init__.py
@@ -642,9 +642,10 @@ class Display(Widget):
             for dirty in dirty_areas:
                 self.refresh(dirty)
         else:
-            if e := self.broker.poll():
-                if e.type in events.filter:
-                    self.handle_event(e)
+            if elist := self.broker.poll():
+                for e in elist:
+                    if e.type in events.filter:
+                        self.handle_event(e)
 
             t = ticks_ms()
             for task in self._tasks:

--- a/src/add_ons/touch_keypad.py
+++ b/src/add_ons/touch_keypad.py
@@ -55,23 +55,26 @@ class Keypad:
             ]
 
     def read(self):
-        event = self._poll()
-        if event and event.type == events.MOUSEBUTTONDOWN and event.button == 1:
-            x, y = self._translate(event.pos)
-            if x < self.x or x > self.x + self.w or y < self.y or y > self.y + self.h:
-                return None
-            col = int((x - self.x) / self.key_width)
-            row = int((y - self.y) / self.key_height)
-            # BUG:  Sometimes throws an IndexError in Wokwi if the touch is on the last line
-            # Instead of doing a bounds check we just catch the exception.
-            try:
-                key = self._keys[row * self.cols + col]
-                return key
-            except IndexError:
-                pass
+        if elist := self._poll():
+            if not isinstance(elist, list):
+                elist = [elist]
+            for event in elist:
+                if event.type == events.MOUSEBUTTONDOWN and event.button == 1:
+                    x, y = self._translate(event.pos)
+                    if x < self.x or x > self.x + self.w or y < self.y or y > self.y + self.h:
+                        return None
+                    col = int((x - self.x) / self.key_width)
+                    row = int((y - self.y) / self.key_height)
+                    # BUG:  Sometimes throws an IndexError in Wokwi if the touch is on the last line
+                    # Instead of doing a bounds check we just catch the exception.
+                    try:
+                        key = self._keys[row * self.cols + col]
+                        return key
+                    except IndexError:
+                        pass
 
-        if event and event.type == events.KEYDOWN:
-            key = event.key
-            return key
+                if event.type == events.KEYDOWN:
+                    key = event.key
+                    return key
 
         return None

--- a/src/add_ons/touch_keypad.py
+++ b/src/add_ons/touch_keypad.py
@@ -76,7 +76,8 @@ class Keypad:
 
         if event.type in [events.KEYDOWN, events.KEYUP]:
             key = event.key
-            self._state[key] = event.type == events.KEYDOWN
+            if key in self._keys:
+                self._state[key] = event.type == events.KEYDOWN
 
     def read(self):
         return [k for k, v in self._state.items() if v]

--- a/src/add_ons/touch_keypad.py
+++ b/src/add_ons/touch_keypad.py
@@ -58,7 +58,6 @@ class Keypad:
         
 
     def callback(self, event):
-        print(f"Touchpad callback: {event}")
         if event.type in [events.MOUSEBUTTONDOWN, events.MOUSEBUTTONUP] and event.button == 1:
             x, y = event.pos
             if x < self.x or x > self.x + self.w or y < self.y or y > self.y + self.h:

--- a/src/add_ons/touch_keypad.py
+++ b/src/add_ons/touch_keypad.py
@@ -35,9 +35,9 @@ except ImportError:
 
 
 class Keypad:
-    def __init__(self, poll, x, y, w, h, cols=3, rows=3, keys=None, translate=None):
+    def __init__(self, broker, x, y, w, h, cols=3, rows=3, keys=None, translate=None):
         self._keys = keys if keys else list(range(cols * rows))
-        self._poll = poll
+        self._broker = broker
         self.x = x
         self.y = y
         self.w = w
@@ -53,28 +53,30 @@ class Keypad:
                 for j in range(rows)
                 for i in range(cols)
             ]
+        self._state = {k:False for k in self._keys}
+        self._broker.subscribe(self.callback, event_types=[events.MOUSEBUTTONDOWN, events.MOUSEBUTTONUP, events.KEYDOWN, events.KEYUP])
+        
+
+    def callback(self, event):
+        print(f"Touchpad callback: {event}")
+        if event.type in [events.MOUSEBUTTONDOWN, events.MOUSEBUTTONUP] and event.button == 1:
+            x, y = event.pos
+            if x < self.x or x > self.x + self.w or y < self.y or y > self.y + self.h:
+                return
+            col = int((x - self.x) / self.key_width)
+            row = int((y - self.y) / self.key_height)
+            # BUG:  Sometimes throws an IndexError in Wokwi if the touch is on the last line
+            # Instead of doing a bounds check we just catch the exception.
+            try:
+                key = self._keys[row * self.cols + col]
+                self._state[key] = event.type == events.MOUSEBUTTONDOWN
+                return
+            except IndexError:
+                return
+
+        if event.type in [events.KEYDOWN, events.KEYUP]:
+            key = event.key
+            self._state[key] = event.type == events.KEYDOWN
 
     def read(self):
-        if elist := self._poll():
-            if not isinstance(elist, list):
-                elist = [elist]
-            for event in elist:
-                if event.type == events.MOUSEBUTTONDOWN and event.button == 1:
-                    x, y = self._translate(event.pos)
-                    if x < self.x or x > self.x + self.w or y < self.y or y > self.y + self.h:
-                        return None
-                    col = int((x - self.x) / self.key_width)
-                    row = int((y - self.y) / self.key_height)
-                    # BUG:  Sometimes throws an IndexError in Wokwi if the touch is on the last line
-                    # Instead of doing a bounds check we just catch the exception.
-                    try:
-                        key = self._keys[row * self.cols + col]
-                        return key
-                    except IndexError:
-                        pass
-
-                if event.type == events.KEYDOWN:
-                    key = event.key
-                    return key
-
-        return None
+        return [k for k, v in self._state.items() if v]

--- a/src/examples/apollo.py
+++ b/src/examples/apollo.py
@@ -15,7 +15,7 @@ gc.collect()
 mem = mem_free()
 print(f"Free memory at start: {mem:,}")
 
-from board_config import display_drv  # noqa: E402
+from board_config import display_drv, broker  # noqa: E402
 import apollo_dsky as dsky  # noqa: E402
 import time  # noqa: E402
 import asyncio  # noqa: E402
@@ -54,18 +54,20 @@ async def main():
 
     while True:
         await asyncio.sleep(0)
-        if (key := dsky.keypad.read()) is not None:
-            dsky.set_acty(True)
-            dsky.set_button(key, True)
+        broker.poll()
+        if (keys := dsky.keypad.read()) is not None:
+            for key in keys:
+                dsky.set_acty(True)
+                dsky.set_button(key, True)
 
-            if key < len(dsky.light_status):
-                dsky.set_light(key)
-            else:
-                await scroll()
+                if key < len(dsky.light_status):
+                    dsky.set_light(key)
+                else:
+                    await scroll()
 
-            await asyncio.sleep(0.2)
-            dsky.set_button(key, False)
-            dsky.set_acty(False)
+                await asyncio.sleep(0.2)
+                dsky.set_button(key, False)
+                dsky.set_acty(False)
 
 
 loop = asyncio.get_event_loop()

--- a/src/examples/apollo_dsky/__init__.py
+++ b/src/examples/apollo_dsky/__init__.py
@@ -93,7 +93,7 @@ data3_pos = (187, 184)
 # The keypad area starts at (2, 233) and is 7 keys wide and 3 keys tall
 # The keys are 45x45 pixels
 keypad = Keypad(
-    broker.poll, 2, 233, 7 * 45, 3 * 45, cols=7, rows=3, translate=display_drv.translate_point
+    broker, 2, 233, 7 * 45, 3 * 45, cols=7, rows=3, translate=display_drv.translate_point
 )
 
 ########### Define the states of the screen elements

--- a/src/examples/bmp565_scroll_sprite.py
+++ b/src/examples/bmp565_scroll_sprite.py
@@ -59,21 +59,22 @@ def main():
         i += 1
         if i < display_drv.width:
             continue
-        event = broker.poll()
-        if event and event.type == broker.events.MOUSEMOTION and event.buttons[0] == 1:
-            touched_point = event.pos
-            if touched_point[1] < display_drv.height // 2:
-                sprites = jump_shoot_sprites
-                if not shot_location:
-                    shot_location = 1
-            elif touched_point[0] < display_drv.width // 2:
-                sprites = jump_sprites
-            elif touched_point[0] > display_drv.width // 2:
-                sprites = shoot_sprites
-                if not shot_location:
-                    shot_location = 1
-        else:
-            sprites = run_sprites
+        elist = broker.poll()
+        for event in elist:
+            if event and event.type == broker.events.MOUSEMOTION and event.buttons[0] == 1:
+                touched_point = event.pos
+                if touched_point[1] < display_drv.height // 2:
+                    sprites = jump_shoot_sprites
+                    if not shot_location:
+                        shot_location = 1
+                elif touched_point[0] < display_drv.width // 2:
+                    sprites = jump_sprites
+                elif touched_point[0] > display_drv.width // 2:
+                    sprites = shoot_sprites
+                    if not shot_location:
+                        shot_location = 1
+            else:
+                sprites = run_sprites
         draw_x = scroll + char_x
         sprite = sprites[i % len(sprites)]
         draw_sprite(draw_x, char_y, sprite.x, sprite.y)

--- a/src/examples/calculator.py
+++ b/src/examples/calculator.py
@@ -57,7 +57,7 @@ async def main():
 
     # Create the keypad
     keypad = Keypad(
-        broker.poll,
+        broker,
         0,
         0,
         display_drv.width,
@@ -141,67 +141,69 @@ async def main():
     # Main loop
     while True:
         await asyncio.sleep(0.01)
-        code = keypad.read()
-        if code is None:
+        broker.poll()
+        codes = keypad.read()
+        if codes is None or len(codes) == 0:
             continue
-        if code not in button_codes:
-            continue
-        x, y = button_pos[code]
-        label = button_labels[button_codes.index(code)]
-        draw_button(x, y, label, True)
-        # print(f"{code=}, {label=}")
+        for code in codes:
+            if code not in button_codes:
+                continue
+            x, y = button_pos[code]
+            label = button_labels[button_codes.index(code)]
+            draw_button(x, y, label, True)
+            # print(f"{code=}, {label=}")
 
-        if label in "0123456789.":
-            if not editable:
-                input = label
-            elif input == "0" and label != ".":
-                input = label
-            elif label == "." and "." not in input:
-                input += label
-            elif label != ".":
-                input += label
-            editable = True
-        elif label == "C":
-            if input == "0":
-                result = 0
-                pending_operation = ""
-            else:
-                input = "0"
-            editable = True
-        elif label == "+/-":
-            if input != "0":
-                input = str(-float(input))
-        elif label in "+-*/=":
-            editable = True
-            if pending_operation:
-                try:
-                    result = eval(f"{result}{pending_operation}{input}")
-                except ZeroDivisionError:
-                    result = "Error: division by zero"
-                    editable = False
-            else:
+            if label in "0123456789.":
+                if not editable:
+                    input = label
+                elif input == "0" and label != ".":
+                    input = label
+                elif label == "." and "." not in input:
+                    input += label
+                elif label != ".":
+                    input += label
+                editable = True
+            elif label == "C":
+                if input == "0":
+                    result = 0
+                    pending_operation = ""
+                else:
+                    input = "0"
+                editable = True
+            elif label == "+/-":
                 if input != "0":
-                    result = float(input)
-            if label == "=":
-                pending_operation = ""
+                    input = str(-float(input))
+            elif label in "+-*/=":
+                editable = True
+                if pending_operation:
+                    try:
+                        result = eval(f"{result}{pending_operation}{input}")
+                    except ZeroDivisionError:
+                        result = "Error: division by zero"
+                        editable = False
+                else:
+                    if input != "0":
+                        result = float(input)
+                if label == "=":
+                    pending_operation = ""
+                else:
+                    pending_operation = label
+                input = "0"
+            elif label == "%":
+                input = str(float(input) / 100)
+                editable = False
+            elif label == "Sqrt":
+                if float(input) < 0:
+                    result = "Error: sqrt of negative number"
+                else:
+                    input = str(float(input) ** 0.5)
+                editable = False
             else:
-                pending_operation = label
-            input = "0"
-        elif label == "%":
-            input = str(float(input) / 100)
-            editable = False
-        elif label == "Sqrt":
-            if float(input) < 0:
-                result = "Error: sqrt of negative number"
-            else:
-                input = str(float(input) ** 0.5)
-            editable = False
-        else:
-            print("Unknown label")
-        show_result(result)
-        show_input(input)
-        sleep(0.15)
-        draw_button(x, y, label, False)
+                print("Unknown label")
+            show_result(result)
+            show_input(input)
+            sleep(0.15)
+            draw_button(x, y, label, False)
 
 
 loop = asyncio.get_event_loop()

--- a/src/examples/displaysys_simpletest.py
+++ b/src/examples/displaysys_simpletest.py
@@ -4,8 +4,9 @@ from graphics import Area
 
 button_area = Area(display_drv.fill_rect(10, 10, 100, 100, 0xF800))
 while True:
-    if evt := broker.poll():
-        if evt.type == broker.events.MOUSEBUTTONDOWN:
-            if button_area.contains(evt.pos):
-                display_drv.fill_rect(*button_area, getrandbits(16))
-                print(f"Button pressed at {evt.pos}")
+    if elist := broker.poll():
+        for e in elist:
+            if e.type == broker.events.MOUSEBUTTONDOWN:
+                if button_area.contains(e.pos):
+                    display_drv.fill_rect(*button_area, getrandbits(16))
+                    print(f"Button pressed at {e.pos}")

--- a/src/examples/eventsys_encoder_test.py
+++ b/src/examples/eventsys_encoder_test.py
@@ -24,25 +24,26 @@ display_drv.vscsad(y_pos)
 draw_line()
 
 while True:
-    if not (e := broker.poll()):
+    if not (elist := broker.poll()):
         continue
-    if e.type == broker.events.MOUSEWHEEL:
-        if e.y != 0:
-            direction = factor if e.y > 0 else -factor
-            delta = e.y * e.y * direction  # Quadratic acceleration
-            y_pos = (y_pos + delta) % h
-            display_drv.vscsad(y_pos)
-        if e.x != 0:
-            direction = factor if e.x > 0 else -factor
-            delta = e.x * e.x * direction
-            x_pos = (x_pos + delta) % w
-            draw_line()
-    elif e.type == broker.events.MOUSEBUTTONDOWN:
-        if e.button == 2:
-            color_byte = color_byte << 1 & 0xFF
-            if color_byte == 0:
-                color_byte = 1
-            draw_line()
-        elif e.button == 3:
-            bg_color = ~bg_color
-            draw_line()
+    for e in elist:
+        if e.type == broker.events.MOUSEWHEEL:
+            if e.y != 0:
+                direction = factor if e.y > 0 else -factor
+                delta = e.y * e.y * direction  # Quadratic acceleration
+                y_pos = (y_pos + delta) % h
+                display_drv.vscsad(y_pos)
+            if e.x != 0:
+                direction = factor if e.x > 0 else -factor
+                delta = e.x * e.x * direction
+                x_pos = (x_pos + delta) % w
+                draw_line()
+        elif e.type == broker.events.MOUSEBUTTONDOWN:
+            if e.button == 2:
+                color_byte = color_byte << 1 & 0xFF
+                if color_byte == 0:
+                    color_byte = 1
+                draw_line()
+            elif e.button == 3:
+                bg_color = ~bg_color
+                draw_line()

--- a/src/examples/eventsys_simpletest.py
+++ b/src/examples/eventsys_simpletest.py
@@ -4,11 +4,11 @@ import asyncio
 
 async def main():
     while True:
-        e = broker.poll()
-        if e:
-            print(e)
-            if e == broker.events.QUIT:
-                break
+        if elist := broker.poll():
+            for e in elist:
+                print(e)
+                if e == broker.events.QUIT:
+                    break
         await asyncio.sleep(0.001)
 
 

--- a/src/examples/eventsys_touch_test.py
+++ b/src/examples/eventsys_touch_test.py
@@ -66,9 +66,10 @@ def loop():
                 )
                 touched_point = None
                 while not touched_point:
-                    event = broker.poll()
-                    if event and event.type == broker.events.MOUSEBUTTONDOWN and event.button == 1:
-                        touched_point = event.pos
+                    if elist := broker.poll():
+                        for event in elist:
+                            if event.type == broker.events.MOUSEBUTTONDOWN and event.button == 1:
+                                touched_point = event.pos
                 zone = (touched_point[1] // half_height) * 2 + (touched_point[0] // half_width)
                 touched_zones.append(zone)
                 print(f"{touched_point=} in {zone=}")

--- a/src/examples/joystick_list_select.py
+++ b/src/examples/joystick_list_select.py
@@ -1,0 +1,45 @@
+
+import board_config
+from eventsys.devices import types
+import pdwidgets as pd
+
+display = pd.Display(board_config.display_drv, board_config.broker,40)
+screen = pd.Screen(display, visible=False)
+
+top, bottom, main = screen.top, screen.bottom, screen.main
+
+pd.Label(top,value="Select an Item")
+
+list_view = pd.ListView(main, w=int(main.width * .9), h=int(main.height * .9), align=pd.ALIGN.CENTER)
+
+items = [pd.Label(list_view,value=i) for i in ["Item 1", "Item 2", "Item 3"]]
+selected = 0
+items[selected].bg = list_view.color_theme.secondary
+
+screen.visible = True
+running = True
+
+
+
+def select_item(up: bool):
+    global selected
+    if up and selected > 0:
+        selected -= 1
+    elif not up and selected < len(items) - 1:
+        selected += 1
+    for i in items:
+        i.bg = list_view.color_theme.secondary if i == items[selected] else list_view.color_theme.transparent
+    list_view.invalidate()
+
+def joystick_callback(event):
+    if event.type == pd.events.JOYHATMOTION:
+        if event.hat == 0:
+            if event.value[1] != 0:
+                select_item(event.value[1] > 0)
+
+board_config.broker.subscribe(joystick_callback,device_types=[types.JOYSTICK])
+
+if not display.timer:
+    print("Starting main loop")
+    while running:
+        pd.tick()        

--- a/src/examples/paint.py
+++ b/src/examples/paint.py
@@ -40,44 +40,45 @@ async def main():
     print("Application loaded.  Select a color and PAINT!")
     while True:
         await asyncio.sleep(0.01)
-        if not (e := broker.poll()):
+        if not (elist := broker.poll()):
             continue
-        if e.type == broker.events.MOUSEBUTTONDOWN:
-            x, y = e.pos
-            last_selected = selected
-            if on_x_axis and y < block_size or not on_x_axis and x < block_size:
-                if on_x_axis:
-                    selected = x // block_size
-                else:
-                    selected = y // block_size
-                if selected != last_selected:
-                    draw_block(last_selected, colors[last_selected])
-                    draw_block(selected, colors[selected])
-                if e.button == 3:
+        for e in elist:
+            if e.type == broker.events.MOUSEBUTTONDOWN:
+                x, y = e.pos
+                last_selected = selected
+                if on_x_axis and y < block_size or not on_x_axis and x < block_size:
                     if on_x_axis:
-                        display_drv.fill_rect(
-                            0,
-                            block_size,
-                            display_drv.width,
-                            display_drv.height - block_size,
-                            colors[selected],
-                        )
+                        selected = x // block_size
                     else:
-                        display_drv.fill_rect(
-                            block_size,
-                            0,
-                            display_drv.width - block_size,
-                            display_drv.height,
-                            colors[selected],
-                        )
-            elif e.button == 1:
-                paint(x, y, colors[selected])
-        elif e.type == broker.events.MOUSEMOTION and e.buttons[0] == 1:
-            x, y = e.pos
-            if (on_x_axis and y > block_size) or (not on_x_axis and x > block_size):
-                paint(x, y, colors[selected])
-        elif e.type == broker.events.QUIT:
-            break
+                        selected = y // block_size
+                    if selected != last_selected:
+                        draw_block(last_selected, colors[last_selected])
+                        draw_block(selected, colors[selected])
+                    if e.button == 3:
+                        if on_x_axis:
+                            display_drv.fill_rect(
+                                0,
+                                block_size,
+                                display_drv.width,
+                                display_drv.height - block_size,
+                                colors[selected],
+                            )
+                        else:
+                            display_drv.fill_rect(
+                                block_size,
+                                0,
+                                display_drv.width - block_size,
+                                display_drv.height,
+                                colors[selected],
+                            )
+                elif e.button == 1:
+                    paint(x, y, colors[selected])
+            elif e.type == broker.events.MOUSEMOTION and e.buttons[0] == 1:
+                x, y = e.pos
+                if (on_x_axis and y > block_size) or (not on_x_axis and x > block_size):
+                    paint(x, y, colors[selected])
+            elif e.type == broker.events.QUIT:
+                break
 
 
 loop = asyncio.get_event_loop()

--- a/src/examples/scroll_touch_test.py
+++ b/src/examples/scroll_touch_test.py
@@ -47,19 +47,20 @@ def main():
 
     while True:
         # Check for mouse events
-        if evt := broker.poll():
-            if evt.type == broker.events.MOUSEBUTTONDOWN:
-                x, y = canvas.translate_point(evt.pos)
-                if y < canvas.tfa:
-                    canvas.vscroll -= line_height
-                elif y > canvas.height - canvas.bfa:
-                    canvas.vscroll += line_height
-                else:
-                    y_pos = (y // line_height) * line_height
-                    canvas.fill_rect(
-                        canvas.width - 20, y_pos + 2, 12, 12, getrandbits(canvas.color_depth)
-                    )
-                canvas.show()
+        if elist := broker.poll():
+            for e in elist:
+                if e.type == broker.events.MOUSEBUTTONDOWN:
+                    x, y = canvas.translate_point(e.pos)
+                    if y < canvas.tfa:
+                        canvas.vscroll -= line_height
+                    elif y > canvas.height - canvas.bfa:
+                        canvas.vscroll += line_height
+                    else:
+                        y_pos = (y // line_height) * line_height
+                        canvas.fill_rect(
+                            canvas.width - 20, y_pos + 2, 12, 12, getrandbits(canvas.color_depth)
+                        )
+                    canvas.show()
 
 
 main()

--- a/src/examples/scroll_touch_test_displaybuf.py
+++ b/src/examples/scroll_touch_test_displaybuf.py
@@ -48,19 +48,20 @@ def main():
 
     while True:
         # Check for mouse events
-        if evt := broker.poll():
-            if evt.type == broker.events.MOUSEBUTTONDOWN:
-                x, y = canvas.translate_point(evt.pos)
-                if y < canvas.tfa:
-                    canvas.vscroll -= line_height
-                elif y > canvas.height - canvas.bfa:
-                    canvas.vscroll += line_height
-                else:
-                    y_pos = (y // line_height) * line_height
-                    canvas.fill_rect(
-                        canvas.width - 20, y_pos + 2, 12, 12, getrandbits(canvas.color_depth)
-                    )
-                canvas.show()
+        if elist := broker.poll():
+            for e in elist:
+                if e.type == broker.events.MOUSEBUTTONDOWN:
+                    x, y = canvas.translate_point(e.pos)
+                    if y < canvas.tfa:
+                        canvas.vscroll -= line_height
+                    elif y > canvas.height - canvas.bfa:
+                        canvas.vscroll += line_height
+                    else:
+                        y_pos = (y // line_height) * line_height
+                        canvas.fill_rect(
+                            canvas.width - 20, y_pos + 2, 12, 12, getrandbits(canvas.color_depth)
+                        )
+                    canvas.show()
 
 
 main()

--- a/src/examples/testris.py
+++ b/src/examples/testris.py
@@ -313,13 +313,11 @@ def main():  # noqa: C901, PLR0915
         Returns:
             str: The key that was pressed.
         """
-        print(f"Waiting for key: {key}, exclude: {exclude}")
         while True:  # Wait for the user to press a key
             broker.poll()
             keys = joystick_keypad.read()
             keys.extend(keypad.read())
-            if len(keys) > 0:
-                print(f"Keys: {keys}")
+            
             if key is not None:
                 if key in keys:
                     return key
@@ -486,9 +484,7 @@ def main():  # noqa: C901, PLR0915
                         keys.extend(keypad.read())
 
                         if len(keys) > 0:  # If keys were pressed
-                            print(f'got {len(keys)} keys')
                             for key in keys:
-                                print(f"Key: {key}")
                                 last_read = ticks_ms()  # Save the time of the last read
                                 if key == LEFT and not collision(current_piece, current_position, -1, 0):
                                     current_position[0] -= 1  # Move the piece left

--- a/src/examples/testris.py
+++ b/src/examples/testris.py
@@ -6,6 +6,7 @@ Testris game implemented in MicroPython by Brad Barnett.
 from board_config import display_drv, broker
 from displaysys import alloc_buffer
 from touch_keypad import Keypad
+from joystick_keypad import JoystickKeypad
 from eventsys.keys import Keys
 from random import choice  # For random piece selection
 from json import load, dump  # For saving the high score
@@ -28,14 +29,14 @@ if display_drv.width > display_drv.height:
 START = Keys.K_RETURN  # RETURN
 UNUSED = 0  # Not used
 PAUSE = Keys.K_ESCAPE  # ESCAPE
-CW = Keys.K_d  # D
+CCW = Keys.K_d  # D
 DROP = Keys.K_UP  # UP
-CCW = Keys.K_f  # F
+CW = Keys.K_f  # F
 LEFT = Keys.K_LEFT  # LEFT
 DOWN = Keys.K_DOWN  # DOWN
 RIGHT = Keys.K_RIGHT  # RIGHT
 keypad = Keypad(
-    broker.poll,
+    broker,
     0,
     0,
     display_drv.width,
@@ -43,6 +44,21 @@ keypad = Keypad(
     keys=[START, UNUSED, PAUSE, CW, DROP, CCW, LEFT, DOWN, RIGHT],
 )
 
+joystick_keypad = JoystickKeypad(
+    broker,
+    joymap={
+        1: {
+            'hats': {
+                0: [LEFT, RIGHT, DOWN, DROP]
+            },
+            'buttons': {
+                0: START,
+                1: CCW,
+                2: CW,
+            }
+        }
+    }
+)
 
 def main():  # noqa: C901, PLR0915
     # Define the draw_block function
@@ -76,7 +92,7 @@ def main():  # noqa: C901, PLR0915
 
     # Define other constants
     SPLASH_ENABLED = const(1)  # Set to 1 to show the splash screen, 0 to skip it
-    DELAY = const(150)  # Delay in ms so we don't read the keypad too quickly
+    DELAY = const(250)  # Delay in ms so we don't read the keypad too quickly
     SPEEDUP = const(
         25
     )  # Amount of time in ms to reduce the drop time by when a row is cleared (Difficulty)
@@ -297,15 +313,20 @@ def main():  # noqa: C901, PLR0915
         Returns:
             str: The key that was pressed.
         """
+        print(f"Waiting for key: {key}, exclude: {exclude}")
         while True:  # Wait for the user to press a key
-            if (
-                pressed := keypad.read()
-            ) and pressed not in exclude:  # If a key was pressed and it's not excluded
-                if (
-                    key is None or pressed == key
-                ):  # If no key was specified or the key pressed matches the specified key
-                    break  # Exit the loop
-        return pressed
+            broker.poll()
+            keys = joystick_keypad.read()
+            keys.extend(keypad.read())
+            if len(keys) > 0:
+                print(f"Keys: {keys}")
+            if key is not None:
+                if key in keys:
+                    return key
+            else:
+                for key in keys:
+                    if key not in exclude:
+                        return key
 
     def sample(population, k):
         """
@@ -458,40 +479,46 @@ def main():  # noqa: C901, PLR0915
                 while (
                     current_piece == old_piece and current_position == old_position
                 ):  # Inner loop - while the piece hasn't moved
-                    # If it has been DELAY ms since the last keypad read, then read the keypad
-                    if (ticks_diff(ticks_ms(), last_read) >= DELAY) and (
-                        key := keypad.read()
-                    ):  # If a key was pressed
-                        last_read = ticks_ms()  # Save the time of the last read
-                        if key == LEFT and not collision(current_piece, current_position, -1, 0):
-                            current_position[0] -= 1  # Move the piece left
-                        elif key == RIGHT and not collision(current_piece, current_position, 1, 0):
-                            current_position[0] += 1  # Move the piece right
-                        elif key == DOWN and not collision(current_piece, current_position, 0, 1):
-                            current_position[1] += 1  # Move the piece down
-                            last_drop = ticks_ms()  # Reset the last drop time
-                        elif key == DROP and not collision(current_piece, current_position, 0, 1):
-                            hard_drop = True  # Hard drop the piece
-                        elif key == CCW and not collision(
-                            current_piece, current_position, 0, 0, ROTCCW
-                        ):
-                            current_piece = rotate(
-                                current_piece, CCW
-                            )  # Rotate the piece counter-clockwise
-                        elif key == CW and not collision(
-                            current_piece, current_position, 0, 0, ROTCW
-                        ):
-                            current_piece = rotate(current_piece, CW)  # Rotate the piece clockwise
-                        elif key == PAUSE:  # Pause the game
-                            draw_banner("Paused.\n\nPress START to reset.\nAny key to resume.")
-                            key = wait_for_key(
-                                exclude=[PAUSE]
-                            )  # Wait for the user to press a key, excluding PAUSE
-                            if key == START:
-                                clear_screen()  # Clear the screen
-                                exit()  # Reset the machine
-                            else:  # Resume the game
-                                show_score()  # Show the score
+                    # If it has been DELAY ms since the last read, then read the keypads
+                    if (ticks_diff(ticks_ms(), last_read) >= DELAY):
+                        broker.poll()
+                        keys = joystick_keypad.read()
+                        keys.extend(keypad.read())
+
+                        if len(keys) > 0:  # If keys were pressed
+                            print(f'got {len(keys)} keys')
+                            for key in keys:
+                                print(f"Key: {key}")
+                                last_read = ticks_ms()  # Save the time of the last read
+                                if key == LEFT and not collision(current_piece, current_position, -1, 0):
+                                    current_position[0] -= 1  # Move the piece left
+                                elif key == RIGHT and not collision(current_piece, current_position, 1, 0):
+                                    current_position[0] += 1  # Move the piece right
+                                elif key == DOWN and not collision(current_piece, current_position, 0, 1):
+                                    current_position[1] += 1  # Move the piece down
+                                    last_drop = ticks_ms()  # Reset the last drop time
+                                elif key == DROP and not collision(current_piece, current_position, 0, 1):
+                                    hard_drop = True  # Hard drop the piece
+                                elif key == CCW and not collision(
+                                    current_piece, current_position, 0, 0, ROTCCW
+                                ):
+                                    current_piece = rotate(
+                                        current_piece, ROTCCW
+                                    )  # Rotate the piece counter-clockwise
+                                elif key == CW and not collision(
+                                    current_piece, current_position, 0, 0, ROTCW
+                                ):
+                                    current_piece = rotate(current_piece, ROTCW)  # Rotate the piece clockwise
+                                elif key == PAUSE:  # Pause the game
+                                    draw_banner("Paused.\n\nPress START to reset.\nAny key to resume.")
+                                    key = wait_for_key(
+                                        exclude=[PAUSE]
+                                    )  # Wait for the user to press a key, excluding PAUSE
+                                    if key == START:
+                                        clear_screen()  # Clear the screen
+                                        exit()  # Reset the machine
+                                    else:  # Resume the game
+                                        show_score()  # Show the score
 
                     if hard_drop:  # Hard drop the piece
                         while not collision(

--- a/src/lib/board_config.py
+++ b/src/lib/board_config.py
@@ -54,7 +54,7 @@ else:
 
     try:
         # This should load for CPython
-        from displaysys.pgdisplay import PGDisplay as DTDisplay, poll
+        from displaysys.pgdisplay import PGDisplay as DTDisplay, poll, get
     except ImportError:
         # This should load for MicroPython on the desktop
         from displaysys.sdldisplay import SDLDisplay as DTDisplay, poll
@@ -71,7 +71,7 @@ else:
 
     events_dev = broker.create_device(
         type=devices.types.QUEUE,
-        read=poll,
+        read=get,
         data=display_drv,
         # data2=events.filter,
     )

--- a/src/lib/board_config.py
+++ b/src/lib/board_config.py
@@ -54,10 +54,10 @@ else:
 
     try:
         # This should load for CPython
-        from displaysys.pgdisplay import PGDisplay as DTDisplay, poll, get
+        from displaysys.pgdisplay import PGDisplay as DTDisplay, get
     except ImportError:
         # This should load for MicroPython on the desktop
-        from displaysys.sdldisplay import SDLDisplay as DTDisplay, poll
+        from displaysys.sdldisplay import SDLDisplay as DTDisplay, get
 
     display_drv = DTDisplay(
         width=width,

--- a/src/lib/displaysys/pgdisplay.py
+++ b/src/lib/displaysys/pgdisplay.py
@@ -24,6 +24,15 @@ def poll() -> Optional[pg.event.Event]:
     """
     return pg.event.poll()
 
+def get() -> [pg.event.Event]:
+    """
+    Gets all events from the event queue.
+
+    Returns:
+        [pg.event.Event]: A list of events.
+    """
+    return pg.event.get()
+
 
 class PGDisplay(DisplayDriver):
     """

--- a/src/lib/displaysys/sdldisplay/__init__.py
+++ b/src/lib/displaysys/sdldisplay/__init__.py
@@ -103,6 +103,24 @@ def poll() -> Optional[events]:
                 return _convert(SDL_Event(_event))
     return None
 
+def get() -> [events]:
+    """
+    Gets all events from the event queue.
+
+    Returns:
+        [events]: A list of events.
+    """
+    global _event
+    eventlist = []
+    while SDL_PollEvent(_event):
+        if is_cpython:
+            if _event.type in events.filter:
+                eventlist.append(_convert(SDL_Event(_event)))
+        else:
+            if int.from_bytes(_event[:4], "little") in events.filter:
+                eventlist.append(_convert(SDL_Event(_event)))
+    return eventlist if len(eventlist) > 0 else None
+
 def _convert(e):
     # Convert an SDL event to a Pygame event
     if e.type == SDL_MOUSEMOTION:

--- a/src/lib/eventsys/__init__.py
+++ b/src/lib/eventsys/__init__.py
@@ -80,6 +80,11 @@ class events:
         MOUSEBUTTONDOWN,
         MOUSEBUTTONUP,
         MOUSEWHEEL,
+        JOYAXISMOTION,
+        JOYBALLMOTION,
+        JOYHATMOTION,
+        JOYBUTTONDOWN,
+        JOYBUTTONUP,
     ]
 
     # Event classes from PyGame
@@ -90,3 +95,8 @@ class events:
     Key = namedtuple("Key", "type name key mod scancode window")  # noqa: PYI024
     Quit = namedtuple("Quit", "type")  # noqa: PYI024
     Any = namedtuple("Any", "type")  # noqa: PYI024
+    JoyAxisMotion = namedtuple("JoyAxisMotion", "type instance_id axis value")  # noqa: PYI024
+    JoyButtonUp = namedtuple("JoyButtonUp", "type instance_id button")  # noqa: PYI024
+    JoyButtonDown = namedtuple("JoyButtonDown", "type instance_id button")  # noqa: PYI024
+    JoyHatMotion = namedtuple("JoyHatMotion", "type instance_id hat value")  # noqa: PYI024
+    JoyBallMotion = namedtuple("JoyBallMotion", "type instance_id ball rel")  # noqa: PYI024

--- a/src/lib/eventsys/devices.py
+++ b/src/lib/eventsys/devices.py
@@ -33,6 +33,7 @@ Devices can be created with the following types:
 
 from micropython import const
 from . import events
+from .joystick import JoystickDriver
 from sys import exit
 
 
@@ -137,7 +138,7 @@ class Device:
         self._state = None
         self._user_data = None  # Can be set and retrieved by apps such as lv_config
 
-    def poll(self, *args) -> events:
+    def poll(self, *args) -> [events]:
         """
         Poll the device for events.
 
@@ -145,17 +146,21 @@ class Device:
             *args (Any): Additional arguments that can be passed to the read callback functions.
 
         Returns:
-            Event: The event that was polled or None if no event was polled.
+            list: A list of event objects if events are received, otherwise None.
         """
-        if (event := self._poll()) is not None:
-            if event.type in events.filter:
+        if (dev_events := self._poll()) is not None:
+            if isinstance(dev_events, list):
+                eventlist = [e for e in dev_events if e.type in events.filter]
+            else:
+                eventlist = [dev_events] if dev_events.type in events.filter else None
+            for event in eventlist:
                 if event.type == events.QUIT:
                     if self._broker:
                         self._broker.quit()
                 if callback_list := self._event_callbacks.get(event.type):
                     for callback in callback_list:
                         callback(event, *args)
-                return event
+            return eventlist if len(eventlist) > 0 else None
         return None
 
     def subscribe(self, callback, event_types=None):
@@ -375,15 +380,17 @@ class Broker(Device):
         Polls the registered devices for events.
 
         Returns:
-            object: The event object if an event is received, otherwise None.
+            list: A list of event objects if events are received, otherwise None.
         """
+        eventlist = []
         for device in self.devices:
-            if (event := device.poll()) is not None:
+            if (dev_events := device.poll()) is not None:
+                eventlist.extend(dev_events)                
                 if callback_list := self._device_callbacks.get(device.type):
-                    for func in callback_list():
-                        func(event)
-                return event
-        return None
+                    for func in callback_list:
+                        for event in dev_events:
+                            func(event)
+        return eventlist if len(eventlist) > 0 else None
 
 
 class QueueDevice(Device):
@@ -671,6 +678,10 @@ class JoystickDevice(Device):
         __init__(*args, **kwargs): Initializes the JoystickDevice instance.
         _poll(): Polls the device for events.
 
+    Args:
+        joystick_driver (JoystickDriver): The joystick driver to use.
+        emulate_digital [(int,int)]: Emulate digital buttons for the given axis pairs. If set, a hat will be added for each axis pair. The hats will be added after any true hats.
+        digital_threshold (float): The threshold to use for digital emulation.
     Raises:
         NotImplementedError: If the `_poll` method is not implemented.
     """
@@ -684,11 +695,64 @@ class JoystickDevice(Device):
         events.JOYBUTTONUP,
     )
 
-    def __init__(self, *args, **kwargs):
+    def __init__(self, *args, joystick_driver: JoystickDriver, emulate_digital: list[(int,int)] = None, digital_threshold: float = 0.5, **kwargs):
         super().__init__(*args, **kwargs)
+        self.joystick_driver = joystick_driver
+        self.emulate_digital = emulate_digital
+        self.digital_threshold = digital_threshold
+        self._state = [
+            [0] * self.joystick_driver.get_numaxes(),
+            [False] * self.joystick_driver.get_numbuttons(),
+            [(0,0)] * self.joystick_driver.get_numhats(),
+            [(0,0)] * self.joystick_driver.get_numballs(),
+        ]
+        if self.emulate_digital:
+            self._state.append([0] * len(self.emulate_digital))
 
+    def emulate(self, value):
+        return -1 if value < -self.digital_threshold else 1 if value > self.digital_threshold else 0
+    
     def _poll(self):
-        raise NotImplementedError("JoystickDevice.read() not implemented")
+        eventlist = []
+        new_state = [
+            [self.joystick_driver.get_axis(i) for i in range(self.joystick_driver.get_numaxes())],
+            [self.joystick_driver.get_button(i) for i in range(self.joystick_driver.get_numbuttons())],
+            [self.joystick_driver.get_hat(i) for i in range(self.joystick_driver.get_numhats())],
+            [self.joystick_driver.get_ball(i) for i in range(self.joystick_driver.get_numballs())],
+        ]
+
+        instance_id = self.joystick_driver.get_instance_id()
+        # axes
+        for i, (old,new) in enumerate(zip(self._state[0], new_state[0])):
+            if old != new:
+                eventlist.append(events.JoyAxisMotion(events.JOYAXISMOTION, instance_id, i, new))
+
+        # buttons
+        for i, (old,new) in enumerate(zip(self._state[1], new_state[1])):
+            if old != new:
+                eventlist.append(events.JoyButtonDown(events.JOYBUTTONDOWN, instance_id, i) if new else events.JoyButtonUp(events.JOYBUTTONUP, instance_id, i))
+
+        # hats
+        for i, (old,new) in enumerate(zip(self._state[2], new_state[2])):
+            if old != new:
+                eventlist.append(events.JoyHatMotion(events.JOYHATMOTION, instance_id, i, new))
+
+        # balls
+        for i, (old,new) in enumerate(zip(self._state[3], new_state[3])):
+            if old != new:
+                eventlist.append(events.JoyBallMotion(events.JOYBALLMOTION, instance_id, i, new))
+
+        if self.emulate_digital:
+            axes = new_state[0]
+            new_state.append([
+                (self.emulate(axes[x]), self.emulate(axes[y])) for x,y in self.emulate_digital
+            ])
+            for i, (old,new) in enumerate(zip(self._state[4], new_state[4])):
+                if old != new:
+                    eventlist.append(events.JoyHatMotion(events.JOYHATMOTION, instance_id, i+self.joystick_driver.get_numhats(), new))
+        
+        self._state = new_state
+        return eventlist if len(eventlist) > 0 else None
 
 
 
@@ -719,13 +783,14 @@ class VirtualDevices:
         self.devices = [self._vd_touch, self._vd_encoder, self._vd_keypad]
 
     def poll_queue_device(self):
-        if e:= self._queue_device.poll():
-            if e.type == events.MOUSEBUTTONDOWN or e.type == events.MOUSEBUTTONUP:
-                self._vd_touch.add_event(e)
-            elif e.type == events.MOUSEWHEEL:
-                self._vd_encoder.add_event(e)
-            elif e.type == events.KEYDOWN or e.type == events.KEYUP:
-                self._vd_keypad.add_event(e)
+        if elist := self._queue_device.poll():
+            for e in elist:
+                if e.type == events.MOUSEBUTTONDOWN or e.type == events.MOUSEBUTTONUP:
+                    self._vd_touch.add_event(e)
+                elif e.type == events.MOUSEWHEEL:
+                    self._vd_encoder.add_event(e)
+                elif e.type == events.KEYDOWN or e.type == events.KEYUP:
+                    self._vd_keypad.add_event(e)
 
 _mapping = {
     # Mapping of device types to device classes

--- a/src/lib/eventsys/devices.py
+++ b/src/lib/eventsys/devices.py
@@ -153,6 +153,8 @@ class Device:
                 eventlist = [e for e in dev_events if e.type in events.filter]
             else:
                 eventlist = [dev_events] if dev_events.type in events.filter else None
+            if events.MOUSEMOTION not in [e.type for e in eventlist]:
+                print(f"Device {self.__class__.__name__} returned events: {eventlist}")
             for event in eventlist:
                 if event.type == events.QUIT:
                     if self._broker:
@@ -413,6 +415,7 @@ class QueueDevice(Device):
             self.scale = self._data.touch_scale
         else:
             self.scale = 1
+        self._debug = False
 
     def _poll(self):
         """
@@ -421,21 +424,30 @@ class QueueDevice(Device):
         Returns:
             Event or None: The next event from the device, or None if no event is available.
         """
-        if (event := self._read()) is not None:
-            if event.type in self._data2:
-                if event.type in (
-                    events.MOUSEMOTION,
-                    events.MOUSEBUTTONDOWN,
-                    events.MOUSEBUTTONUP,
-                ):
-                    if (scale := self.scale) != 1:
-                        event.pos = (
-                            int(event.pos[0] // scale),
-                            int(event.pos[1] // scale),
-                        )
-                        if event.type == events.MOUSEMOTION:
-                            event.rel = (event.rel[0] // scale, event.rel[1] // scale)
-                return event
+        if (dev_events := self._read()) is not None:
+            for event in dev_events:
+                print(f"PyGame returned event: {event}")
+                if event.type in self._data2:
+                    if event.type in (
+                        events.MOUSEMOTION,
+                        events.MOUSEBUTTONDOWN,
+                        events.MOUSEBUTTONUP,
+                    ):
+                        if (scale := self.scale) != 1:
+                            event.pos = (
+                                int(event.pos[0] // scale),
+                                int(event.pos[1] // scale),
+                            )
+                            if event.type == events.MOUSEMOTION:
+                                event.rel = (event.rel[0] // scale, event.rel[1] // scale)
+                    if event.type == events.KEYDOWN:
+                        self._debug = True
+                    elif event.type == events.KEYUP:
+                        self._debug = False
+                    return event
+                else:
+                    if self._debug:
+                        print(f"QueueDevice {self.__class__.__name__} returned event: {event} but it was not in the filter")
         return None
 
     def peek(self) -> bool:
@@ -683,7 +695,8 @@ class JoystickDevice(Device):
         emulate_digital [(int,int)]: Emulate digital buttons for the given axis pairs. If set, a hat will be added for each axis pair. The hats will be added after any true hats.
         digital_threshold (float): The threshold to use for digital emulation.
     Raises:
-        NotImplementedError: If the `_poll` method is not implemented.
+        NotImplementedError: If any of the joystick driver methods are not implemented.
+        ValueError: If a hat has an invalid value, e.g. both up and down are true.
     """
 
     type = types.JOYSTICK

--- a/src/lib/eventsys/devices.py
+++ b/src/lib/eventsys/devices.py
@@ -153,8 +153,7 @@ class Device:
                 eventlist = [e for e in dev_events if e.type in events.filter]
             else:
                 eventlist = [dev_events] if dev_events.type in events.filter else None
-            if events.MOUSEMOTION not in [e.type for e in eventlist]:
-                print(f"Device {self.__class__.__name__} returned events: {eventlist}")
+            
             for event in eventlist:
                 if event.type == events.QUIT:
                     if self._broker:
@@ -426,7 +425,6 @@ class QueueDevice(Device):
         """
         if (dev_events := self._read()) is not None:
             for event in dev_events:
-                print(f"PyGame returned event: {event}")
                 if event.type in self._data2:
                     if event.type in (
                         events.MOUSEMOTION,
@@ -440,14 +438,9 @@ class QueueDevice(Device):
                             )
                             if event.type == events.MOUSEMOTION:
                                 event.rel = (event.rel[0] // scale, event.rel[1] // scale)
-                    if event.type == events.KEYDOWN:
-                        self._debug = True
-                    elif event.type == events.KEYUP:
-                        self._debug = False
+                    
                     return event
-                else:
-                    if self._debug:
-                        print(f"QueueDevice {self.__class__.__name__} returned event: {event} but it was not in the filter")
+                
         return None
 
     def peek(self) -> bool:

--- a/src/lib/eventsys/joystick.py
+++ b/src/lib/eventsys/joystick.py
@@ -1,4 +1,3 @@
-from machine import ADC,Pin
 
 class JoystickDriver:
     

--- a/src/lib/eventsys/joystick.py
+++ b/src/lib/eventsys/joystick.py
@@ -1,0 +1,30 @@
+from machine import ADC,Pin
+
+class JoystickDriver:
+    
+    def get_instance_id(self):
+        raise NotImplementedError("JoystickDriver.get_instance_id() not implemented")
+
+    def get_numaxes(self):
+        raise NotImplementedError("JoystickDriver.get_numaxes() not implemented")
+
+    def get_axis(self, axis):
+        raise NotImplementedError("JoystickDriver.get_axis() not implemented")
+    
+    def get_numballs(self):
+        raise NotImplementedError("JoystickDriver.get_numballs() not implemented")
+    
+    def get_ball(self, ball):
+        raise NotImplementedError("JoystickDriver.get_ball() not implemented")
+    
+    def get_numbuttons(self):
+        raise NotImplementedError("JoystickDriver.get_numbuttons() not implemented")
+    
+    def get_button(self, button):
+        raise NotImplementedError("JoystickDriver.get_button() not implemented")
+    
+    def get_numhats(self):
+        raise NotImplementedError("JoystickDriver.get_numhats() not implemented")
+    
+    def get_hat(self, hat):
+        raise NotImplementedError("JoystickDriver.get_hat() not implemented")

--- a/src/lib/graphics/_framebuf.py
+++ b/src/lib/graphics/_framebuf.py
@@ -294,7 +294,7 @@ class RGB565Format:
                 offset = _y * stride
                 for _x in range(x, x + width):
                     index = (offset + _x) * 2
-                    framebuf.buffer[index : index + 2] = rgb565_color
+                    framebuf._buffer[index : index + 2] = rgb565_color
 
 
 class FrameBuffer:


### PR DESCRIPTION
Implemented Joysticks using pygame methodology.

This also required reworking the eventsys to allow for multiple events per poll cycle. This is because of a few reasons:
- Joysticks are inherently more complex than other devices, and warrant generating multiple events at once 
  - ex:
    -  a touchscreen only needs one at a time (ignoring multitouch): MOUSEBUTTONDOWN, then possibly some MOUSEMOTION events, then MOUSEBUTTONUP. They never need to happen at the same time.
    - a joystick typically moves both axes at once, and each needs its own event.
- As stated in pygame docs: `Analog joysticks usually have a bit of noise in their axis, which will generate a lot of rapid small motion events.` (one might even say a _plethora_ of pygame events) Even when the joystick is "idle" in the center, lots of events still get generated. So, if Broker.poll only returns the first event, then only the first input that moved will have an event generated. The rest of the inputs (including the hats and buttons, and more importantly, the second axis) will be ignored. In addition any other _devices_ that were added to the Broker after the joystick will also likely never generate any events, since the broker checks them in order. I understand it's rare to have more than one device, but when joysticks are included, that becomes much more common.
- It's also the recommended (required?) way to handle events for both pygame and SDL.
  - in the microcontroller case, where all events are internally generated, this is not really an issue. But when running on desktop where it is actually using pygame/sdl, events can quickly back up and fill the queue if not handled fast enough (e.g. only one event per frame)

Changes made:
- I changed Broker._poll() to check all the devices, and build a list of events to return instead of returning just the first one.
- I changed Device.poll() to handle either single or multiple events when it in turn calls _poll().
- I implemented Joystick._poll() to also return multiple.
- I went through the rest of the devices and all the examples and updated them to handle multiple where appropriate. I tried to keep backwards compatibility in mind wherever possible.
- I also added a driver for a GPIO-based joystick. Analog axes take machine.ADC inputs. Buttons and Hats take machine.Pin inputs.
  - I did not implement trackballs since I don't have any GPIO-based trackballs to test with. (not sure any exist, actually)
    - This also means the trackball part of the Joystick Device is untested.
  - I added an example board config using the new driver.

Additional features/changes:
- The Joystick device has the ability to emulate digital buttons using the analog axes. They are emulated using additional Hats. 
  - This allows you to treat a joystick as a d-pad, for example.
  - Axes return a float between -1 and 1. Hats return int -1, 0, or 1.
  - You can give a threshold (default 0.5) and if the axis is pushed past that threshold, it generates a hat event with -1 or 1 appropriately.
  - I added an example (`joystick_list_select.py`) showing this feature.
- I added a `joystick_keypad`, analogous to `touch_keypad`, but for joystick input
- I updated `touch_keypad` to use a subscribe methodology instead of polling.
  - This was needed because of the multiple event processing, and to have it interact with `joystick_keypad` appropriately when both are used
  - I updated all the examples where needed to account for these changes
- I updated the example `testris`:
  - Added joystick support.
  - Fixed a piece rotation bug
  - I did not test the joystick in desktop mode because:
    - I haven't been able to get SDL to work when running pydisplay on my mac, so I run linux-based tests using docker.
      - (it can't find `libSDL2-2.0.so.0` in mac when loading `multimer`)
    - my USB joystick is not usable in docker
  - However, I did run a plain pygame test (without pydisplay) and it generates all the same events, so it is likely ok.
- Fixed a bug in `_framebuf.py` - was missing a `_` on one of the internal `_buffer` references


I acknowledge that there are a lot of changes here, and significant ones as well. I understand if you don't want to merge this PR because of that. However, a project I'm working on needed a joystick, and it seems to be working well for me, so I figured I'd contribute what I wrote.

I'm also open to changes and available to work on them if needed. And to help maintain going forward.
