### PR TITLE
Add self-contained multimer test suite and make its docstrings self-referential

### DIFF
--- a/src/lib/multimer/__init__.py
+++ b/src/lib/multimer/__init__.py
@@ -32,7 +32,15 @@ On CPython (non-Linux), CircuitPython, and MicroPython ports using the polling
 backend, call ``run_queued()`` from the main thread to drain queued callbacks
 (for example in an event loop).  ``sleep_ms()`` also advances polling timers.
 
-For asyncio-based apps, use ``multimer.aio`` — see ``docs/concepts/multimer.md``.
+``REQUIRES_RUN_QUEUED`` is exported at the package level (true whenever the
+backend may deliver callbacks from another thread, e.g. CPython); the chosen
+``Timer`` class also exposes a ``Timer.REQUIRES_RUN_QUEUED`` attribute for the
+specific backend.  Check ``getattr(Timer, "REQUIRES_RUN_QUEUED", False)`` to
+decide whether your main loop must call ``run_queued()``.
+
+For asyncio-based apps, import ``multimer.aio`` instead; see that module's
+docstring for the asyncio/uasyncio ``Timer`` and its ``run``/``run_queued``
+helpers.
 """
 
 import sys

--- a/src/lib/multimer/aio.py
+++ b/src/lib/multimer/aio.py
@@ -4,8 +4,14 @@
 """
 asyncio/uasyncio Timer for multimer.
 
-Opt-in module — not wired into ``multimer.Timer``. Use when the app runs under
-asyncio/uasyncio. See ``docs/concepts/multimer.md`` for full documentation.
+Opt-in module — not wired into the package-level ``multimer.Timer``. Use it when
+the whole app runs under asyncio/uasyncio (e.g. PyScript, async ports, or
+CircuitPython with the asyncio library installed). It tries ``uasyncio`` first,
+then falls back to ``asyncio``.
+
+This module is self-contained: the public API is ``Timer`` (an asyncio software
+timer with the same ``machine.Timer``-style API as the rest of multimer) plus
+two optional helpers, ``run`` and ``run_queued``.
 
 Quick start (helpers are optional)::
 
@@ -13,16 +19,26 @@ Quick start (helpers are optional)::
 
     async def main():
         t = Timer()
+        # init() must be called while the event loop is already running
         t.init(mode=Timer.PERIODIC, period=33, callback=cb)
         while True:
-            broker.poll()
-            display.show()
+            do_periodic_work()
             await run_queued()  # or await asyncio.sleep(0)
 
     run(main)  # or asyncio.run(main())
 
