### PR TITLE
Update quick start demo import

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ python3 -i path.py
 ```
 
 ```python
->>> import hello
+>>> import pydisplay_demo
 ```
 
 On a MicroPython board, use [installer.py](installer.py) or see [Getting started](https://pydisplay.readthedocs.io/en/latest/getting-started/).


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- Replace the README quick-start `import hello` example with `import pydisplay_demo`

## Testing
- Verified README no longer contains `import hello` and includes `import pydisplay_demo`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-877a24e0-1e67-4d22-90d4-f16b54bef0c8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-877a24e0-1e67-4d22-90d4-f16b54bef0c8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

