### PR TITLE
Use the bundled MicroPython interpreter for the PyScript demo

### DIFF
--- a/html/pyscript.toml
+++ b/html/pyscript.toml
@@ -1,3 +1,11 @@
+# Pin the MicroPython interpreter to the copy bundled in this repo
+# (html/pyscript/micropython/) instead of fetching it from the jsDelivr CDN.
+# PyScript resolves this URL relative to each HTML page, so the same value works
+# both when serving html/ locally and under the GitHub Pages /demo/html/ prefix.
+# To use a custom build, drop a webassembly VARIANT=pyscript micropython.mjs +
+# micropython.wasm into html/pyscript/micropython/ (no further config changes).
+interpreter = "./pyscript/micropython/micropython.mjs"
+
 [files]
 "../src/add_ons/README.md" = "/add_ons/"
 "../src/add_ons/bmp565.py" = "/add_ons/"


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What

Adds a single `interpreter` line to `html/pyscript.toml` so the PyScript demo uses the MicroPython build already vendored in `html/pyscript/micropython/` instead of fetching `@micropython/micropython-webassembly-pyscript` from the jsDelivr CDN at runtime.

```toml
interpreter = "./pyscript/micropython/micropython.mjs"
```

## Why

The demo previously relied on the CDN default baked into the vendored PyScript core (`@micropython/micropython-webassembly-pyscript@1.28.0-6`), leaving the bundled `html/pyscript/micropython/micropython.mjs` + `micropython.wasm` unused. Pinning the interpreter:

- removes the runtime CDN dependency (works offline / fully self-hosted), and
- makes `html/pyscript/micropython/` the **drop-in location for a custom-compiled interpreter** — e.g. a `ports/webassembly` build with `VARIANT=pyscript` that includes LVGL via `lv_micropython_cmod`. Replacing the two files there is then the only step needed; no further config changes.

## Path resolution

PyScript resolves the `interpreter` value against the page URL, not the config file:

```
Xs = (e, t = location.href) => new URL(e, t).href
```

All demo pages (`example.html`, `repl.html`, `test.html`, `editor.html`) live in `html/` next to the `pyscript/` folder, so the page-relative `./pyscript/micropython/micropython.mjs` resolves correctly both when serving `html/` locally and under the GitHub Pages `/pydisplay/demo/html/` prefix.

## Validation

Loaded the bundled interpreter under Node (same `.mjs` → `.wasm` resolution the browser uses):

```
MicroPython v1.28.0-6.g974b56afa6 on 2026-04-06
asyncio frozen ok: True
```

Confirms the vendored build is a valid pyscript variant, matches the version the bundled core expects, and has the frozen `asyncio` module the demo requires.

## Notes for a custom LVGL build

To swap in your own interpreter, build the webassembly port (requires emsdk):

```bash
cd micropython/ports/webassembly
make VARIANT=pyscript submodules
make VARIANT=pyscript USER_C_MODULES=/path/to/cmods FROZEN_MANIFEST=/path/to/manifest.py
```

- Must be the `webassembly` port with `VARIANT=pyscript` (not a unix/MCU build) — PyScript depends on that variant's JS↔Python proxying / REPL interface.
- Keep the variant's frozen manifest (`include("$(PORT_DIR)/variants/manifest.py")`) so `asyncio` and the PyScript glue remain frozen.
- pydisplay's own Python is delivered via the `[files]` table and `mip.install`, so it does not need freezing; the LVGL C module needs no frozen Python.
- Copy the resulting `build-pyscript/micropython.mjs` + `micropython.wasm` into `html/pyscript/micropython/`.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-c04b96dc-1686-49fd-ad48-ce6cf2b1289e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-c04b96dc-1686-49fd-ad48-ce6cf2b1289e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