-``run_queued`` and ``run`` are convenience wrappers only. Any ``await`` that
-yields to the event loop is sufficient for timer callbacks to fire.
+Notes:
+
+- ``Timer.init()`` must run while the event loop is already running; it raises
+  ``RuntimeError`` otherwise.  Callbacks run on the event-loop thread.
+- ``run(main)`` runs an async ``main`` coroutine function to completion with
+  ``asyncio.run`` (or ``run_until_complete``); on a host that already drives a
+  loop (Jupyter, PyScript) it schedules ``main`` as a background task instead.
+- ``run_queued`` and ``run`` are convenience wrappers only.  Any ``await`` that
+  yields to the event loop is sufficient for timer callbacks to fire, so a loop
+  that already awaits something can drop ``run_queued`` entirely.
+- ``aio.run_queued()`` (async) is unrelated to the sync package-level
+  ``multimer.run_queued()`` used by the threading/SDL backends.
 """
 
 try:

--- a/tests/README.md
+++ b/tests/README.md
@@ -1,0 +1,40 @@
+# Tests
+
+Self-contained tests for the standalone [`multimer`](../src/lib/multimer) package.
+
+They use only the Python standard library (`unittest`) — no third-party test
+runner or build step is required. The shared bootstrap in
+[`_env.py`](_env.py) puts `src/lib` on `sys.path`, so nothing needs to be
+installed first.
+
+## Running
+
+From the repository root:
+
+```bash
+python -m unittest discover -s tests -v
+```
+
+Or run a single module:
+
+```bash
+python -m unittest tests.test_ticks -v
+# or
+python tests/test_ticks.py
+```
+
+## What is covered
+
+| Module | Area |
+|--------|------|
+| `test_ticks.py` | `ticks_ms` / `ticks_add` / `ticks_diff` / `ticks_less` / `sleep_ms` |
+| `test_schedule.py` | `schedule` / `run_queued` and the `REQUIRES_RUN_QUEUED` flag |
+| `test_timer.py` | the default `multimer.Timer` (whichever backend is selected) |
+| `test_get_timer.py` | the `get_timer` convenience helper |
+| `test_aio.py` | the opt-in `multimer.aio` asyncio timer |
+| `test_standalone.py` | proves `multimer` imports and runs with **none** of the rest of pydisplay on the path |
+
+The timer tests run on whichever synchronous backend the host selects
+(`_ctypes`/`_ffi`/`_threading`/`_sdl2`/`_polling`); `_support.pump()` drives
+them uniformly. Tests that need a real `machine.Timer` are skipped when no
+backend is available.

--- a/tests/_env.py
+++ b/tests/_env.py
@@ -1,0 +1,24 @@
+# SPDX-FileCopyrightText: 2026 Brad Barnett
+#
+# SPDX-License-Identifier: MIT
+"""Shared test bootstrap that puts ``multimer`` on ``sys.path``.
+
+The tests are self-contained: importing this module makes ``src/lib`` (where
+the ``multimer`` package lives) importable without installing anything. Import
+it before importing ``multimer`` in any test module::
+
+    import _env  # noqa: F401
+    import multimer
+"""
+
+import os
+import sys
+
+_SRC_LIB = os.path.abspath(os.path.join(os.path.dirname(__file__), "..", "src", "lib"))
+
+if _SRC_LIB not in sys.path:
+    sys.path.insert(0, _SRC_LIB)
+
+#: Absolute path to the ``multimer`` package directory, handy for tests that
+#: want to copy it somewhere isolated.
+MULTIMER_DIR = os.path.join(_SRC_LIB, "multimer")

--- a/tests/_support.py
+++ b/tests/_support.py
@@ -1,0 +1,27 @@
+# SPDX-FileCopyrightText: 2026 Brad Barnett
+#
+# SPDX-License-Identifier: MIT
+"""Helpers shared by the synchronous timer tests."""
+
+import time
+
+import _env  # noqa: F401
+
+import multimer
+
+
+def pump(duration_s, step_s=0.005):
+    """Drive timers for ``duration_s`` seconds.
+
+    Works across every synchronous backend:
+
+    - threading / SDL / polling backends deliver callbacks through the schedule
+      queue, which ``multimer.run_queued()`` drains here on the main thread;
+    - the POSIX ``_ctypes``/``_ffi`` backends deliver callbacks on the main
+      thread during ``time.sleep`` (``run_queued`` is then a harmless no-op).
+    """
+    end = time.monotonic() + duration_s
+    while time.monotonic() < end:
+        multimer.run_queued()
+        time.sleep(step_s)
+    multimer.run_queued()

--- a/tests/test_aio.py
+++ b/tests/test_aio.py
@@ -1,0 +1,87 @@
+# SPDX-FileCopyrightText: 2026 Brad Barnett
+#
+# SPDX-License-Identifier: MIT
+"""Tests for the opt-in ``multimer.aio`` asyncio timer."""
+
+import asyncio
+import unittest
+
+import _env  # noqa: F401
+
+from multimer.aio import Timer, run
+
+
+class TestAioTimer(unittest.TestCase):
+    def test_requires_run_queued_is_false(self):
+        self.assertFalse(Timer.REQUIRES_RUN_QUEUED)
+
+    def test_init_without_running_loop_raises(self):
+        t = Timer(-1)
+        with self.assertRaises(RuntimeError):
+            t.init(mode=Timer.PERIODIC, period=20, callback=lambda tmr: None)
+
+    def test_periodic_fires_repeatedly(self):
+        hits = []
+
+        async def main():
+            t = Timer(-1)
+            t.init(mode=Timer.PERIODIC, period=20, callback=lambda tmr: hits.append(1))
+            await asyncio.sleep(0.25)
+            t.deinit()
+
+        asyncio.run(main())
+        self.assertGreaterEqual(len(hits), 3)
+
+    def test_one_shot_fires_once(self):
+        hits = []
+
+        async def main():
+            t = Timer(-1)
+            t.init(mode=Timer.ONE_SHOT, period=30, callback=lambda tmr: hits.append(1))
+            await asyncio.sleep(0.25)
+
+        asyncio.run(main())
+        self.assertEqual(len(hits), 1)
+
+    def test_callback_receives_timer_instance(self):
+        seen = []
+
+        async def main():
+            t = Timer(-1)
+            t.init(mode=Timer.PERIODIC, period=20, callback=seen.append)
+            await asyncio.sleep(0.1)
+            t.deinit()
+            return t
+
+        created = asyncio.run(main())
+        self.assertTrue(seen)
+        self.assertIs(seen[0], created)
+
+    def test_deinit_stops_callbacks(self):
+        hits = []
+
+        async def main():
+            t = Timer(-1)
+            t.init(mode=Timer.PERIODIC, period=20, callback=lambda tmr: hits.append(1))
+            await asyncio.sleep(0.1)
+            t.deinit()
+            count = len(hits)
+            await asyncio.sleep(0.15)
+            return count
+
+        count_at_deinit = asyncio.run(main())
+        self.assertEqual(len(hits), count_at_deinit)
+
+    def test_run_helper_runs_coroutine_to_completion(self):
+        result = []
+
+        async def main():
+            await asyncio.sleep(0)
+            result.append("done")
+
+        run(main)
+        self.assertEqual(result, ["done"])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_get_timer.py
+++ b/tests/test_get_timer.py
@@ -1,0 +1,63 @@
+# SPDX-FileCopyrightText: 2026 Brad Barnett
+#
+# SPDX-License-Identifier: MIT
+"""Tests for the ``multimer.get_timer`` convenience helper."""
+
+import sys
+import unittest
+
+import _env  # noqa: F401
+from _support import pump
+
+import multimer
+from multimer import Timer, get_timer, run_queued
+
+
+@unittest.skipIf(Timer is None, "no Timer backend on this platform")
+class TestGetTimer(unittest.TestCase):
+    def setUp(self):
+        run_queued()
+        self._debug = multimer.DEBUG
+        multimer.DEBUG = False  # keep test output quiet
+        self._timers = []
+
+    def tearDown(self):
+        multimer.DEBUG = self._debug
+        for t in self._timers:
+            try:
+                t.deinit()
+            except Exception:
+                pass
+        run_queued()
+
+    def _track(self, t):
+        self._timers.append(t)
+        return t
+
+    def test_returns_running_timer_that_fires(self):
+        hits = []
+        self._track(get_timer(lambda t: hits.append(1), period=20, warn=False))
+        pump(0.2)
+        self.assertGreaterEqual(len(hits), 2)
+
+    def test_callback_receives_timer_instance(self):
+        seen = []
+        t = self._track(get_timer(seen.append, period=20, warn=False))
+        pump(0.15)
+        self.assertTrue(seen)
+        self.assertIs(seen[0], t)
+
+    @unittest.skipIf(sys.platform == "rp2", "rp2 always uses id -1")
+    def test_auto_allocates_increasing_ids(self):
+        t1 = self._track(get_timer(lambda t: None, period=1000, warn=False))
+        t2 = self._track(get_timer(lambda t: None, period=1000, warn=False))
+        self.assertEqual(t2.id, t1.id + 1)
+
+    def test_asynchronous_without_loop_raises(self):
+        # multimer.aio.Timer.init() requires a running event loop.
+        with self.assertRaises(RuntimeError):
+            get_timer(lambda t: None, period=20, asynchronous=True, warn=False)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_schedule.py
+++ b/tests/test_schedule.py
@@ -1,0 +1,77 @@
+# SPDX-FileCopyrightText: 2026 Brad Barnett
+#
+# SPDX-License-Identifier: MIT
+"""Tests for ``multimer.schedule`` / ``multimer.run_queued``."""
+
+import threading
+import unittest
+
+import _env  # noqa: F401
+
+import multimer
+from multimer import run_queued, schedule
+
+
+class TestSchedule(unittest.TestCase):
+    def setUp(self):
+        # Drain anything left over from a previous test so the shared module
+        # queue starts empty.
+        run_queued()
+
+    def tearDown(self):
+        run_queued()
+
+    def test_requires_run_queued_flag_is_true_on_cpython(self):
+        # CPython may post callbacks from worker threads, so the module-level
+        # flag is true.
+        self.assertTrue(multimer.REQUIRES_RUN_QUEUED)
+
+    def test_main_thread_runs_callback_immediately(self):
+        calls = []
+        schedule(calls.append, "now")
+        # No run_queued() needed when scheduling from the main thread.
+        self.assertEqual(calls, ["now"])
+
+    def test_worker_thread_defers_until_run_queued(self):
+        calls = []
+        main_ident = threading.current_thread().ident
+        ran_on = []
+
+        def cb(arg):
+            calls.append(arg)
+            ran_on.append(threading.current_thread().ident)
+
+        def worker():
+            schedule(cb, "later")
+
+        t = threading.Thread(target=worker)
+        t.start()
+        t.join()
+
+        # Callback was queued, not run on the worker thread.
+        self.assertEqual(calls, [])
+
+        run_queued()
+        self.assertEqual(calls, ["later"])
+        # Drained on the main thread.
+        self.assertEqual(ran_on, [main_ident])
+
+    def test_run_queued_respects_max_items(self):
+        calls = []
+
+        def worker():
+            for i in range(4):
+                schedule(calls.append, i)
+
+        t = threading.Thread(target=worker)
+        t.start()
+        t.join()
+
+        run_queued(max_items=2)
+        self.assertEqual(calls, [0, 1])
+        run_queued()
+        self.assertEqual(calls, [0, 1, 2, 3])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_standalone.py
+++ b/tests/test_standalone.py
@@ -1,0 +1,94 @@
+# SPDX-FileCopyrightText: 2026 Brad Barnett
+#
+# SPDX-License-Identifier: MIT
+"""Prove ``multimer`` is standalone with respect to the rest of pydisplay.
+
+This copies *only* the ``multimer`` package into a temporary directory and
+imports it in a fresh subprocess whose path contains nothing else from the
+repository. If ``multimer`` secretly depended on ``displaysys``/``eventsys``/
+``graphics``/``pdwidgets``/etc., the import would fail or those modules would
+appear in ``sys.modules``.
+"""
+
+import os
+import shutil
+import subprocess
+import sys
+import tempfile
+import textwrap
+import unittest
+
+import _env
+
+_PYDISPLAY_SIBLINGS = ("displaysys", "eventsys", "graphics", "pdwidgets", "palettes")
+
+_CHILD = textwrap.dedent(
+    """
+    import sys
+
+    import multimer
+    from multimer import (
+        Timer,
+        get_timer,
+        run_queued,
+        schedule,
+        sleep_ms,
+        ticks_add,
+        ticks_diff,
+        ticks_less,
+        ticks_ms,
+    )
+    import multimer.aio  # opt-in asyncio backend must also be standalone
+
+    forbidden = [m for m in {siblings!r} if m in sys.modules]
+    assert not forbidden, "multimer pulled in pydisplay modules: %r" % forbidden
+
+    assert ticks_ms() >= 0
+    if Timer is not None:
+        hits = []
+        t = get_timer(lambda tmr: hits.append(1), period=10, warn=False)
+        import time
+        end = time.time() + 0.2
+        while time.time() < end:
+            run_queued()
+            time.sleep(0.005)
+        run_queued()
+        t.deinit()
+        assert hits, "standalone timer never fired"
+
+    print("STANDALONE_OK")
+    """
+).format(siblings=list(_PYDISPLAY_SIBLINGS))
+
+
+class TestStandalone(unittest.TestCase):
+    def test_imports_and_runs_in_isolation(self):
+        tmp = tempfile.mkdtemp(prefix="multimer_standalone_")
+        try:
+            shutil.copytree(_env.MULTIMER_DIR, os.path.join(tmp, "multimer"))
+
+            env = dict(os.environ)
+            # The child sees ONLY the temp dir (plus the stdlib) — no src/lib,
+            # so the rest of pydisplay is unreachable.
+            env["PYTHONPATH"] = tmp
+
+            proc = subprocess.run(
+                [sys.executable, "-c", _CHILD],
+                cwd=tmp,
+                env=env,
+                capture_output=True,
+                text=True,
+                check=False,
+            )
+            self.assertEqual(
+                proc.returncode,
+                0,
+                msg=f"child failed\nstdout:\n{proc.stdout}\nstderr:\n{proc.stderr}",
+            )
+            self.assertIn("STANDALONE_OK", proc.stdout)
+        finally:
+            shutil.rmtree(tmp, ignore_errors=True)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_ticks.py
+++ b/tests/test_ticks.py
@@ -1,0 +1,74 @@
+# SPDX-FileCopyrightText: 2026 Brad Barnett
+#
+# SPDX-License-Identifier: MIT
+"""Tests for the cross-platform tick helpers in ``multimer._ticks``."""
+
+import time
+import unittest
+
+import _env  # noqa: F401
+
+from multimer import sleep_ms, ticks_add, ticks_diff, ticks_less, ticks_ms
+
+_TICKS_PERIOD = 1 << 29
+_TICKS_MAX = _TICKS_PERIOD - 1
+
+
+class TestTicksMath(unittest.TestCase):
+    def test_ticks_ms_returns_int_within_period(self):
+        t = ticks_ms()
+        self.assertIsInstance(t, int)
+        self.assertGreaterEqual(t, 0)
+        self.assertLessEqual(t, _TICKS_MAX)
+
+    def test_ticks_add_simple(self):
+        self.assertEqual(ticks_add(100, 50), 150)
+
+    def test_ticks_add_wraps_at_period(self):
+        self.assertEqual(ticks_add(_TICKS_MAX, 1), 0)
+        self.assertEqual(ticks_add(0, -1), _TICKS_MAX)
+
+    def test_ticks_add_overflow_guard(self):
+        with self.assertRaises(OverflowError):
+            ticks_add(0, _TICKS_PERIOD)
+
+    def test_ticks_diff_sign(self):
+        self.assertEqual(ticks_diff(150, 100), 50)
+        self.assertEqual(ticks_diff(100, 150), -50)
+        self.assertEqual(ticks_diff(100, 100), 0)
+
+    def test_ticks_diff_wraparound(self):
+        # later value has wrapped past the period boundary
+        later = ticks_add(_TICKS_MAX, 10)  # == 9
+        self.assertEqual(ticks_diff(later, _TICKS_MAX), 10)
+
+    def test_ticks_less(self):
+        self.assertTrue(ticks_less(100, 150))
+        self.assertFalse(ticks_less(150, 100))
+        self.assertFalse(ticks_less(100, 100))
+
+
+class TestTicksTiming(unittest.TestCase):
+    def test_ticks_ms_advances_over_real_sleep(self):
+        start = ticks_ms()
+        time.sleep(0.05)
+        elapsed = ticks_diff(ticks_ms(), start)
+        # generous bounds to tolerate slow/loaded CI machines
+        self.assertGreaterEqual(elapsed, 30)
+        self.assertLess(elapsed, 2000)
+
+    def test_sleep_ms_blocks_at_least_requested(self):
+        start = time.monotonic()
+        sleep_ms(60)
+        elapsed = (time.monotonic() - start) * 1000
+        self.assertGreaterEqual(elapsed, 40)
+
+    def test_sleep_ms_zero_returns_promptly(self):
+        start = time.monotonic()
+        sleep_ms(0)
+        elapsed = (time.monotonic() - start) * 1000
+        self.assertLess(elapsed, 200)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_timer.py
+++ b/tests/test_timer.py
@@ -1,0 +1,87 @@
+# SPDX-FileCopyrightText: 2026 Brad Barnett
+#
+# SPDX-License-Identifier: MIT
+"""Tests for the default ``multimer.Timer`` (whichever backend is selected)."""
+
+import unittest
+
+import _env  # noqa: F401
+from _support import pump
+
+import multimer
+from multimer import Timer, run_queued
+
+
+@unittest.skipIf(Timer is None, "no Timer backend on this platform")
+class TestTimer(unittest.TestCase):
+    def setUp(self):
+        run_queued()
+        self._timers = []
+
+    def tearDown(self):
+        for t in self._timers:
+            try:
+                t.deinit()
+            except Exception:
+                pass
+        run_queued()
+
+    def _make(self, **kwargs):
+        t = Timer(-1)
+        self._timers.append(t)
+        if kwargs:
+            t.init(**kwargs)
+        return t
+
+    def test_mode_constants(self):
+        self.assertEqual(Timer.PERIODIC, 0)
+        self.assertEqual(Timer.ONE_SHOT, 1)
+
+    def test_periodic_fires_repeatedly(self):
+        hits = []
+        self._make(mode=Timer.PERIODIC, period=20, callback=lambda t: hits.append(1))
+        pump(0.3)
+        self.assertGreaterEqual(len(hits), 3)
+
+    def test_callback_receives_timer_instance(self):
+        seen = []
+        t = self._make(mode=Timer.PERIODIC, period=20, callback=seen.append)
+        pump(0.15)
+        t.deinit()
+        self.assertTrue(seen)
+        self.assertIs(seen[0], t)
+
+    def test_one_shot_fires_once(self):
+        hits = []
+        self._make(mode=Timer.ONE_SHOT, period=30, callback=lambda t: hits.append(1))
+        pump(0.3)
+        self.assertEqual(len(hits), 1)
+
+    def test_deinit_stops_callbacks(self):
+        hits = []
+        t = self._make(mode=Timer.PERIODIC, period=20, callback=lambda tmr: hits.append(1))
+        pump(0.1)
+        t.deinit()
+        count_after_deinit = len(hits)
+        pump(0.2)
+        self.assertEqual(len(hits), count_after_deinit)
+
+    def test_freq_sets_period(self):
+        t = self._make()
+        t.init(mode=Timer.PERIODIC, freq=50, callback=lambda tmr: None)
+        # 50 Hz -> 20 ms period
+        self.assertEqual(t._interval, 20)
+
+    def test_invalid_mode_raises(self):
+        t = self._make()
+        with self.assertRaises(ValueError):
+            t.init(mode=99, period=10, callback=lambda tmr: None)
+
+    def test_invalid_period_raises(self):
+        t = self._make()
+        with self.assertRaises(ValueError):
+            t.init(mode=Timer.PERIODIC, period=0, callback=lambda tmr: None)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Reinforces `multimer` as a standalone package (independent of the rest of pydisplay) in two ways:

1. **Self-referential docstrings** — the `multimer` package docstring and the `multimer.aio` module docstring previously pointed readers to pydisplay's `docs/concepts/multimer.md`. Those references are replaced with self-contained usage notes so the module documents itself.
2. **Self-contained test suite under `tests/`** — a new `unittest` suite (no third-party runner or build step required) exercising the public API.

## Test suite

Run from the repo root:

```bash
python -m unittest discover -s tests -v
```

The shared bootstrap (`tests/_env.py`) puts `src/lib` on `sys.path`, so nothing needs to be installed.

| Module | Area |
|--------|------|
| `test_ticks.py` | `ticks_ms` / `ticks_add` / `ticks_diff` / `ticks_less` / `sleep_ms` (incl. wraparound) |
| `test_schedule.py` | `schedule` / `run_queued`, main-thread vs worker-thread behavior, `REQUIRES_RUN_QUEUED` |
| `test_timer.py` | default `multimer.Timer` (periodic/one-shot/deinit/validation) on whichever backend is selected |
| `test_get_timer.py` | `get_timer` helper (callbacks, id auto-allocation, `asynchronous=True` guard) |
| `test_aio.py` | opt-in `multimer.aio` asyncio `Timer` and `run()` helper |
| `test_standalone.py` | copies **only** the `multimer` package into a temp dir and imports/runs it in a fresh subprocess whose path contains nothing else from the repo — proving zero dependency on `displaysys`/`eventsys`/`graphics`/etc. |

The synchronous timer tests run uniformly across backends via `_support.pump()`, and skip gracefully if no `Timer` backend is available.

## Verification

- `python -m unittest discover -s tests` → **34 tests, OK**
- Individual files runnable directly (e.g. `python tests/test_ticks.py`)
- `ruff check` and `ruff format --check` pass on the new/edited files

No runtime behavior of `multimer` changed; this only updates docstrings and adds tests.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-adbdbdca-3be2-4ff5-9b6f-ad746411fffd"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-adbdbdca-3be2-4ff5-9b6f-ad746411fffd"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

