### PR TITLE
docs: embed LVGL Jupyter notebook in the MkDocs site

### DIFF
--- a/docs/building-docs.md
+++ b/docs/building-docs.md
@@ -38,6 +38,38 @@ API reference pages under `reference/` and `reference/add_ons/` are generated at
 
 Shared copy-paste blocks: `docs/_snippets/` (included via pymdownx Snippets).
 
+### Embedding the Jupyter notebook
+
+The LVGL example notebook ([`src/jupyter_notebook.ipynb`](https://github.com/PyDevices/pydisplay/blob/main/src/jupyter_notebook.ipynb))
+is rendered as a docs page at [Platforms → Jupyter notebook](platforms/jupyter.md).
+It is wired up with three pieces:
+
+| Piece | Role |
+|-------|------|
+| [`mkdocs-jupyter`](https://github.com/danielfrg/mkdocs-jupyter) (in `docs/requirements.txt`) | Converts `.ipynb` files into MkDocs pages |
+| [`tools/gen_notebook_pages.py`](https://github.com/PyDevices/pydisplay/blob/main/tools/gen_notebook_pages.py) | `mkdocs-gen-files` script that copies the notebook from `src/` into the docs tree at build time (MkDocs only renders files under `docs_dir`) |
+| [`overrides/main.html`](https://github.com/PyDevices/pydisplay/blob/main/overrides/main.html) | Material theme override that adds a **Download notebook** button (uses `page.nb_url` from `include_source: true`) |
+
+The notebook keeps living in `src/` so it can still be **run** there against the
+real source (relative imports like `import lib.path`). The committed copy has its
+outputs stripped (nbstripout), and the docs build sets `execute: false`, so the
+rendered page shows **markdown and code cells only** — no live output or the
+interactive touch widget.
+
+!!! note "Why the docs don't execute the notebook"
+    Executing it at build time would need a desktop LVGL runtime
+    ([`PyDevices/lv_cpython_mod`](https://github.com/PyDevices/lv_cpython_mod)),
+    the `JNDisplay` backend, `ipywidgets`/`ipyevents`, and a running asyncio event
+    loop with an interactive display — none of which work in a headless
+    ReadTheDocs builder. To see live output, run the notebook locally (see
+    [Platforms → Jupyter](platforms/jupyter.md)). Installing `lv_cpython_mod` is
+    what makes `import lvgl` work in desktop CPython / Jupyter; it is a separate,
+    source-built C extension and is **not** required to build the docs.
+
+To embed another notebook, add its path to `tools/gen_notebook_pages.py` (or a
+similar gen-files script), reference the copied path in the `nav:` in `mkdocs.yml`,
+and add it to the `include:` list of the `mkdocs-jupyter` plugin.
+
 ### Troubleshooting
 
 **`ModuleNotFoundError` during build** — use a venv as shown above; do not `pip install` into the system Python on Debian/Ubuntu (externally-managed-environment error).

--- a/docs/platforms/jupyter.md
+++ b/docs/platforms/jupyter.md
@@ -2,6 +2,13 @@
 
 Run pydisplay examples in VS Code or Jupyter with the `JNDisplay` backend.
 
+!!! tip "Read the notebook online"
+    The example notebook is rendered directly in these docs at
+    [Jupyter notebook](jupyter-notebook.ipynb) (markdown and code cells; not executed
+    during the build). Use the **download** button at the top of that page to grab
+    the `.ipynb`, or open [`src/jupyter_notebook.ipynb`](https://github.com/PyDevices/pydisplay/blob/main/src/jupyter_notebook.ipynb)
+    from the repo.
+
 ## Limitations
 
 - **Touch only** — mouse clicks on the interactive display widget are emulated as touch (`MOUSEBUTTONDOWN`/`MOUSEMOTION`/`MOUSEBUTTONUP`). Keyboard and encoder emulation are not implemented.

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -4,3 +4,4 @@ mkdocstrings[python]>=0.26
 mkdocs-gen-files>=0.5
 mkdocs-literate-nav>=0.6
 mkdocs-section-index>=0.3
+mkdocs-jupyter>=0.25

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -8,6 +8,7 @@ site_dir: site
 
 theme:
   name: material
+  custom_dir: overrides
   palette:
     - scheme: default
       primary: indigo
@@ -35,9 +36,15 @@ plugins:
 - gen-files:
     scripts:
     - tools/gen_ref_pages.py
+    - tools/gen_notebook_pages.py
 - literate-nav:
     nav_file: SUMMARY.md
 - section-index
+- mkdocs-jupyter:
+    include_source: true
+    execute: false
+    include: ["platforms/jupyter-notebook.ipynb"]
+    ignore: ["src/*.ipynb", ".venv*/**/*.ipynb"]
 - mkdocstrings:
     handlers:
       python:
@@ -93,6 +100,7 @@ nav:
     - CircuitPython: platforms/circuitpython.md
     - CPython desktop: platforms/cpython-desktop.md
     - Jupyter: platforms/jupyter.md
+    - Jupyter notebook: platforms/jupyter-notebook.ipynb
     - PyScript: platforms/pyscript.md
   - Examples:
     - App starter: examples/app-starter.md

--- a/overrides/main.html
+++ b/overrides/main.html
@@ -1,0 +1,15 @@
+{% extends "base.html" %}
+
+{#
+  Adds a "Download Notebook" button to pages rendered by mkdocs-jupyter.
+  page.nb_url is only set when the mkdocs-jupyter plugin runs with
+  include_source: true, so regular Markdown pages are unaffected.
+#}
+{% block content %}
+{% if page.nb_url %}
+  <a href="{{ page.nb_url }}" title="Download notebook" class="md-content__button md-icon">
+    {% include ".icons/material/download.svg" %}
+  </a>
+{% endif %}
+{{ super() }}
+{% endblock content %}

--- a/tools/gen_notebook_pages.py
+++ b/tools/gen_notebook_pages.py
@@ -1,0 +1,25 @@
+"""Copy the LVGL Jupyter notebook into the docs site so mkdocs-jupyter can render it.
+
+The notebook is maintained at ``src/jupyter_notebook.ipynb`` (next to the source it
+imports, so it can be executed locally). MkDocs only renders files under ``docs_dir``,
+so this generator copies it into the virtual docs tree at build time. Outputs are
+stripped from the committed notebook (nbstripout), so the rendered page shows the
+markdown and code cells only -- it is not executed during the build.
+"""
+
+from pathlib import Path
+
+import mkdocs_gen_files
+
+ROOT = Path(__file__).parent.parent
+
+# (source notebook relative to repo root, destination path under docs_dir)
+NOTEBOOKS = (("src/jupyter_notebook.ipynb", "platforms/jupyter-notebook.ipynb"),)
+
+for source_rel, docs_path in NOTEBOOKS:
+    source = ROOT / source_rel
+    if not source.is_file():
+        continue
+    with mkdocs_gen_files.open(docs_path, "w") as fd:
+        fd.write(source.read_text(encoding="utf-8"))
+    mkdocs_gen_files.set_edit_path(docs_path, source.relative_to(ROOT))


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What & why

Answers two related questions:

1. **How can I embed a Jupyter notebook in the docs?** — This PR renders `src/jupyter_notebook.ipynb` as a page in the MkDocs/ReadTheDocs site (`Platforms → Jupyter notebook`).
2. **Could I also install `pydevices/lv_cpython_mod`?** — Documented: it's the desktop CPython LVGL extension that makes the notebook *runnable* locally, but it is **not** needed (and can't run headless) to *build/embed* the docs, so the build renders the notebook statically.

The notebook deliberately stays in `src/` (next to the source it imports, e.g. `import lib.path`, so it can still be executed there). MkDocs only renders files under `docs_dir`, so it is copied into the docs tree at build time.

## Changes

- **`docs/requirements.txt`** — add `mkdocs-jupyter`.
- **`tools/gen_notebook_pages.py`** — new `mkdocs-gen-files` script that copies the notebook from `src/` into the docs tree (`platforms/jupyter-notebook.ipynb`) at build time.
- **`mkdocs.yml`** — register the new gen-files script, add the `mkdocs-jupyter` plugin (`execute: false`, `include_source: true`), add the page to `nav`, and set `theme.custom_dir: overrides`.
- **`overrides/main.html`** — Material theme override adding a **Download notebook** button (only on pages with `page.nb_url`, i.e. notebook pages).
- **`docs/platforms/jupyter.md`** — link to the embedded page + download/source options.
- **`docs/building-docs.md`** — document how the embedding works and why the build does not execute the notebook (needs `lv_cpython_mod` + `JNDisplay` + interactive widgets, unavailable on the headless RTD builder).

## Why not execute at build time

The notebook drives LVGL via `JNDisplay`, `ipywidgets`/`ipyevents`, and a running asyncio loop with an interactive display widget. Executing it would require building [`PyDevices/lv_cpython_mod`](https://github.com/PyDevices/lv_cpython_mod) (a source-built C extension) plus a windowing/interactive environment — not available on ReadTheDocs. The committed notebook also has outputs stripped (nbstripout). So the docs render markdown + code cells; live output is available by running the notebook locally.

## Testing

- `mkdocs build` succeeds; `platforms/jupyter-notebook/index.html` renders all markdown + code cells, the source `.ipynb` is copied for download, and the **Download notebook** button appears only on the notebook page.
- No new build warnings introduced (pre-existing relative-link warnings are unchanged).

## Notes for maintainers

`mkdocs-jupyter` is a new docs build dependency. ReadTheDocs installs from `docs/requirements.txt`, so it will be picked up automatically. The GitHub Pages landing site (`PyDevices.github.io/pydisplay/`) is a separate static page that links to ReadTheDocs; this embedding lives in the ReadTheDocs MkDocs site.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-7850b59a-f7e6-40eb-9e0b-ce57a31cea00"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-7850b59a-f7e6-40eb-9e0b-ce57a31cea00"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

