### PR TITLE
Unify display input: single PSDevices/JNDevices QUEUE source with full input capture

### DIFF
--- a/board_configs/jndisplay/board_config.py
+++ b/board_configs/jndisplay/board_config.py
@@ -2,7 +2,7 @@
 Board configuration for Jupyter Notebook.
 """
 
-from displaysys.jndisplay import JNDisplay, JNKeys, JNTouch
+from displaysys.jndisplay import JNDevices, JNDisplay
 from eventsys import devices
 
 TIMER_ASYNC = True
@@ -14,19 +14,11 @@ broker = devices.Broker()
 
 display_drv = JNDisplay(width, height)
 
-touch_drv = JNTouch(display_drv)
+devices_drv = JNDevices(display_drv)
 
-touch_dev = broker.create_device(
-    type=devices.types.TOUCH,
-    read=touch_drv.get_mouse_pos,
-    data=display_drv,
-)
-
-keys_drv = JNKeys(display_drv)
-
-keys_dev = broker.create_device(
+events_dev = broker.create_device(
     type=devices.types.QUEUE,
-    read=keys_drv.read,
+    read=devices_drv.read,
     data=display_drv,
 )
 

--- a/board_configs/jndisplay/board_config.py
+++ b/board_configs/jndisplay/board_config.py
@@ -2,7 +2,7 @@
 Board configuration for Jupyter Notebook.
 """
 
-from displaysys.jndisplay import JNDisplay, JNTouch
+from displaysys.jndisplay import JNDisplay, JNKeys, JNTouch
 from eventsys import devices
 
 TIMER_ASYNC = True
@@ -19,6 +19,14 @@ touch_drv = JNTouch(display_drv)
 touch_dev = broker.create_device(
     type=devices.types.TOUCH,
     read=touch_drv.get_mouse_pos,
+    data=display_drv,
+)
+
+keys_drv = JNKeys(display_drv)
+
+keys_dev = broker.create_device(
+    type=devices.types.QUEUE,
+    read=keys_drv.read,
     data=display_drv,
 )
 

--- a/board_configs/jndisplay/board_config.py
+++ b/board_configs/jndisplay/board_config.py
@@ -2,7 +2,7 @@
 Board configuration for Jupyter Notebook.
 """
 
-from displaysys.jndisplay import JNDevices, JNDisplay
+from displaysys.jndisplay import JNDisplay, JNTouch
 from eventsys import devices
 
 TIMER_ASYNC = True
@@ -14,7 +14,7 @@ broker = devices.Broker()
 
 display_drv = JNDisplay(width, height)
 
-touch_drv = JNDevices(display_drv)
+touch_drv = JNTouch(display_drv)
 
 touch_dev = broker.create_device(
     type=devices.types.TOUCH,

--- a/board_configs/psdisplay/board_config.py
+++ b/board_configs/psdisplay/board_config.py
@@ -2,7 +2,7 @@
 Board configuration for PyScript.
 """
 
-from displaysys.psdisplay import PSDisplay, PSTouch
+from displaysys.psdisplay import PSDisplay, PSKeys, PSTouch
 from eventsys import devices
 
 width = 320
@@ -17,6 +17,14 @@ touch_drv = PSTouch("display_canvas")
 touch_dev = broker.create_device(
     type=devices.types.TOUCH,
     read=touch_drv.get_mouse_pos,
+    data=display_drv,
+)
+
+keys_drv = PSKeys("display_canvas")
+
+keys_dev = broker.create_device(
+    type=devices.types.QUEUE,
+    read=keys_drv.read,
     data=display_drv,
 )
 

--- a/board_configs/psdisplay/board_config.py
+++ b/board_configs/psdisplay/board_config.py
@@ -2,7 +2,7 @@
 Board configuration for PyScript.
 """
 
-from displaysys.psdisplay import PSDisplay, PSKeys, PSTouch
+from displaysys.psdisplay import PSDevices, PSDisplay
 from eventsys import devices
 
 width = 320
@@ -12,19 +12,11 @@ display_drv = PSDisplay("display_canvas", width, height)
 
 broker = devices.Broker()
 
-touch_drv = PSTouch("display_canvas")
+devices_drv = PSDevices("display_canvas")
 
-touch_dev = broker.create_device(
-    type=devices.types.TOUCH,
-    read=touch_drv.get_mouse_pos,
-    data=display_drv,
-)
-
-keys_drv = PSKeys("display_canvas")
-
-keys_dev = broker.create_device(
+events_dev = broker.create_device(
     type=devices.types.QUEUE,
-    read=keys_drv.read,
+    read=devices_drv.read,
     data=display_drv,
 )
 

--- a/board_configs/psdisplay/board_config.py
+++ b/board_configs/psdisplay/board_config.py
@@ -2,7 +2,7 @@
 Board configuration for PyScript.
 """
 
-from displaysys.psdisplay import PSDevices, PSDisplay
+from displaysys.psdisplay import PSDisplay, PSTouch
 from eventsys import devices
 
 width = 320
@@ -12,7 +12,7 @@ display_drv = PSDisplay("display_canvas", width, height)
 
 broker = devices.Broker()
 
-touch_drv = PSDevices("display_canvas")
+touch_drv = PSTouch("display_canvas")
 
 touch_dev = broker.create_device(
     type=devices.types.TOUCH,

--- a/docs/concepts/displays.md
+++ b/docs/concepts/displays.md
@@ -42,7 +42,7 @@ USB Video lets a board stream the framebuffer as a USB webcam (RP2040; host supp
 
 ### JNDisplay
 
-Jupyter Notebook output via an interactive `ipywidgets` image when touch is enabled (`JNDevices` + `ipyevents`). Mouse clicks map to touch events. Config: `board_configs/jndisplay/`.
+Jupyter Notebook output via an interactive `ipywidgets` image when touch is enabled (`JNTouch` + `ipyevents`). Mouse clicks map to touch events. Config: `board_configs/jndisplay/`.
 
 ### PSDisplay
 
@@ -51,6 +51,62 @@ PyScript browser canvas. Touch only. Config: `board_configs/psdisplay/`. See [Py
 ### EPaperDisplay
 
 Planned — community help wanted.
+
+## How displays expose input
+
+Display backends do not handle input the same way, because the platforms they
+run on do not offer the same input capabilities. There are **two families**,
+and which one a backend belongs to determines how its `board_config.py` wires
+input into [`eventsys`](events.md).
+
+| Family | Backends | Driver exposes | eventsys device | Reports |
+|--------|----------|----------------|-----------------|---------|
+| **Native event queue** | `SDL2Display`, `PGDisplay` | module-level `poll()` / `get()` returning `eventsys.events` objects | `QUEUE` | mouse motion/buttons, wheel, keyboard, window-close (QUIT) |
+| **Single-pointer** | `JNDisplay`, `PSDisplay` | a touch helper class (`JNTouch` / `PSTouch`) with `get_mouse_pos()` | `TOUCH` | left-button "touch" only (synthesized MOUSEBUTTONDOWN / MOUSEMOTION / MOUSEBUTTONUP) |
+
+### Native event queue (SDL2, PyGame)
+
+SDL2 and PyGame provide a real OS event queue. The driver module drains it and
+converts each event to an `eventsys.events` object, then `board_config.py`
+registers a `QUEUE` device:
+
+```python
+from displaysys.sdldisplay import SDLDisplay, poll
+from eventsys import devices
+
+display_drv = SDLDisplay(...)
+broker = devices.Broker()
+broker.create_device(type=devices.types.QUEUE, read=poll, data=display_drv)
+```
+
+This is the richest model — keyboard, mouse wheel, all mouse buttons, and the
+window-close event all flow through one device.
+
+### Single-pointer (Jupyter, PyScript)
+
+Jupyter and PyScript only expose pointer events on a single widget/canvas, so
+each provides a small helper class that tracks the current pressed position via
+`get_mouse_pos()`. `board_config.py` registers it as a `TOUCH` device, and
+`eventsys` synthesizes button-1 press/move/release events from the polled
+position (and applies touch rotation):
+
+```python
+from displaysys.psdisplay import PSDisplay, PSTouch
+from eventsys import devices
+
+display_drv = PSDisplay("display_canvas", width, height)
+broker = devices.Broker()
+touch_drv = PSTouch("display_canvas")
+broker.create_device(type=devices.types.TOUCH, read=touch_drv.get_mouse_pos, data=display_drv)
+```
+
+These backends cannot offer the full queue model because the platform has no
+equivalent keyboard/window event stream — the single-pointer helper is the most
+they can support.
+
+> The touch helpers were previously named `JNDevices` / `PSDevices`. Those names
+> remain available as aliases, but `JNTouch` / `PSTouch` better describe that
+> they are single-pointer touch adapters, not general event brokers.
 
 ## Canvases
 

--- a/docs/concepts/displays.md
+++ b/docs/concepts/displays.md
@@ -104,10 +104,6 @@ These backends cannot offer the full queue model because the platform has no
 equivalent keyboard/window event stream — the single-pointer helper is the most
 they can support.
 
-> The touch helpers were previously named `JNDevices` / `PSDevices`. Those names
-> remain available as aliases, but `JNTouch` / `PSTouch` better describe that
-> they are single-pointer touch adapters, not general event brokers.
-
 ## Canvases
 
 Anything you can draw on implements the framebuf API:

--- a/docs/concepts/displays.md
+++ b/docs/concepts/displays.md
@@ -81,6 +81,11 @@ broker = devices.Broker()
 broker.create_device(type=devices.types.QUEUE, read=poll, data=display_drv)
 ```
 
+This captures mouse motion/buttons, the wheel, the keyboard, the window-close
+(`QUIT`) event, and **joysticks/gamepads** (`JOYAXISMOTION`, `JOYBALLMOTION`,
+`JOYHATMOTION`, `JOYBUTTONDOWN`, `JOYBUTTONUP`). Connect controllers before
+launching — hot-plugging after startup is not handled.
+
 ### Browser / notebook (PyScript, Jupyter)
 
 `PSDevices` (PyScript) and `JNDevices` (Jupyter) capture all available input on

--- a/docs/concepts/displays.md
+++ b/docs/concepts/displays.md
@@ -103,8 +103,9 @@ broker.create_device(type=devices.types.TOUCH, read=touch_drv.get_mouse_pos, dat
 Each backend also provides a **keyboard helper** (`JNKeys` / `PSKeys`) that
 listens for browser `keydown` / `keyup` events and produces fully-formed
 `eventsys.events.Key` objects — with SDL-style key codes, names, and modifier
-masks via a per-module keymap — so keyboard input matches the desktop event
-stream. It is registered as a `QUEUE` device through its `read()` method:
+masks via the shared keymap in `eventsys.keys` — so keyboard input matches the
+desktop event stream. It is registered as a `QUEUE` device through its `read()`
+method:
 
 ```python
 from displaysys.psdisplay import PSDisplay, PSKeys

--- a/docs/concepts/displays.md
+++ b/docs/concepts/displays.md
@@ -62,7 +62,7 @@ input into [`eventsys`](events.md).
 | Family | Backends | Driver exposes | eventsys device | Reports |
 |--------|----------|----------------|-----------------|---------|
 | **Native event queue** | `SDL2Display`, `PGDisplay` | module-level `poll()` / `get()` returning `eventsys.events` objects | `QUEUE` | mouse motion/buttons, wheel, keyboard, window-close (QUIT) |
-| **Single-pointer** | `JNDisplay`, `PSDisplay` | a touch helper class (`JNTouch` / `PSTouch`) with `get_mouse_pos()` | `TOUCH` | left-button "touch" only (synthesized MOUSEBUTTONDOWN / MOUSEMOTION / MOUSEBUTTONUP) |
+| **Single-pointer + keyboard** | `JNDisplay`, `PSDisplay` | a touch helper (`JNTouch` / `PSTouch`) with `get_mouse_pos()`, plus a keyboard helper (`JNKeys` / `PSKeys`) with `read()` | `TOUCH` + `QUEUE` | left-button "touch" (synthesized MOUSEBUTTONDOWN / MOUSEMOTION / MOUSEBUTTONUP) and keyboard KEYDOWN / KEYUP + QUIT |
 
 ### Native event queue (SDL2, PyGame)
 
@@ -82,11 +82,11 @@ broker.create_device(type=devices.types.QUEUE, read=poll, data=display_drv)
 This is the richest model — keyboard, mouse wheel, all mouse buttons, and the
 window-close event all flow through one device.
 
-### Single-pointer (Jupyter, PyScript)
+### Single-pointer + keyboard (Jupyter, PyScript)
 
 Jupyter and PyScript only expose pointer events on a single widget/canvas, so
-each provides a small helper class that tracks the current pressed position via
-`get_mouse_pos()`. `board_config.py` registers it as a `TOUCH` device, and
+each provides a small **touch helper** that tracks the current pressed position
+via `get_mouse_pos()`. `board_config.py` registers it as a `TOUCH` device, and
 `eventsys` synthesizes button-1 press/move/release events from the polled
 position (and applies touch rotation):
 
@@ -100,9 +100,37 @@ touch_drv = PSTouch("display_canvas")
 broker.create_device(type=devices.types.TOUCH, read=touch_drv.get_mouse_pos, data=display_drv)
 ```
 
-These backends cannot offer the full queue model because the platform has no
-equivalent keyboard/window event stream — the single-pointer helper is the most
-they can support.
+Each backend also provides a **keyboard helper** (`JNKeys` / `PSKeys`) that
+listens for browser `keydown` / `keyup` events and produces fully-formed
+`eventsys.events.Key` objects — with SDL-style key codes, names, and modifier
+masks via a per-module keymap — so keyboard input matches the desktop event
+stream. It is registered as a `QUEUE` device through its `read()` method:
+
+```python
+from displaysys.psdisplay import PSDisplay, PSKeys
+from eventsys import devices
+
+keys_drv = PSKeys("display_canvas")
+broker.create_device(type=devices.types.QUEUE, read=keys_drv.read, data=display_drv)
+```
+
+The keyboard helper also captures an assignable **quit chord** that emits an
+`events.QUIT` (the equivalent of clicking an SDL window's close button — the
+broker then deinitializes the display and exits). It defaults to **CTRL+C**;
+assign a different `(key_code, modifier_mask)` tuple (or `None` to disable) if
+the host browser/notebook intercepts that chord:
+
+```python
+from eventsys.keys import Keys
+
+keys_drv.quit_chord = (Keys.K_q, Keys.KMOD_CTRL)  # use CTRL+Q instead
+```
+
+> **Caveat:** key events require the canvas/widget to be focused (click it
+> first), and the notebook/browser front end may consume some keys (arrows,
+> space, `Ctrl`/`Cmd` shortcuts) before they reach the helper. This makes
+> keyboard input on these backends less reliable than on the desktop SDL/PyGame
+> backends.
 
 ## Canvases
 

--- a/docs/concepts/displays.md
+++ b/docs/concepts/displays.md
@@ -42,11 +42,11 @@ USB Video lets a board stream the framebuffer as a USB webcam (RP2040; host supp
 
 ### JNDisplay
 
-Jupyter Notebook output via an interactive `ipywidgets` image when touch is enabled (`JNTouch` + `ipyevents`). Mouse clicks map to touch events. Config: `board_configs/jndisplay/`.
+Jupyter Notebook output via an interactive `ipywidgets` image. Input (mouse, wheel, keyboard) is captured by `JNDevices` (`ipyevents`) and delivered as events. Config: `board_configs/jndisplay/`.
 
 ### PSDisplay
 
-PyScript browser canvas. Touch only. Config: `board_configs/psdisplay/`. See [PyScript](../guides/pyscript.md).
+PyScript browser canvas. Input (pointer/touch/pen, wheel, keyboard, gamepad) is captured by `PSDevices` and delivered as events. Config: `board_configs/psdisplay/`. See [PyScript](../guides/pyscript.md).
 
 ### EPaperDisplay
 
@@ -54,21 +54,23 @@ Planned — community help wanted.
 
 ## How displays expose input
 
-Display backends do not handle input the same way, because the platforms they
-run on do not offer the same input capabilities. There are **two families**,
-and which one a backend belongs to determines how its `board_config.py` wires
-input into [`eventsys`](events.md).
+All display backends feed input into [`eventsys`](events.md) the same way: as a
+stream of `eventsys.events` objects drained through a **`QUEUE`** device. They
+differ only in *how* that stream is produced, which depends on what each
+platform exposes:
 
-| Family | Backends | Driver exposes | eventsys device | Reports |
-|--------|----------|----------------|-----------------|---------|
-| **Native event queue** | `SDL2Display`, `PGDisplay` | module-level `poll()` / `get()` returning `eventsys.events` objects | `QUEUE` | mouse motion/buttons, wheel, keyboard, window-close (QUIT) |
-| **Single-pointer + keyboard** | `JNDisplay`, `PSDisplay` | a touch helper (`JNTouch` / `PSTouch`) with `get_mouse_pos()`, plus a keyboard helper (`JNKeys` / `PSKeys`) with `read()` | `TOUCH` + `QUEUE` | left-button "touch" (synthesized MOUSEBUTTONDOWN / MOUSEMOTION / MOUSEBUTTONUP) and keyboard KEYDOWN / KEYUP + QUIT |
+| Backends | Input source | Registered as |
+|----------|--------------|---------------|
+| `SDL2Display`, `PGDisplay` | module-level `poll()` / `get()` draining the native OS event queue | `QUEUE` device with `read=poll`/`read=get` |
+| `JNDisplay`, `PSDisplay` | a `JNDevices` / `PSDevices` instance capturing browser input, drained via `read()` | `QUEUE` device with `read=devices_drv.read` |
 
-### Native event queue (SDL2, PyGame)
+Either way your handler sees the same `eventsys.events` objects, so application
+code never needs to know which backend is active.
+
+### Desktop (SDL2, PyGame)
 
 SDL2 and PyGame provide a real OS event queue. The driver module drains it and
-converts each event to an `eventsys.events` object, then `board_config.py`
-registers a `QUEUE` device:
+converts each event to an `eventsys.events` object:
 
 ```python
 from displaysys.sdldisplay import SDLDisplay, poll
@@ -79,52 +81,42 @@ broker = devices.Broker()
 broker.create_device(type=devices.types.QUEUE, read=poll, data=display_drv)
 ```
 
-This is the richest model — keyboard, mouse wheel, all mouse buttons, and the
-window-close event all flow through one device.
+### Browser / notebook (PyScript, Jupyter)
 
-### Single-pointer + keyboard (Jupyter, PyScript)
-
-Jupyter and PyScript only expose pointer events on a single widget/canvas, so
-each provides a small **touch helper** that tracks the current pressed position
-via `get_mouse_pos()`. `board_config.py` registers it as a `TOUCH` device, and
-`eventsys` synthesizes button-1 press/move/release events from the polled
-position (and applies touch rotation):
+`PSDevices` (PyScript) and `JNDevices` (Jupyter) capture all available input on
+the canvas/widget and turn it into the same `eventsys.events` objects, drained
+through `read()`:
 
 ```python
-from displaysys.psdisplay import PSDisplay, PSTouch
+from displaysys.psdisplay import PSDevices, PSDisplay
 from eventsys import devices
 
 display_drv = PSDisplay("display_canvas", width, height)
 broker = devices.Broker()
-touch_drv = PSTouch("display_canvas")
-broker.create_device(type=devices.types.TOUCH, read=touch_drv.get_mouse_pos, data=display_drv)
+devices_drv = PSDevices("display_canvas")
+broker.create_device(type=devices.types.QUEUE, read=devices_drv.read, data=display_drv)
 ```
 
-Each backend also provides a **keyboard helper** (`JNKeys` / `PSKeys`) that
-listens for browser `keydown` / `keyup` events and produces fully-formed
-`eventsys.events.Key` objects — with SDL-style key codes, names, and modifier
-masks via the shared keymap in `eventsys.keys` — so keyboard input matches the
-desktop event stream. It is registered as a `QUEUE` device through its `read()`
-method:
+Each captures:
 
-```python
-from displaysys.psdisplay import PSDisplay, PSKeys
-from eventsys import devices
-
-keys_drv = PSKeys("display_canvas")
-broker.create_device(type=devices.types.QUEUE, read=keys_drv.read, data=display_drv)
-```
-
-The keyboard helper also captures an assignable **quit chord** that emits an
-`events.QUIT` (the equivalent of clicking an SDL window's close button — the
-broker then deinitializes the display and exits). It defaults to **CTRL+C**;
-assign a different `(key_code, modifier_mask)` tuple (or `None` to disable) if
-the host browser/notebook intercepts that chord:
+- **Pointer** — `MOUSEMOTION` on every move and `MOUSEBUTTONDOWN` /
+  `MOUSEBUTTONUP` for any button. On PyScript this uses Pointer Events, so mouse,
+  touch, and pen all work (with the `touch` flag set for non-mouse pointers).
+- **Wheel** — `MOUSEWHEEL` (also consumed by encoder devices).
+- **Keyboard** — `KEYDOWN` / `KEYUP` with SDL-style key codes, names, and
+  modifier masks (incl. left/right modifier variants) via the shared keymap in
+  `eventsys.keys`.
+- **Gamepad** (PyScript only) — `JOYAXISMOTION` / `JOYBUTTONDOWN` /
+  `JOYBUTTONUP`, polled from the Gamepad API on each `read()`.
+- **Quit** — an assignable key chord emits `events.QUIT` (the equivalent of
+  clicking an SDL window's close button; the broker then deinitializes the
+  display and exits). It defaults to **CTRL+C**; reassign if the host intercepts
+  it:
 
 ```python
 from eventsys.keys import Keys
 
-keys_drv.quit_chord = (Keys.K_q, Keys.KMOD_CTRL)  # use CTRL+Q instead
+devices_drv.quit_chord = (Keys.K_q, Keys.KMOD_CTRL)  # use CTRL+Q instead
 ```
 
 > **Caveat:** key events require the canvas/widget to be focused (click it
@@ -132,6 +124,10 @@ keys_drv.quit_chord = (Keys.K_q, Keys.KMOD_CTRL)  # use CTRL+Q instead
 > space, `Ctrl`/`Cmd` shortcuts) before they reach the helper. This makes
 > keyboard input on these backends less reliable than on the desktop SDL/PyGame
 > backends.
+>
+> Rotation on these backends only reshapes the surface (e.g. 320×480 ↔ 480×320);
+> it does not physically rotate, so pointer coordinates need no rotation
+> remapping.
 
 ## Canvases
 

--- a/docs/concepts/events.md
+++ b/docs/concepts/events.md
@@ -57,28 +57,23 @@ The same event types fire regardless of physical hardware — develop on desktop
 
 ## How displays feed the broker
 
-Desktop and restricted (browser/notebook) display backends supply input to the
-broker differently, because they have different access to the underlying
-platform. There are **two families** (see [Displays → How displays expose
-input](displays.md#how-displays-expose-input) for the full table):
+Every display backend feeds the broker the same way — as `eventsys.events`
+objects drained through a **`QUEUE`** device — differing only in how that stream
+is produced (see [Displays → How displays expose
+input](displays.md#how-displays-expose-input)):
 
-- **Native event queue** (`SDL2Display`, `PGDisplay`) — the driver exposes
-  module-level `poll()` / `get()` that return ready-made `eventsys.events`
-  objects, registered as a **`QUEUE`** device. This carries mouse motion/buttons,
-  the scroll wheel, the keyboard, and the window-close (`QUIT`) event.
-- **Single-pointer + keyboard** (`JNDisplay`, `PSDisplay`) — the driver exposes
-  a touch helper (`JNTouch` / `PSTouch`) with `get_mouse_pos()`, registered as a
-  **`TOUCH`** device, from which `eventsys` synthesizes button-1
-  `MOUSEBUTTONDOWN` / `MOUSEMOTION` / `MOUSEBUTTONUP` events. It also exposes a
-  keyboard helper (`JNKeys` / `PSKeys`) with `read()`, registered as a
-  **`QUEUE`** device, that emits `KEYDOWN` / `KEYUP` (with SDL-style key codes,
-  names and modifiers from the shared keymap in `eventsys.keys`) plus a `QUIT`
-  from an assignable quit chord (default **CTRL+C**). Browser/notebook platforms
-  expose only single-element pointer events, so touch is limited to one pressed
-  position.
+- **Desktop** (`SDL2Display`, `PGDisplay`) — module-level `poll()` / `get()`
+  drain the native OS event queue and return ready-made `eventsys.events`.
+- **Browser / notebook** (`PSDisplay`, `JNDisplay`) — a `PSDevices` / `JNDevices`
+  instance captures all available canvas/widget input and returns it via
+  `read()`: pointer (`MOUSEMOTION` / `MOUSEBUTTONDOWN` / `MOUSEBUTTONUP`, incl.
+  touch and pen on PyScript), wheel (`MOUSEWHEEL`), keyboard (`KEYDOWN` /
+  `KEYUP` with SDL-style codes/names/modifiers from the shared keymap in
+  `eventsys.keys`), gamepad (`JOY*`, PyScript only), and a `QUIT` from an
+  assignable quit chord (default **CTRL+C**).
 
 Either way your handler sees the same `eventsys.events` objects, so application
-code does not need to know which family the active display belongs to.
+code does not need to know which backend the active display uses.
 
 ## Brokers
 

--- a/docs/concepts/events.md
+++ b/docs/concepts/events.md
@@ -55,6 +55,27 @@ See [API reference → eventsys.devices.Broker](../reference/eventsys/devices.md
 
 The same event types fire regardless of physical hardware — develop on desktop with a mouse, deploy with a touchscreen.
 
+## How displays feed the broker
+
+Desktop and restricted (browser/notebook) display backends supply input to the
+broker differently, because they have different access to the underlying
+platform. There are **two families** (see [Displays → How displays expose
+input](displays.md#how-displays-expose-input) for the full table):
+
+- **Native event queue** (`SDL2Display`, `PGDisplay`) — the driver exposes
+  module-level `poll()` / `get()` that return ready-made `eventsys.events`
+  objects, registered as a **`QUEUE`** device. This carries mouse motion/buttons,
+  the scroll wheel, the keyboard, and the window-close (`QUIT`) event.
+- **Single-pointer** (`JNDisplay`, `PSDisplay`) — the driver exposes a small
+  touch helper (`JNTouch` / `PSTouch`) with `get_mouse_pos()`, registered as a
+  **`TOUCH`** device. `eventsys` synthesizes button-1
+  `MOUSEBUTTONDOWN` / `MOUSEMOTION` / `MOUSEBUTTONUP` events from the polled
+  position. Browser/notebook platforms expose only single-element pointer
+  events, so this is the most they can provide.
+
+Either way your handler sees the same `eventsys.events` objects, so application
+code does not need to know which family the active display belongs to.
+
 ## Brokers
 
 `board_config.py` typically sets up brokers that poll hardware and enqueue events:

--- a/docs/concepts/events.md
+++ b/docs/concepts/events.md
@@ -66,12 +66,15 @@ input](displays.md#how-displays-expose-input) for the full table):
   module-level `poll()` / `get()` that return ready-made `eventsys.events`
   objects, registered as a **`QUEUE`** device. This carries mouse motion/buttons,
   the scroll wheel, the keyboard, and the window-close (`QUIT`) event.
-- **Single-pointer** (`JNDisplay`, `PSDisplay`) — the driver exposes a small
-  touch helper (`JNTouch` / `PSTouch`) with `get_mouse_pos()`, registered as a
-  **`TOUCH`** device. `eventsys` synthesizes button-1
-  `MOUSEBUTTONDOWN` / `MOUSEMOTION` / `MOUSEBUTTONUP` events from the polled
-  position. Browser/notebook platforms expose only single-element pointer
-  events, so this is the most they can provide.
+- **Single-pointer + keyboard** (`JNDisplay`, `PSDisplay`) — the driver exposes
+  a touch helper (`JNTouch` / `PSTouch`) with `get_mouse_pos()`, registered as a
+  **`TOUCH`** device, from which `eventsys` synthesizes button-1
+  `MOUSEBUTTONDOWN` / `MOUSEMOTION` / `MOUSEBUTTONUP` events. It also exposes a
+  keyboard helper (`JNKeys` / `PSKeys`) with `read()`, registered as a
+  **`QUEUE`** device, that emits `KEYDOWN` / `KEYUP` (with SDL-style key codes,
+  names and modifiers from a per-module keymap) plus a `QUIT` from an assignable
+  quit chord (default **CTRL+C**). Browser/notebook platforms expose only
+  single-element pointer events, so touch is limited to one pressed position.
 
 Either way your handler sees the same `eventsys.events` objects, so application
 code does not need to know which family the active display belongs to.

--- a/docs/concepts/events.md
+++ b/docs/concepts/events.md
@@ -72,9 +72,10 @@ input](displays.md#how-displays-expose-input) for the full table):
   `MOUSEBUTTONDOWN` / `MOUSEMOTION` / `MOUSEBUTTONUP` events. It also exposes a
   keyboard helper (`JNKeys` / `PSKeys`) with `read()`, registered as a
   **`QUEUE`** device, that emits `KEYDOWN` / `KEYUP` (with SDL-style key codes,
-  names and modifiers from a per-module keymap) plus a `QUIT` from an assignable
-  quit chord (default **CTRL+C**). Browser/notebook platforms expose only
-  single-element pointer events, so touch is limited to one pressed position.
+  names and modifiers from the shared keymap in `eventsys.keys`) plus a `QUIT`
+  from an assignable quit chord (default **CTRL+C**). Browser/notebook platforms
+  expose only single-element pointer events, so touch is limited to one pressed
+  position.
 
 Either way your handler sees the same `eventsys.events` objects, so application
 code does not need to know which family the active display belongs to.

--- a/docs/platforms/jupyter.md
+++ b/docs/platforms/jupyter.md
@@ -20,7 +20,7 @@ Run pydisplay examples in VS Code or Jupyter with the `JNDisplay` backend.
 4. Open [`src/jupyter_notebook.ipynb`](https://github.com/PyDevices/pydisplay/blob/main/src/jupyter_notebook.ipynb).
 5. Run cells starting with `import lib.path`.
 
-Board config: `board_configs/jndisplay/board_config.py` (registers `JNDevices` + `TouchDevice`).
+Board config: `board_configs/jndisplay/board_config.py` (registers `JNTouch` + `TouchDevice`).
 
 Touch examples (e.g. [`eventsys_touch_test.py`](https://github.com/PyDevices/pydisplay/blob/main/src/examples/eventsys_touch_test.py)) render a single interactive **ipywidgets Image** — click on that widget.
 

--- a/docs/platforms/jupyter.md
+++ b/docs/platforms/jupyter.md
@@ -20,9 +20,11 @@ Run pydisplay examples in VS Code or Jupyter with the `JNDisplay` backend.
 4. Open [`src/jupyter_notebook.ipynb`](https://github.com/PyDevices/pydisplay/blob/main/src/jupyter_notebook.ipynb).
 5. Run cells starting with `import lib.path`.
 
-Board config: `board_configs/jndisplay/board_config.py` (registers `JNTouch` + `TouchDevice`).
+Board config: `board_configs/jndisplay/board_config.py` (registers `JNTouch` as a `TOUCH` device and `JNKeys` as a `QUEUE` device).
 
 Touch examples (e.g. [`eventsys_touch_test.py`](https://github.com/PyDevices/pydisplay/blob/main/src/examples/eventsys_touch_test.py)) render a single interactive **ipywidgets Image** — click on that widget.
+
+Keyboard input (`JNKeys`) reuses that same Image widget via `ipyevents`, so the widget must be focused (clicked) to receive key events, and some keys may be consumed by the notebook front end. `JNKeys` also captures an assignable quit chord (default **CTRL+C**) that emits a `QUIT` event; reassign `keys_drv.quit_chord` if the front end intercepts it. See [Displays → How displays expose input](../concepts/displays.md#how-displays-expose-input).
 
 ## Async execution model
 

--- a/docs/platforms/jupyter.md
+++ b/docs/platforms/jupyter.md
@@ -20,11 +20,11 @@ Run pydisplay examples in VS Code or Jupyter with the `JNDisplay` backend.
 4. Open [`src/jupyter_notebook.ipynb`](https://github.com/PyDevices/pydisplay/blob/main/src/jupyter_notebook.ipynb).
 5. Run cells starting with `import lib.path`.
 
-Board config: `board_configs/jndisplay/board_config.py` (registers `JNTouch` as a `TOUCH` device and `JNKeys` as a `QUEUE` device).
+Board config: `board_configs/jndisplay/board_config.py` (registers `JNDevices` as a `QUEUE` device).
 
 Touch examples (e.g. [`eventsys_touch_test.py`](https://github.com/PyDevices/pydisplay/blob/main/src/examples/eventsys_touch_test.py)) render a single interactive **ipywidgets Image** — click on that widget.
 
-Keyboard input (`JNKeys`) reuses that same Image widget via `ipyevents`, so the widget must be focused (clicked) to receive key events, and some keys may be consumed by the notebook front end. `JNKeys` also captures an assignable quit chord (default **CTRL+C**) that emits a `QUIT` event; reassign `keys_drv.quit_chord` if the front end intercepts it. See [Displays → How displays expose input](../concepts/displays.md#how-displays-expose-input).
+`JNDevices` captures mouse (motion/buttons), wheel, and keyboard input on that Image widget via `ipyevents`. The widget must be focused (clicked) to receive key events, and some keys may be consumed by the notebook front end. It also captures an assignable quit chord (default **CTRL+C**) that emits a `QUIT` event; reassign `devices_drv.quit_chord` if the front end intercepts it. See [Displays → How displays expose input](../concepts/displays.md#how-displays-expose-input).
 
 ## Async execution model
 

--- a/src/lib/board_config.py
+++ b/src/lib/board_config.py
@@ -31,31 +31,23 @@ except ImportError:
 
 if _ps:
     # Running in PyScript
-    from displaysys.psdisplay import PSDisplay, PSKeys, PSTouch
+    from displaysys.psdisplay import PSDevices, PSDisplay
     from eventsys import devices
 
     display_drv = PSDisplay("display_canvas", width, height)
 
     broker = devices.Broker()
 
-    touch_drv = PSTouch("display_canvas")
+    devices_drv = PSDevices("display_canvas")
 
-    touch_dev = broker.create_device(
-        type=devices.types.TOUCH,
-        read=touch_drv.get_mouse_pos,
-        data=display_drv,
-    )
-
-    keys_drv = PSKeys("display_canvas")
-
-    keys_dev = broker.create_device(
+    events_dev = broker.create_device(
         type=devices.types.QUEUE,
-        read=keys_drv.read,
+        read=devices_drv.read,
         data=display_drv,
     )
 elif _jn:
     # Running in Jupyter Notebook
-    from displaysys.jndisplay import JNDisplay, JNKeys, JNTouch
+    from displaysys.jndisplay import JNDevices, JNDisplay
     from eventsys import devices
 
     TIMER_ASYNC = True
@@ -64,19 +56,11 @@ elif _jn:
 
     display_drv = JNDisplay(width, height)
 
-    touch_drv = JNTouch(display_drv)
+    devices_drv = JNDevices(display_drv)
 
-    touch_dev = broker.create_device(
-        type=devices.types.TOUCH,
-        read=touch_drv.get_mouse_pos,
-        data=display_drv,
-    )
-
-    keys_drv = JNKeys(display_drv)
-
-    keys_dev = broker.create_device(
+    events_dev = broker.create_device(
         type=devices.types.QUEUE,
-        read=keys_drv.read,
+        read=devices_drv.read,
         data=display_drv,
     )
 else:

--- a/src/lib/board_config.py
+++ b/src/lib/board_config.py
@@ -31,7 +31,7 @@ except ImportError:
 
 if _ps:
     # Running in PyScript
-    from displaysys.psdisplay import PSDisplay, PSTouch
+    from displaysys.psdisplay import PSDisplay, PSKeys, PSTouch
     from eventsys import devices
 
     display_drv = PSDisplay("display_canvas", width, height)
@@ -45,9 +45,17 @@ if _ps:
         read=touch_drv.get_mouse_pos,
         data=display_drv,
     )
+
+    keys_drv = PSKeys("display_canvas")
+
+    keys_dev = broker.create_device(
+        type=devices.types.QUEUE,
+        read=keys_drv.read,
+        data=display_drv,
+    )
 elif _jn:
     # Running in Jupyter Notebook
-    from displaysys.jndisplay import JNDisplay, JNTouch
+    from displaysys.jndisplay import JNDisplay, JNKeys, JNTouch
     from eventsys import devices
 
     TIMER_ASYNC = True
@@ -61,6 +69,14 @@ elif _jn:
     touch_dev = broker.create_device(
         type=devices.types.TOUCH,
         read=touch_drv.get_mouse_pos,
+        data=display_drv,
+    )
+
+    keys_drv = JNKeys(display_drv)
+
+    keys_dev = broker.create_device(
+        type=devices.types.QUEUE,
+        read=keys_drv.read,
         data=display_drv,
     )
 else:

--- a/src/lib/board_config.py
+++ b/src/lib/board_config.py
@@ -31,14 +31,14 @@ except ImportError:
 
 if _ps:
     # Running in PyScript
-    from displaysys.psdisplay import PSDevices, PSDisplay
+    from displaysys.psdisplay import PSDisplay, PSTouch
     from eventsys import devices
 
     display_drv = PSDisplay("display_canvas", width, height)
 
     broker = devices.Broker()
 
-    touch_drv = PSDevices("display_canvas")
+    touch_drv = PSTouch("display_canvas")
 
     touch_dev = broker.create_device(
         type=devices.types.TOUCH,
@@ -47,7 +47,7 @@ if _ps:
     )
 elif _jn:
     # Running in Jupyter Notebook
-    from displaysys.jndisplay import JNDevices, JNDisplay
+    from displaysys.jndisplay import JNDisplay, JNTouch
     from eventsys import devices
 
     TIMER_ASYNC = True
@@ -56,7 +56,7 @@ elif _jn:
 
     display_drv = JNDisplay(width, height)
 
-    touch_drv = JNDevices(display_drv)
+    touch_drv = JNTouch(display_drv)
 
     touch_dev = broker.create_device(
         type=devices.types.TOUCH,

--- a/src/lib/displaysys/jndisplay.py
+++ b/src/lib/displaysys/jndisplay.py
@@ -13,102 +13,11 @@ from PIL import Image, ImageDraw
 
 from displaysys import DisplayDriver, color_rgb
 from eventsys import events
-from eventsys.keys import Keys
+from eventsys.keys import Keys, chord_matches, key_to_keycode, mod_mask
 
 _JN_TOUCH_DEPS = "pip install ipywidgets ipyevents"
 
 _CSS_DISPLAY_ID = "pydisplay_jn_styles"
-
-
-# ---------------------------------------------------------------------------
-# Keyboard mapping
-#
-# Translate browser ``KeyboardEvent`` values (delivered by ipyevents) into
-# eventsys (SDL-style) key codes so the events produced here match the QUEUE
-# backends (SDL2 / PyGame).  ``key`` holds either a single printable character
-# (mapped by code point below) or a named value such as ``"ArrowUp"`` (mapped
-# via the table).  The table is kept local to this module by design.
-# ---------------------------------------------------------------------------
-_NAMED_KEYS = {
-    "Backspace": Keys.K_BACKSPACE,
-    "Tab": Keys.K_TAB,
-    "Enter": Keys.K_RETURN,
-    "Escape": Keys.K_ESCAPE,
-    "Delete": Keys.K_DELETE,
-    "ArrowUp": Keys.K_UP,
-    "ArrowDown": Keys.K_DOWN,
-    "ArrowLeft": Keys.K_LEFT,
-    "ArrowRight": Keys.K_RIGHT,
-    "Home": Keys.K_HOME,
-    "End": Keys.K_END,
-    "PageUp": Keys.K_PAGEUP,
-    "PageDown": Keys.K_PAGEDOWN,
-    "Insert": Keys.K_INSERT,
-    "CapsLock": Keys.K_CAPSLOCK,
-    "NumLock": Keys.K_NUMLOCKCLEAR,
-    "ScrollLock": Keys.K_SCROLLLOCK,
-    "Pause": Keys.K_PAUSE,
-    "PrintScreen": Keys.K_PRINTSCREEN,
-    "ContextMenu": Keys.K_MENU,
-    "Control": Keys.K_LCTRL,
-    "Shift": Keys.K_LSHIFT,
-    "Alt": Keys.K_LALT,
-    "Meta": Keys.K_LGUI,
-    "F1": Keys.K_F1,
-    "F2": Keys.K_F2,
-    "F3": Keys.K_F3,
-    "F4": Keys.K_F4,
-    "F5": Keys.K_F5,
-    "F6": Keys.K_F6,
-    "F7": Keys.K_F7,
-    "F8": Keys.K_F8,
-    "F9": Keys.K_F9,
-    "F10": Keys.K_F10,
-    "F11": Keys.K_F11,
-    "F12": Keys.K_F12,
-}
-
-_MOD_GROUPS = (Keys.KMOD_CTRL, Keys.KMOD_SHIFT, Keys.KMOD_ALT, Keys.KMOD_GUI)
-
-
-def _key_to_keycode(key):
-    """Map a DOM ``KeyboardEvent.key`` value to an eventsys key code."""
-    code = _NAMED_KEYS.get(key)
-    if code is not None:
-        return code
-    if key and len(key) == 1:
-        o = ord(key)
-        if 0x41 <= o <= 0x5A:  # 'A'-'Z' -> lowercase code, matching SDL
-            return o + 0x20
-        return o
-    return Keys.K_UNKNOWN
-
-
-def _mod_mask(ctrl, shift, alt, meta):
-    """Build an eventsys modifier mask from DOM modifier flags."""
-    mask = 0
-    if shift:
-        mask |= Keys.KMOD_LSHIFT
-    if ctrl:
-        mask |= Keys.KMOD_LCTRL
-    if alt:
-        mask |= Keys.KMOD_LALT
-    if meta:
-        mask |= Keys.KMOD_LGUI
-    return mask
-
-
-def _chord_matches(chord, keycode, mod):
-    """Return True if (keycode, mod) satisfies a ``(key, mod_mask)`` chord."""
-    if not chord:
-        return False
-    chord_key, chord_mod = chord
-    if keycode != chord_key:
-        return False
-    for group in _MOD_GROUPS:
-        if (chord_mod & group) and not (mod & group):
-            return False
-    return True
 
 
 def _inject_notebook_css(width, height, first_time):
@@ -343,15 +252,15 @@ class JNKeys:
         kind = event.get("type")
         if kind not in ("keydown", "keyup"):
             return
-        keycode = _key_to_keycode(event.get("key", ""))
-        mod = _mod_mask(
+        keycode = key_to_keycode(event.get("key", ""))
+        mod = mod_mask(
             event.get("ctrlKey"),
             event.get("shiftKey"),
             event.get("altKey"),
             event.get("metaKey"),
         )
         if kind == "keydown":
-            if _chord_matches(self.quit_chord, keycode, mod):
+            if chord_matches(self.quit_chord, keycode, mod):
                 self._queue.append(events.Quit(events.QUIT))
                 return
             if event.get("repeat"):  # ignore auto-repeat

--- a/src/lib/displaysys/jndisplay.py
+++ b/src/lib/displaysys/jndisplay.py
@@ -55,9 +55,15 @@ def _inject_notebook_css(width, height, first_time):
         update_display(css, display_id=_CSS_DISPLAY_ID)
 
 
-class JNDevices:
+class JNTouch:
     """
     Mouse/touch input for Jupyter Notebook via ipywidgets + ipyevents.
+
+    Wraps the interactive ``ipywidgets`` Image that mirrors the display buffer
+    and tracks the pointer position while the left mouse button is held,
+    exposing it through :meth:`get_mouse_pos`.  Intended to be registered as an
+    ``eventsys`` ``TOUCH`` device, which turns the polled position into button-1
+    MOUSEBUTTONDOWN / MOUSEMOTION / MOUSEBUTTONUP events.
 
     Args:
         display_drv (JNDisplay): Display whose buffer is shown on the Image widget.
@@ -163,6 +169,10 @@ class JNDevices:
             self._mouse_pos = (int(event["dataX"]), int(event["dataY"]))
         elif kind in ("mouseup", "mouseleave"):
             self._mouse_pos = None
+
+
+# Backwards-compatible alias for the pre-rename name.
+JNDevices = JNTouch
 
 
 class JNDisplay(DisplayDriver):
@@ -287,7 +297,7 @@ class JNDisplay(DisplayDriver):
             if _timer is not None:
                 # Auto-refresh timer fired before a device or explicit show().
                 # Creating a static output here would duplicate the interactive
-                # widget that JNDevices is about to display.  Wait for an
+                # widget that JNTouch is about to display.  Wait for an
                 # explicit show() (non-interactive use) or device attach.
                 return
             display(self._buffer, display_id=self._display_id)

--- a/src/lib/displaysys/jndisplay.py
+++ b/src/lib/displaysys/jndisplay.py
@@ -12,10 +12,103 @@ from IPython.display import display, update_display
 from PIL import Image, ImageDraw
 
 from displaysys import DisplayDriver, color_rgb
+from eventsys import events
+from eventsys.keys import Keys
 
 _JN_TOUCH_DEPS = "pip install ipywidgets ipyevents"
 
 _CSS_DISPLAY_ID = "pydisplay_jn_styles"
+
+
+# ---------------------------------------------------------------------------
+# Keyboard mapping
+#
+# Translate browser ``KeyboardEvent`` values (delivered by ipyevents) into
+# eventsys (SDL-style) key codes so the events produced here match the QUEUE
+# backends (SDL2 / PyGame).  ``key`` holds either a single printable character
+# (mapped by code point below) or a named value such as ``"ArrowUp"`` (mapped
+# via the table).  The table is kept local to this module by design.
+# ---------------------------------------------------------------------------
+_NAMED_KEYS = {
+    "Backspace": Keys.K_BACKSPACE,
+    "Tab": Keys.K_TAB,
+    "Enter": Keys.K_RETURN,
+    "Escape": Keys.K_ESCAPE,
+    "Delete": Keys.K_DELETE,
+    "ArrowUp": Keys.K_UP,
+    "ArrowDown": Keys.K_DOWN,
+    "ArrowLeft": Keys.K_LEFT,
+    "ArrowRight": Keys.K_RIGHT,
+    "Home": Keys.K_HOME,
+    "End": Keys.K_END,
+    "PageUp": Keys.K_PAGEUP,
+    "PageDown": Keys.K_PAGEDOWN,
+    "Insert": Keys.K_INSERT,
+    "CapsLock": Keys.K_CAPSLOCK,
+    "NumLock": Keys.K_NUMLOCKCLEAR,
+    "ScrollLock": Keys.K_SCROLLLOCK,
+    "Pause": Keys.K_PAUSE,
+    "PrintScreen": Keys.K_PRINTSCREEN,
+    "ContextMenu": Keys.K_MENU,
+    "Control": Keys.K_LCTRL,
+    "Shift": Keys.K_LSHIFT,
+    "Alt": Keys.K_LALT,
+    "Meta": Keys.K_LGUI,
+    "F1": Keys.K_F1,
+    "F2": Keys.K_F2,
+    "F3": Keys.K_F3,
+    "F4": Keys.K_F4,
+    "F5": Keys.K_F5,
+    "F6": Keys.K_F6,
+    "F7": Keys.K_F7,
+    "F8": Keys.K_F8,
+    "F9": Keys.K_F9,
+    "F10": Keys.K_F10,
+    "F11": Keys.K_F11,
+    "F12": Keys.K_F12,
+}
+
+_MOD_GROUPS = (Keys.KMOD_CTRL, Keys.KMOD_SHIFT, Keys.KMOD_ALT, Keys.KMOD_GUI)
+
+
+def _key_to_keycode(key):
+    """Map a DOM ``KeyboardEvent.key`` value to an eventsys key code."""
+    code = _NAMED_KEYS.get(key)
+    if code is not None:
+        return code
+    if key and len(key) == 1:
+        o = ord(key)
+        if 0x41 <= o <= 0x5A:  # 'A'-'Z' -> lowercase code, matching SDL
+            return o + 0x20
+        return o
+    return Keys.K_UNKNOWN
+
+
+def _mod_mask(ctrl, shift, alt, meta):
+    """Build an eventsys modifier mask from DOM modifier flags."""
+    mask = 0
+    if shift:
+        mask |= Keys.KMOD_LSHIFT
+    if ctrl:
+        mask |= Keys.KMOD_LCTRL
+    if alt:
+        mask |= Keys.KMOD_LALT
+    if meta:
+        mask |= Keys.KMOD_LGUI
+    return mask
+
+
+def _chord_matches(chord, keycode, mod):
+    """Return True if (keycode, mod) satisfies a ``(key, mod_mask)`` chord."""
+    if not chord:
+        return False
+    chord_key, chord_mod = chord
+    if keycode != chord_key:
+        return False
+    for group in _MOD_GROUPS:
+        if (chord_mod & group) and not (mod & group):
+            return False
+    return True
 
 
 def _inject_notebook_css(width, height, first_time):
@@ -169,6 +262,105 @@ class JNTouch:
             self._mouse_pos = (int(event["dataX"]), int(event["dataY"]))
         elif kind in ("mouseup", "mouseleave"):
             self._mouse_pos = None
+
+
+class JNKeys:
+    """
+    Keyboard input for Jupyter Notebook via ipyevents.
+
+    Watches ``keydown`` / ``keyup`` on the interactive ``ipywidgets`` Image
+    created by :class:`JNTouch` and queues ``eventsys`` ``Key`` events (with
+    SDL-style key codes, names and modifier masks).  Intended to be registered
+    as an ``eventsys`` ``QUEUE`` device via :meth:`read`, matching the desktop
+    SDL2 / PyGame event stream.
+
+    A configurable key chord emits an ``events.QUIT`` event, the equivalent of
+    clicking an SDL window's close button (the broker then deinitializes the
+    display and exits).  ``quit_chord`` is a ``(key_code, modifier_mask)`` tuple
+    and defaults to CTRL+C; assign a different chord (e.g.
+    ``(Keys.K_q, Keys.KMOD_CTRL)``) or ``None`` to disable it.  If the notebook
+    front end intercepts the chosen chord, pick another one.
+
+    Note:
+        The Image widget must be focused (e.g. clicked) to receive key events,
+        and some keys may be consumed by the notebook front end (JupyterLab /
+        classic Notebook / VS Code) before they reach the widget.
+
+    Args:
+        display_drv (JNDisplay): Display whose JNTouch Image widget is watched.
+    """
+
+    def __init__(self, display_drv):
+        try:
+            from ipyevents import Event  # noqa: F401
+        except ImportError as exc:
+            raise ImportError(
+                "Jupyter keyboard input requires ipywidgets and ipyevents. "
+                f"Install with: {_JN_TOUCH_DEPS}"
+            ) from exc
+
+        touch = getattr(display_drv, "_jn_devices", None)
+        if touch is None or getattr(touch, "_events", None) is None:
+            raise RuntimeError(
+                "JNKeys requires a JNTouch instance; create JNTouch(display_drv) first."
+            )
+
+        self._queue = []
+        self._pressed = set()
+        self.quit_chord = (Keys.K_c, Keys.KMOD_CTRL)
+
+        # Reuse the JNTouch DOM event source so a single ipyevents listener
+        # serves both mouse and keyboard; JNTouch ignores key events and this
+        # class ignores mouse events.
+        self._events = touch._events
+        watched = list(self._events.watched_events)
+        changed = False
+        for ev in ("keydown", "keyup"):
+            if ev not in watched:
+                watched.append(ev)
+                changed = True
+        if changed:
+            self._events.watched_events = watched
+        self._events.on_dom_event(self._on_dom_event)
+
+    def read(self):
+        """
+        Returns queued keyboard/quit events for an eventsys QUEUE device.
+
+        Returns:
+            list or None: The events received since the last call, or None.
+        """
+        if not self._queue:
+            return None
+        queued = self._queue
+        self._queue = []
+        return queued
+
+    def _enqueue(self, type, keycode, mod):
+        self._queue.append(events.Key(type, Keys.keyname(keycode), keycode, mod, 0, None))
+
+    def _on_dom_event(self, event):
+        kind = event.get("type")
+        if kind not in ("keydown", "keyup"):
+            return
+        keycode = _key_to_keycode(event.get("key", ""))
+        mod = _mod_mask(
+            event.get("ctrlKey"),
+            event.get("shiftKey"),
+            event.get("altKey"),
+            event.get("metaKey"),
+        )
+        if kind == "keydown":
+            if _chord_matches(self.quit_chord, keycode, mod):
+                self._queue.append(events.Quit(events.QUIT))
+                return
+            if event.get("repeat"):  # ignore auto-repeat
+                return
+            self._pressed.add(keycode)
+            self._enqueue(events.KEYDOWN, keycode, mod)
+        else:
+            self._pressed.discard(keycode)
+            self._enqueue(events.KEYUP, keycode, mod)
 
 
 class JNDisplay(DisplayDriver):

--- a/src/lib/displaysys/jndisplay.py
+++ b/src/lib/displaysys/jndisplay.py
@@ -171,10 +171,6 @@ class JNTouch:
             self._mouse_pos = None
 
 
-# Backwards-compatible alias for the pre-rename name.
-JNDevices = JNTouch
-
-
 class JNDisplay(DisplayDriver):
     """
     A class to emulate a display on Jupyter Notebook.

--- a/src/lib/displaysys/jndisplay.py
+++ b/src/lib/displaysys/jndisplay.py
@@ -15,7 +15,7 @@ from displaysys import DisplayDriver, color_rgb
 from eventsys import events
 from eventsys.keys import Keys, chord_matches, key_to_keycode, mod_mask
 
-_JN_TOUCH_DEPS = "pip install ipywidgets ipyevents"
+_JN_DEPS = "pip install ipywidgets ipyevents"
 
 _CSS_DISPLAY_ID = "pydisplay_jn_styles"
 
@@ -57,15 +57,43 @@ def _inject_notebook_css(width, height, first_time):
         update_display(css, display_id=_CSS_DISPLAY_ID)
 
 
-class JNTouch:
-    """
-    Mouse/touch input for Jupyter Notebook via ipywidgets + ipyevents.
+def _buttons_tuple(buttons):
+    """Convert a DOM ``buttons`` bitmask to an (left, middle, right) tuple."""
+    return (
+        1 if buttons & 1 else 0,  # left
+        1 if buttons & 4 else 0,  # middle
+        1 if buttons & 2 else 0,  # right
+    )
 
-    Wraps the interactive ``ipywidgets`` Image that mirrors the display buffer
-    and tracks the pointer position while the left mouse button is held,
-    exposing it through :meth:`get_mouse_pos`.  Intended to be registered as an
-    ``eventsys`` ``TOUCH`` device, which turns the polled position into button-1
-    MOUSEBUTTONDOWN / MOUSEMOTION / MOUSEBUTTONUP events.
+
+class JNDevices:
+    """
+    Unified input for Jupyter Notebook, registered as an eventsys QUEUE device.
+
+    Creates the interactive ``ipywidgets`` Image that mirrors the display buffer
+    and watches it (via ``ipyevents``) for all available input, turning it into
+    ``eventsys.events`` objects (matching the desktop SDL2 / PyGame event
+    stream), drained through :meth:`read`:
+
+    - **Mouse**: ``MOUSEMOTION`` on every move, ``MOUSEBUTTONDOWN`` /
+      ``MOUSEBUTTONUP`` for any button.
+    - **Wheel**: ``MOUSEWHEEL`` (also consumed by encoder devices).
+    - **Keyboard**: ``KEYDOWN`` / ``KEYUP`` with SDL-style key codes, names and
+      modifier masks (left/right modifier variants via key location).
+    - **Quit**: an assignable key chord emits ``events.QUIT`` (the equivalent of
+      clicking an SDL window's close button; the broker then deinitializes the
+      display and exits).  ``quit_chord`` is a ``(key_code, modifier_mask)``
+      tuple defaulting to CTRL+C; assign another (e.g.
+      ``(Keys.K_q, Keys.KMOD_CTRL)``) or ``None`` to disable.  If the notebook
+      front end intercepts the chord, pick a different one.
+
+    This class also owns the display widget: ``JNDisplay`` pushes frames to it
+    via :meth:`update_buffer`.
+
+    Note:
+        The Image widget must be focused (e.g. clicked) to receive key events,
+        and some keys may be consumed by the notebook front end (JupyterLab /
+        classic Notebook / VS Code) before they reach the widget.
 
     Args:
         display_drv (JNDisplay): Display whose buffer is shown on the Image widget.
@@ -77,23 +105,33 @@ class JNTouch:
             from ipywidgets import Image, Layout, VBox
         except ImportError as exc:
             raise ImportError(
-                "Jupyter touch input requires ipywidgets and ipyevents. "
-                f"Install with: {_JN_TOUCH_DEPS}"
+                "Jupyter input requires ipywidgets and ipyevents. "
+                f"Install with: {_JN_DEPS}"
             ) from exc
 
         self._display_drv = display_drv
-        self._mouse_pos = None
         self._png_buf = BytesIO()
         self._last_png = b""
         self._layout_wh = (0, 0)
         self._css_shown = False
+
+        self._queue = []
+        self._pressed = set()
+        self.quit_chord = (Keys.K_c, Keys.KMOD_CTRL)
 
         self.image = Image(format="png")
         self.image.add_class("pydisplay-jn-image")
 
         self._events = Event(
             source=self.image,
-            watched_events=["mousedown", "mouseup", "mousemove", "mouseleave"],
+            watched_events=[
+                "mousedown",
+                "mouseup",
+                "mousemove",
+                "wheel",
+                "keydown",
+                "keyup",
+            ],
         )
         self._events.on_dom_event(self._on_dom_event)
 
@@ -116,14 +154,18 @@ class JNTouch:
         )
         display(self._root)
 
-    def get_mouse_pos(self):
+    def read(self):
         """
-        Returns the current mouse position in display coordinates.
+        Returns queued input events for an eventsys QUEUE device.
 
         Returns:
-            tuple or None: (x, y) while the left button is pressed, else None.
+            list or None: The events received since the last call, or None.
         """
-        return self._mouse_pos
+        if not self._queue:
+            return None
+        queued = self._queue
+        self._queue = []
+        return queued
 
     def update_buffer(self, pil_image):
         """Push a PIL image to the interactive widget."""
@@ -161,98 +203,52 @@ class JNTouch:
             root.width = px
             root.height = py
 
+    ############### Event handling ################
+
     def _on_dom_event(self, event):
         kind = event.get("type")
-        if kind == "mousedown" and event.get("button", 0) == 0:
-            if "dataX" not in event or "dataY" not in event:
-                return
-            self._mouse_pos = (int(event["dataX"]), int(event["dataY"]))
-        elif kind == "mousemove" and event.get("buttons", 0) & 1:
-            self._mouse_pos = (int(event["dataX"]), int(event["dataY"]))
-        elif kind in ("mouseup", "mouseleave"):
-            self._mouse_pos = None
+        if kind == "mousemove":
+            self._on_mouse_move(event)
+        elif kind == "mousedown":
+            self._on_mouse_button(event, events.MOUSEBUTTONDOWN)
+        elif kind == "mouseup":
+            self._on_mouse_button(event, events.MOUSEBUTTONUP)
+        elif kind == "wheel":
+            self._on_wheel(event)
+        elif kind in ("keydown", "keyup"):
+            self._on_key(event, kind)
 
+    def _pos(self, event):
+        return (int(event.get("dataX", 0)), int(event.get("dataY", 0)))
 
-class JNKeys:
-    """
-    Keyboard input for Jupyter Notebook via ipyevents.
+    def _on_mouse_button(self, event, type):
+        self._queue.append(
+            events.Button(type, self._pos(event), event.get("button", 0) + 1, False, None)
+        )
 
-    Watches ``keydown`` / ``keyup`` on the interactive ``ipywidgets`` Image
-    created by :class:`JNTouch` and queues ``eventsys`` ``Key`` events (with
-    SDL-style key codes, names and modifier masks).  Intended to be registered
-    as an ``eventsys`` ``QUEUE`` device via :meth:`read`, matching the desktop
-    SDL2 / PyGame event stream.
-
-    A configurable key chord emits an ``events.QUIT`` event, the equivalent of
-    clicking an SDL window's close button (the broker then deinitializes the
-    display and exits).  ``quit_chord`` is a ``(key_code, modifier_mask)`` tuple
-    and defaults to CTRL+C; assign a different chord (e.g.
-    ``(Keys.K_q, Keys.KMOD_CTRL)``) or ``None`` to disable it.  If the notebook
-    front end intercepts the chosen chord, pick another one.
-
-    Note:
-        The Image widget must be focused (e.g. clicked) to receive key events,
-        and some keys may be consumed by the notebook front end (JupyterLab /
-        classic Notebook / VS Code) before they reach the widget.
-
-    Args:
-        display_drv (JNDisplay): Display whose JNTouch Image widget is watched.
-    """
-
-    def __init__(self, display_drv):
-        try:
-            from ipyevents import Event  # noqa: F401
-        except ImportError as exc:
-            raise ImportError(
-                "Jupyter keyboard input requires ipywidgets and ipyevents. "
-                f"Install with: {_JN_TOUCH_DEPS}"
-            ) from exc
-
-        touch = getattr(display_drv, "_jn_devices", None)
-        if touch is None or getattr(touch, "_events", None) is None:
-            raise RuntimeError(
-                "JNKeys requires a JNTouch instance; create JNTouch(display_drv) first."
+    def _on_mouse_move(self, event):
+        rel = (int(event.get("movementX", 0)), int(event.get("movementY", 0)))
+        self._queue.append(
+            events.Motion(
+                events.MOUSEMOTION,
+                self._pos(event),
+                rel,
+                _buttons_tuple(event.get("buttons", 0)),
+                False,
+                None,
             )
+        )
 
-        self._queue = []
-        self._pressed = set()
-        self.quit_chord = (Keys.K_c, Keys.KMOD_CTRL)
+    def _on_wheel(self, event):
+        dx = event.get("deltaX", 0)
+        dy = event.get("deltaY", 0)
+        # DOM deltaY > 0 means scrolling down; SDL/PyGame report up as positive.
+        x = -1 if dx < 0 else (1 if dx > 0 else 0)
+        y = 1 if dy < 0 else (-1 if dy > 0 else 0)
+        self._queue.append(events.Wheel(events.MOUSEWHEEL, False, x, y, dx, dy, False, None))
 
-        # Reuse the JNTouch DOM event source so a single ipyevents listener
-        # serves both mouse and keyboard; JNTouch ignores key events and this
-        # class ignores mouse events.
-        self._events = touch._events
-        watched = list(self._events.watched_events)
-        changed = False
-        for ev in ("keydown", "keyup"):
-            if ev not in watched:
-                watched.append(ev)
-                changed = True
-        if changed:
-            self._events.watched_events = watched
-        self._events.on_dom_event(self._on_dom_event)
-
-    def read(self):
-        """
-        Returns queued keyboard/quit events for an eventsys QUEUE device.
-
-        Returns:
-            list or None: The events received since the last call, or None.
-        """
-        if not self._queue:
-            return None
-        queued = self._queue
-        self._queue = []
-        return queued
-
-    def _enqueue(self, type, keycode, mod):
-        self._queue.append(events.Key(type, Keys.keyname(keycode), keycode, mod, 0, None))
-
-    def _on_dom_event(self, event):
-        kind = event.get("type")
-        if kind not in ("keydown", "keyup"):
-            return
-        keycode = key_to_keycode(event.get("key", ""))
+    def _on_key(self, event, kind):
+        keycode = key_to_keycode(event.get("key", ""), event.get("location", 0))
         mod = mod_mask(
             event.get("ctrlKey"),
             event.get("shiftKey"),
@@ -266,10 +262,13 @@ class JNKeys:
             if event.get("repeat"):  # ignore auto-repeat
                 return
             self._pressed.add(keycode)
-            self._enqueue(events.KEYDOWN, keycode, mod)
+            self._enqueue_key(events.KEYDOWN, keycode, mod)
         else:
             self._pressed.discard(keycode)
-            self._enqueue(events.KEYUP, keycode, mod)
+            self._enqueue_key(events.KEYUP, keycode, mod)
+
+    def _enqueue_key(self, type, keycode, mod):
+        self._queue.append(events.Key(type, Keys.keyname(keycode), keycode, mod, 0, None))
 
 
 class JNDisplay(DisplayDriver):
@@ -394,7 +393,7 @@ class JNDisplay(DisplayDriver):
             if _timer is not None:
                 # Auto-refresh timer fired before a device or explicit show().
                 # Creating a static output here would duplicate the interactive
-                # widget that JNTouch is about to display.  Wait for an
+                # widget that JNDevices is about to display.  Wait for an
                 # explicit show() (non-interactive use) or device attach.
                 return
             display(self._buffer, display_id=self._display_id)

--- a/src/lib/displaysys/pgdisplay.py
+++ b/src/lib/displaysys/pgdisplay.py
@@ -31,6 +31,32 @@ def get() -> [pg.event.Event]:
     return pg.event.get()
 
 
+# Opened joystick handles, kept referenced so PyGame keeps delivering their
+# events.  PyGame's joystick events (JOYAXISMOTION, JOYBUTTONDOWN, ...) already
+# share eventsys's numeric types and attribute names, so they flow through
+# poll()/get() unchanged once the joysticks are opened.
+_joysticks = []
+
+
+def _init_joysticks() -> None:
+    """
+    Initialize the joystick subsystem and open all connected joysticks.
+
+    Joysticks must be opened for PyGame to deliver their events.  Devices
+    connected after startup are not hot-plugged (connect controllers before
+    launching).  Failures are ignored so a missing joystick subsystem never
+    breaks the display.
+    """
+    try:
+        pg.joystick.init()
+        for i in range(pg.joystick.get_count()):
+            js = pg.joystick.Joystick(i)
+            js.init()
+            _joysticks.append(js)
+    except Exception:
+        pass
+
+
 class PGDisplay(DisplayDriver):
     """
     A class to emulate an LCD using pygame.
@@ -81,6 +107,7 @@ class PGDisplay(DisplayDriver):
             self._scale = 1
 
         pg.init()
+        _init_joysticks()
 
         self._buffer = pg.Surface(size=(self._width, self._height), depth=self.color_depth)
         self._buffer.fill((0, 0, 0))

--- a/src/lib/displaysys/psdisplay.py
+++ b/src/lib/displaysys/psdisplay.py
@@ -83,10 +83,6 @@ class PSTouch:
         self._mouse_pos = None
 
 
-# Backwards-compatible alias for the pre-rename name.
-PSDevices = PSTouch
-
-
 class PSDisplay(DisplayDriver):
     """
     A class to emulate a display on PyScript.

--- a/src/lib/displaysys/psdisplay.py
+++ b/src/lib/displaysys/psdisplay.py
@@ -11,102 +11,11 @@ from pyscript.ffi import create_proxy
 
 from displaysys import DisplayDriver, color_rgb
 from eventsys import events
-from eventsys.keys import Keys
+from eventsys.keys import Keys, chord_matches, key_to_keycode, mod_mask
 
 
 def log(*args):
     console.log(*args)
-
-
-# ---------------------------------------------------------------------------
-# Keyboard mapping
-#
-# Translate browser ``KeyboardEvent`` values into eventsys (SDL-style) key
-# codes so the events produced here match the QUEUE backends (SDL2 / PyGame).
-# ``KeyboardEvent.key`` holds either a single printable character (mapped by
-# code point below) or a named value such as ``"ArrowUp"`` (mapped via the
-# table).  The table is kept local to this module by design.
-# ---------------------------------------------------------------------------
-_NAMED_KEYS = {
-    "Backspace": Keys.K_BACKSPACE,
-    "Tab": Keys.K_TAB,
-    "Enter": Keys.K_RETURN,
-    "Escape": Keys.K_ESCAPE,
-    "Delete": Keys.K_DELETE,
-    "ArrowUp": Keys.K_UP,
-    "ArrowDown": Keys.K_DOWN,
-    "ArrowLeft": Keys.K_LEFT,
-    "ArrowRight": Keys.K_RIGHT,
-    "Home": Keys.K_HOME,
-    "End": Keys.K_END,
-    "PageUp": Keys.K_PAGEUP,
-    "PageDown": Keys.K_PAGEDOWN,
-    "Insert": Keys.K_INSERT,
-    "CapsLock": Keys.K_CAPSLOCK,
-    "NumLock": Keys.K_NUMLOCKCLEAR,
-    "ScrollLock": Keys.K_SCROLLLOCK,
-    "Pause": Keys.K_PAUSE,
-    "PrintScreen": Keys.K_PRINTSCREEN,
-    "ContextMenu": Keys.K_MENU,
-    "Control": Keys.K_LCTRL,
-    "Shift": Keys.K_LSHIFT,
-    "Alt": Keys.K_LALT,
-    "Meta": Keys.K_LGUI,
-    "F1": Keys.K_F1,
-    "F2": Keys.K_F2,
-    "F3": Keys.K_F3,
-    "F4": Keys.K_F4,
-    "F5": Keys.K_F5,
-    "F6": Keys.K_F6,
-    "F7": Keys.K_F7,
-    "F8": Keys.K_F8,
-    "F9": Keys.K_F9,
-    "F10": Keys.K_F10,
-    "F11": Keys.K_F11,
-    "F12": Keys.K_F12,
-}
-
-_MOD_GROUPS = (Keys.KMOD_CTRL, Keys.KMOD_SHIFT, Keys.KMOD_ALT, Keys.KMOD_GUI)
-
-
-def _key_to_keycode(key):
-    """Map a DOM ``KeyboardEvent.key`` value to an eventsys key code."""
-    code = _NAMED_KEYS.get(key)
-    if code is not None:
-        return code
-    if key and len(key) == 1:
-        o = ord(key)
-        if 0x41 <= o <= 0x5A:  # 'A'-'Z' -> lowercase code, matching SDL
-            return o + 0x20
-        return o
-    return Keys.K_UNKNOWN
-
-
-def _mod_mask(ctrl, shift, alt, meta):
-    """Build an eventsys modifier mask from DOM modifier flags."""
-    mask = 0
-    if shift:
-        mask |= Keys.KMOD_LSHIFT
-    if ctrl:
-        mask |= Keys.KMOD_LCTRL
-    if alt:
-        mask |= Keys.KMOD_LALT
-    if meta:
-        mask |= Keys.KMOD_LGUI
-    return mask
-
-
-def _chord_matches(chord, keycode, mod):
-    """Return True if (keycode, mod) satisfies a ``(key, mod_mask)`` chord."""
-    if not chord:
-        return False
-    chord_key, chord_mod = chord
-    if keycode != chord_key:
-        return False
-    for group in _MOD_GROUPS:
-        if (chord_mod & group) and not (mod & group):
-            return False
-    return True
 
 
 class PSTouch:
@@ -235,9 +144,9 @@ class PSKeys:
         self._queue.append(events.Key(type, Keys.keyname(keycode), keycode, mod, 0, None))
 
     def _on_keydown(self, e):
-        keycode = _key_to_keycode(e.key)
-        mod = _mod_mask(e.ctrlKey, e.shiftKey, e.altKey, e.metaKey)
-        if _chord_matches(self.quit_chord, keycode, mod):
+        keycode = key_to_keycode(e.key)
+        mod = mod_mask(e.ctrlKey, e.shiftKey, e.altKey, e.metaKey)
+        if chord_matches(self.quit_chord, keycode, mod):
             try:
                 e.preventDefault()
             except Exception:
@@ -250,8 +159,8 @@ class PSKeys:
         self._enqueue(events.KEYDOWN, keycode, mod)
 
     def _on_keyup(self, e):
-        keycode = _key_to_keycode(e.key)
-        mod = _mod_mask(e.ctrlKey, e.shiftKey, e.altKey, e.metaKey)
+        keycode = key_to_keycode(e.key)
+        mod = mod_mask(e.ctrlKey, e.shiftKey, e.altKey, e.metaKey)
         self._pressed.discard(keycode)
         self._enqueue(events.KEYUP, keycode, mod)
 

--- a/src/lib/displaysys/psdisplay.py
+++ b/src/lib/displaysys/psdisplay.py
@@ -10,10 +10,103 @@ from js import console, document
 from pyscript.ffi import create_proxy
 
 from displaysys import DisplayDriver, color_rgb
+from eventsys import events
+from eventsys.keys import Keys
 
 
 def log(*args):
     console.log(*args)
+
+
+# ---------------------------------------------------------------------------
+# Keyboard mapping
+#
+# Translate browser ``KeyboardEvent`` values into eventsys (SDL-style) key
+# codes so the events produced here match the QUEUE backends (SDL2 / PyGame).
+# ``KeyboardEvent.key`` holds either a single printable character (mapped by
+# code point below) or a named value such as ``"ArrowUp"`` (mapped via the
+# table).  The table is kept local to this module by design.
+# ---------------------------------------------------------------------------
+_NAMED_KEYS = {
+    "Backspace": Keys.K_BACKSPACE,
+    "Tab": Keys.K_TAB,
+    "Enter": Keys.K_RETURN,
+    "Escape": Keys.K_ESCAPE,
+    "Delete": Keys.K_DELETE,
+    "ArrowUp": Keys.K_UP,
+    "ArrowDown": Keys.K_DOWN,
+    "ArrowLeft": Keys.K_LEFT,
+    "ArrowRight": Keys.K_RIGHT,
+    "Home": Keys.K_HOME,
+    "End": Keys.K_END,
+    "PageUp": Keys.K_PAGEUP,
+    "PageDown": Keys.K_PAGEDOWN,
+    "Insert": Keys.K_INSERT,
+    "CapsLock": Keys.K_CAPSLOCK,
+    "NumLock": Keys.K_NUMLOCKCLEAR,
+    "ScrollLock": Keys.K_SCROLLLOCK,
+    "Pause": Keys.K_PAUSE,
+    "PrintScreen": Keys.K_PRINTSCREEN,
+    "ContextMenu": Keys.K_MENU,
+    "Control": Keys.K_LCTRL,
+    "Shift": Keys.K_LSHIFT,
+    "Alt": Keys.K_LALT,
+    "Meta": Keys.K_LGUI,
+    "F1": Keys.K_F1,
+    "F2": Keys.K_F2,
+    "F3": Keys.K_F3,
+    "F4": Keys.K_F4,
+    "F5": Keys.K_F5,
+    "F6": Keys.K_F6,
+    "F7": Keys.K_F7,
+    "F8": Keys.K_F8,
+    "F9": Keys.K_F9,
+    "F10": Keys.K_F10,
+    "F11": Keys.K_F11,
+    "F12": Keys.K_F12,
+}
+
+_MOD_GROUPS = (Keys.KMOD_CTRL, Keys.KMOD_SHIFT, Keys.KMOD_ALT, Keys.KMOD_GUI)
+
+
+def _key_to_keycode(key):
+    """Map a DOM ``KeyboardEvent.key`` value to an eventsys key code."""
+    code = _NAMED_KEYS.get(key)
+    if code is not None:
+        return code
+    if key and len(key) == 1:
+        o = ord(key)
+        if 0x41 <= o <= 0x5A:  # 'A'-'Z' -> lowercase code, matching SDL
+            return o + 0x20
+        return o
+    return Keys.K_UNKNOWN
+
+
+def _mod_mask(ctrl, shift, alt, meta):
+    """Build an eventsys modifier mask from DOM modifier flags."""
+    mask = 0
+    if shift:
+        mask |= Keys.KMOD_LSHIFT
+    if ctrl:
+        mask |= Keys.KMOD_LCTRL
+    if alt:
+        mask |= Keys.KMOD_LALT
+    if meta:
+        mask |= Keys.KMOD_LGUI
+    return mask
+
+
+def _chord_matches(chord, keycode, mod):
+    """Return True if (keycode, mod) satisfies a ``(key, mod_mask)`` chord."""
+    if not chord:
+        return False
+    chord_key, chord_mod = chord
+    if keycode != chord_key:
+        return False
+    for group in _MOD_GROUPS:
+        if (chord_mod & group) and not (mod & group):
+            return False
+    return True
 
 
 class PSTouch:
@@ -81,6 +174,86 @@ class PSTouch:
     def _on_leave(self, e):
         log("Mouse leave")
         self._mouse_pos = None
+
+
+class PSKeys:
+    """
+    Keyboard input for a PyScript canvas.
+
+    Listens for ``keydown`` / ``keyup`` on an HTML element and queues
+    ``eventsys`` ``Key`` events (with SDL-style key codes, names and modifier
+    masks).  Intended to be registered as an ``eventsys`` ``QUEUE`` device via
+    :meth:`read`, matching the desktop SDL2 / PyGame event stream.
+
+    A configurable key chord emits an ``events.QUIT`` event, the equivalent of
+    clicking an SDL window's close button (the broker then deinitializes the
+    display and exits).  ``quit_chord`` is a ``(key_code, modifier_mask)`` tuple
+    and defaults to CTRL+C; assign a different chord (e.g.
+    ``(Keys.K_q, Keys.KMOD_CTRL)``) or ``None`` to disable it.  If the host
+    browser/page intercepts the chosen chord, pick another one.
+
+    Note:
+        The element must be focusable and focused (e.g. clicked) to receive key
+        events; the constructor sets ``tabindex`` to make the canvas focusable.
+
+    Args:
+        id (str): The id of the element to watch (usually the canvas).
+    """
+
+    def __init__(self, id):
+        self.canvas = document.getElementById(id)
+        try:
+            self.canvas.tabIndex = 0  # make the element focusable for key events
+        except Exception:
+            pass
+
+        self._queue = []
+        self._pressed = set()
+        self.quit_chord = (Keys.K_c, Keys.KMOD_CTRL)
+
+        # Proxy functions are required for javascript
+        self.on_keydown = create_proxy(self._on_keydown)
+        self.on_keyup = create_proxy(self._on_keyup)
+
+        self.canvas.addEventListener("keydown", self.on_keydown)
+        self.canvas.addEventListener("keyup", self.on_keyup)
+
+    def read(self):
+        """
+        Returns queued keyboard/quit events for an eventsys QUEUE device.
+
+        Returns:
+            list or None: The events received since the last call, or None.
+        """
+        if not self._queue:
+            return None
+        queued = self._queue
+        self._queue = []
+        return queued
+
+    def _enqueue(self, type, keycode, mod):
+        self._queue.append(events.Key(type, Keys.keyname(keycode), keycode, mod, 0, None))
+
+    def _on_keydown(self, e):
+        keycode = _key_to_keycode(e.key)
+        mod = _mod_mask(e.ctrlKey, e.shiftKey, e.altKey, e.metaKey)
+        if _chord_matches(self.quit_chord, keycode, mod):
+            try:
+                e.preventDefault()
+            except Exception:
+                pass
+            self._queue.append(events.Quit(events.QUIT))
+            return
+        if e.repeat:  # ignore auto-repeat
+            return
+        self._pressed.add(keycode)
+        self._enqueue(events.KEYDOWN, keycode, mod)
+
+    def _on_keyup(self, e):
+        keycode = _key_to_keycode(e.key)
+        mod = _mod_mask(e.ctrlKey, e.shiftKey, e.altKey, e.metaKey)
+        self._pressed.discard(keycode)
+        self._enqueue(events.KEYUP, keycode, mod)
 
 
 class PSDisplay(DisplayDriver):

--- a/src/lib/displaysys/psdisplay.py
+++ b/src/lib/displaysys/psdisplay.py
@@ -13,97 +13,51 @@ from displaysys import DisplayDriver, color_rgb
 from eventsys import events
 from eventsys.keys import Keys, chord_matches, key_to_keycode, mod_mask
 
+try:  # Gamepad polling is optional and only available in a browser.
+    from js import navigator
+except ImportError:
+    navigator = None
+
 
 def log(*args):
     console.log(*args)
 
 
-class PSTouch:
+def _buttons_tuple(buttons):
+    """Convert a DOM ``buttons`` bitmask to an (left, middle, right) tuple."""
+    return (
+        1 if buttons & 1 else 0,  # left
+        1 if buttons & 4 else 0,  # middle
+        1 if buttons & 2 else 0,  # right
+    )
+
+
+class PSDevices:
     """
-    Mouse/touch input for a PyScript canvas.
+    Unified input for a PyScript canvas, registered as an eventsys QUEUE device.
 
-    Wraps a single HTML ``<canvas>`` element and tracks the pointer position
-    while the left mouse button is held, exposing it through
-    :meth:`get_mouse_pos`.  Intended to be registered as an ``eventsys``
-    ``TOUCH`` device, which turns the polled position into button-1
-    MOUSEBUTTONDOWN / MOUSEMOTION / MOUSEBUTTONUP events.
+    Captures all available browser input on a single HTML element and turns it
+    into ``eventsys.events`` objects (matching the desktop SDL2 / PyGame event
+    stream), drained through :meth:`read`:
 
-    Args:
-        id (str): The id of the canvas element.
-    """
-
-    def __init__(self, id):
-        self.canvas = document.getElementById(id)
-        self._mouse_pos = None
-
-        # Proxy functions are required for javascript
-        self.on_down = create_proxy(self._on_down)
-        self.on_up = create_proxy(self._on_up)
-        self.on_move = create_proxy(self._on_move)
-        self.on_enter = create_proxy(self._on_enter)
-        self.on_leave = create_proxy(self._on_leave)
-
-        self.canvas.addEventListener("mousedown", self.on_down)
-        self.canvas.addEventListener("mouseup", self.on_up)
-        self.canvas.addEventListener("mousemove", self.on_move)
-        self.canvas.addEventListener("mouseenter", self.on_enter)
-        self.canvas.addEventListener("mouseleave", self.on_leave)
-
-    def get_mouse_pos(self) -> tuple | None:
-        """
-        Returns the current mouse position.
-
-        Returns:
-            tuple or None: The x, y coordinates of the mouse position.
-        """
-        return self._mouse_pos
-
-    def _on_down(self, e):
-        if e.button == 0:  # left mouse button
-            log(f"Mouse down {e.offsetX}, {e.offsetY}")
-            self._mouse_pos = (e.offsetX, e.offsetY)
-        else:
-            return False
-
-    def _on_up(self, e):
-        if e.button == 0:  # left mouse button
-            log(f"Mouse up {e.offsetX}, {e.offsetY}")
-            self._mouse_pos = None
-        else:
-            return False
-
-    def _on_move(self, e):
-        if e.buttons & 1:
-            log(f"Mouse move {e.offsetX}, {e.offsetY}")
-            self._mouse_pos = (e.offsetX, e.offsetY)
-
-    def _on_enter(self, e):
-        log("Mouse enter")
-
-    def _on_leave(self, e):
-        log("Mouse leave")
-        self._mouse_pos = None
-
-
-class PSKeys:
-    """
-    Keyboard input for a PyScript canvas.
-
-    Listens for ``keydown`` / ``keyup`` on an HTML element and queues
-    ``eventsys`` ``Key`` events (with SDL-style key codes, names and modifier
-    masks).  Intended to be registered as an ``eventsys`` ``QUEUE`` device via
-    :meth:`read`, matching the desktop SDL2 / PyGame event stream.
-
-    A configurable key chord emits an ``events.QUIT`` event, the equivalent of
-    clicking an SDL window's close button (the broker then deinitializes the
-    display and exits).  ``quit_chord`` is a ``(key_code, modifier_mask)`` tuple
-    and defaults to CTRL+C; assign a different chord (e.g.
-    ``(Keys.K_q, Keys.KMOD_CTRL)``) or ``None`` to disable it.  If the host
-    browser/page intercepts the chosen chord, pick another one.
+    - **Pointer** (mouse, touch and pen via Pointer Events): ``MOUSEMOTION`` on
+      every move, ``MOUSEBUTTONDOWN`` / ``MOUSEBUTTONUP`` for any button, with
+      the ``touch`` flag set for non-mouse pointers.
+    - **Wheel**: ``MOUSEWHEEL`` (also consumed by encoder devices).
+    - **Keyboard**: ``KEYDOWN`` / ``KEYUP`` with SDL-style key codes, names and
+      modifier masks (left/right modifier variants via key location).
+    - **Gamepad** (Gamepad API, polled on each :meth:`read`): ``JOYAXISMOTION``,
+      ``JOYBUTTONDOWN`` / ``JOYBUTTONUP``.
+    - **Quit**: an assignable key chord emits ``events.QUIT`` (the equivalent of
+      clicking an SDL window's close button; the broker then deinitializes the
+      display and exits).  ``quit_chord`` is a ``(key_code, modifier_mask)``
+      tuple defaulting to CTRL+C; assign another (e.g.
+      ``(Keys.K_q, Keys.KMOD_CTRL)``) or ``None`` to disable.  If the host
+      browser/page intercepts the chord, pick a different one.
 
     Note:
-        The element must be focusable and focused (e.g. clicked) to receive key
-        events; the constructor sets ``tabindex`` to make the canvas focusable.
+        The element must be focused (e.g. clicked) to receive key events; the
+        constructor sets ``tabindex`` to make the canvas focusable.
 
     Args:
         id (str): The id of the element to watch (usually the canvas).
@@ -113,6 +67,7 @@ class PSKeys:
         self.canvas = document.getElementById(id)
         try:
             self.canvas.tabIndex = 0  # make the element focusable for key events
+            self.canvas.style.touchAction = "none"  # don't scroll/zoom on touch
         except Exception:
             pass
 
@@ -120,31 +75,112 @@ class PSKeys:
         self._pressed = set()
         self.quit_chord = (Keys.K_c, Keys.KMOD_CTRL)
 
-        # Proxy functions are required for javascript
-        self.on_keydown = create_proxy(self._on_keydown)
-        self.on_keyup = create_proxy(self._on_keyup)
+        # Gamepad state keyed by gamepad index: (axes list, pressed-bool list).
+        self._gp_axes = {}
+        self._gp_buttons = {}
 
-        self.canvas.addEventListener("keydown", self.on_keydown)
-        self.canvas.addEventListener("keyup", self.on_keyup)
+        # Proxy functions are required for javascript
+        self._proxies = {
+            "pointerdown": create_proxy(self._on_pointer_down),
+            "pointerup": create_proxy(self._on_pointer_up),
+            "pointermove": create_proxy(self._on_pointer_move),
+            "wheel": create_proxy(self._on_wheel),
+            "contextmenu": create_proxy(self._on_contextmenu),
+            "keydown": create_proxy(self._on_keydown),
+            "keyup": create_proxy(self._on_keyup),
+        }
+        for name, proxy in self._proxies.items():
+            self.canvas.addEventListener(name, proxy)
 
     def read(self):
         """
-        Returns queued keyboard/quit events for an eventsys QUEUE device.
+        Returns queued input events for an eventsys QUEUE device.
+
+        Polls connected gamepads (if any) and returns all events received since
+        the last call.
 
         Returns:
-            list or None: The events received since the last call, or None.
+            list or None: The events, or None if there were none.
         """
+        self._poll_gamepads()
         if not self._queue:
             return None
         queued = self._queue
         self._queue = []
         return queued
 
-    def _enqueue(self, type, keycode, mod):
+    ############### Pointer (mouse / touch / pen) ################
+
+    def _is_touch(self, e):
+        try:
+            return e.pointerType != "mouse"
+        except Exception:
+            return False
+
+    def _on_pointer_down(self, e):
+        try:
+            self.canvas.setPointerCapture(e.pointerId)
+        except Exception:
+            pass
+        self._queue.append(
+            events.Button(
+                events.MOUSEBUTTONDOWN,
+                (e.offsetX, e.offsetY),
+                e.button + 1,  # DOM 0/1/2 -> SDL 1/2/3
+                self._is_touch(e),
+                None,
+            )
+        )
+
+    def _on_pointer_up(self, e):
+        self._queue.append(
+            events.Button(
+                events.MOUSEBUTTONUP,
+                (e.offsetX, e.offsetY),
+                e.button + 1,
+                self._is_touch(e),
+                None,
+            )
+        )
+
+    def _on_pointer_move(self, e):
+        self._queue.append(
+            events.Motion(
+                events.MOUSEMOTION,
+                (e.offsetX, e.offsetY),
+                (e.movementX, e.movementY),
+                _buttons_tuple(e.buttons),
+                self._is_touch(e),
+                None,
+            )
+        )
+
+    def _on_wheel(self, e):
+        try:
+            e.preventDefault()
+        except Exception:
+            pass
+        # DOM deltaY > 0 means scrolling down; SDL/PyGame report up as positive.
+        x = -1 if e.deltaX < 0 else (1 if e.deltaX > 0 else 0)
+        y = 1 if e.deltaY < 0 else (-1 if e.deltaY > 0 else 0)
+        self._queue.append(
+            events.Wheel(events.MOUSEWHEEL, False, x, y, e.deltaX, e.deltaY, False, None)
+        )
+
+    def _on_contextmenu(self, e):
+        # Suppress the browser menu so right-click is usable as a button event.
+        try:
+            e.preventDefault()
+        except Exception:
+            pass
+
+    ############### Keyboard ################
+
+    def _enqueue_key(self, type, keycode, mod):
         self._queue.append(events.Key(type, Keys.keyname(keycode), keycode, mod, 0, None))
 
     def _on_keydown(self, e):
-        keycode = key_to_keycode(e.key)
+        keycode = key_to_keycode(e.key, e.location)
         mod = mod_mask(e.ctrlKey, e.shiftKey, e.altKey, e.metaKey)
         if chord_matches(self.quit_chord, keycode, mod):
             try:
@@ -156,13 +192,51 @@ class PSKeys:
         if e.repeat:  # ignore auto-repeat
             return
         self._pressed.add(keycode)
-        self._enqueue(events.KEYDOWN, keycode, mod)
+        self._enqueue_key(events.KEYDOWN, keycode, mod)
 
     def _on_keyup(self, e):
-        keycode = key_to_keycode(e.key)
+        keycode = key_to_keycode(e.key, e.location)
         mod = mod_mask(e.ctrlKey, e.shiftKey, e.altKey, e.metaKey)
         self._pressed.discard(keycode)
-        self._enqueue(events.KEYUP, keycode, mod)
+        self._enqueue_key(events.KEYUP, keycode, mod)
+
+    ############### Gamepad ################
+
+    def _poll_gamepads(self):
+        if navigator is None:
+            return
+        try:
+            pads = navigator.getGamepads()
+        except Exception:
+            return
+        for i in range(pads.length):
+            pad = pads[i]
+            if not pad:
+                continue
+            gid = pad.index
+
+            axes = pad.axes
+            cur_axes = [float(axes[a]) for a in range(axes.length)]
+            prev_axes = self._gp_axes.get(gid, [0.0] * len(cur_axes))
+            for a in range(len(cur_axes)):
+                prev = prev_axes[a] if a < len(prev_axes) else 0.0
+                if cur_axes[a] != prev:
+                    self._queue.append(
+                        events.JoyAxisMotion(events.JOYAXISMOTION, gid, a, cur_axes[a])
+                    )
+            self._gp_axes[gid] = cur_axes
+
+            btns = pad.buttons
+            cur_btns = [bool(btns[b].pressed) for b in range(btns.length)]
+            prev_btns = self._gp_buttons.get(gid, [False] * len(cur_btns))
+            for b in range(len(cur_btns)):
+                prev = prev_btns[b] if b < len(prev_btns) else False
+                if cur_btns[b] != prev:
+                    if cur_btns[b]:
+                        self._queue.append(events.JoyButtonDown(events.JOYBUTTONDOWN, gid, b))
+                    else:
+                        self._queue.append(events.JoyButtonUp(events.JOYBUTTONUP, gid, b))
+            self._gp_buttons[gid] = cur_btns
 
 
 class PSDisplay(DisplayDriver):

--- a/src/lib/displaysys/psdisplay.py
+++ b/src/lib/displaysys/psdisplay.py
@@ -16,9 +16,15 @@ def log(*args):
     console.log(*args)
 
 
-class PSDevices:
+class PSTouch:
     """
-    A class to emulate a display on PyScript.
+    Mouse/touch input for a PyScript canvas.
+
+    Wraps a single HTML ``<canvas>`` element and tracks the pointer position
+    while the left mouse button is held, exposing it through
+    :meth:`get_mouse_pos`.  Intended to be registered as an ``eventsys``
+    ``TOUCH`` device, which turns the polled position into button-1
+    MOUSEBUTTONDOWN / MOUSEMOTION / MOUSEBUTTONUP events.
 
     Args:
         id (str): The id of the canvas element.
@@ -75,6 +81,10 @@ class PSDevices:
     def _on_leave(self, e):
         log("Mouse leave")
         self._mouse_pos = None
+
+
+# Backwards-compatible alias for the pre-rename name.
+PSDevices = PSTouch
 
 
 class PSDisplay(DisplayDriver):

--- a/src/lib/displaysys/sdldisplay/__init__.py
+++ b/src/lib/displaysys/sdldisplay/__init__.py
@@ -16,7 +16,17 @@ from ._sdl2_lib import (
     SDL_BUTTON_LMASK,
     SDL_BUTTON_MMASK,
     SDL_BUTTON_RMASK,
+    SDL_HAT_DOWN,
+    SDL_HAT_LEFT,
+    SDL_HAT_RIGHT,
+    SDL_HAT_UP,
     SDL_INIT_EVERYTHING,
+    SDL_INIT_JOYSTICK,
+    SDL_JOYAXISMOTION,
+    SDL_JOYBALLMOTION,
+    SDL_JOYBUTTONDOWN,
+    SDL_JOYBUTTONUP,
+    SDL_JOYHATMOTION,
     SDL_KEYDOWN,
     SDL_KEYUP,
     SDL_MOUSEBUTTONDOWN,
@@ -56,6 +66,22 @@ from ._sdl2_lib import (
     SDL_SetWindowSize,
     SDL_UpdateTexture,
 )
+
+# Joystick support requires functions not present in every SDL2 backend (the
+# native usdl2 module may omit them).  Import them separately so their absence
+# only disables joystick input instead of breaking the whole module.
+try:
+    from ._sdl2_lib import (
+        SDL_InitSubSystem,
+        SDL_JoystickClose,
+        SDL_JoystickInstanceID,
+        SDL_JoystickOpen,
+        SDL_NumJoysticks,
+    )
+
+    _HAS_JOYSTICK_API = True
+except ImportError:
+    _HAS_JOYSTICK_API = False
 
 if implementation.name == "cpython":
     import ctypes
@@ -131,6 +157,51 @@ def _ensure_tty_sane() -> None:
 
 
 _event = SDL_Event()
+
+# Open joystick handles, keyed by SDL instance id, kept referenced so SDL keeps
+# delivering their events.
+_joysticks = {}
+
+
+def _init_joysticks() -> None:
+    """
+    Initialize the joystick subsystem and open all connected joysticks.
+
+    Joysticks must be opened for SDL to deliver their events.  Devices connected
+    after startup are not hot-plugged (connect controllers before launching).
+    Failures are ignored so a missing/headless joystick subsystem never breaks
+    the display.
+    """
+    if not _HAS_JOYSTICK_API:
+        return
+    try:
+        if SDL_InitSubSystem(SDL_INIT_JOYSTICK) != 0:
+            return
+        for i in range(SDL_NumJoysticks()):
+            handle = SDL_JoystickOpen(i)
+            if handle:
+                _joysticks[SDL_JoystickInstanceID(handle)] = handle
+    except Exception:
+        pass
+
+
+def _close_joysticks() -> None:
+    """Close any opened joysticks."""
+    if not _HAS_JOYSTICK_API:
+        return
+    for handle in _joysticks.values():
+        try:
+            SDL_JoystickClose(handle)
+        except Exception:
+            pass
+    _joysticks.clear()
+
+
+def _hat_xy(value):
+    """Convert an SDL hat bitmask to an (x, y) tuple matching PyGame's get_hat()."""
+    x = (1 if value & SDL_HAT_RIGHT else 0) - (1 if value & SDL_HAT_LEFT else 0)
+    y = (1 if value & SDL_HAT_UP else 0) - (1 if value & SDL_HAT_DOWN else 0)
+    return (x, y)
 
 
 def poll():
@@ -213,6 +284,19 @@ def _convert(e):
             e.key.keysym.scancode,
             e.key.windowID,
         )
+    elif e.type == SDL_JOYAXISMOTION:
+        # Normalize the Sint16 axis value to -1.0..1.0 to match PyGame/Gamepad.
+        evt = events.JoyAxisMotion(e.type, e.jaxis.which, e.jaxis.axis, e.jaxis.value / 32767)
+    elif e.type == SDL_JOYBALLMOTION:
+        evt = events.JoyBallMotion(
+            e.type, e.jball.which, e.jball.ball, (e.jball.xrel, e.jball.yrel)
+        )
+    elif e.type == SDL_JOYHATMOTION:
+        evt = events.JoyHatMotion(e.type, e.jhat.which, e.jhat.hat, _hat_xy(e.jhat.value))
+    elif e.type == SDL_JOYBUTTONDOWN:
+        evt = events.JoyButtonDown(e.type, e.jbutton.which, e.jbutton.button)
+    elif e.type == SDL_JOYBUTTONUP:
+        evt = events.JoyButtonUp(e.type, e.jbutton.which, e.jbutton.button)
     elif e.type == SDL_QUIT:
         evt = events.Quit(e.type)
     else:
@@ -280,6 +364,7 @@ class SDLDisplay(DisplayDriver):
 
         _save_tty()
         retcheck(SDL_Init(SDL_INIT_EVERYTHING))
+        _init_joysticks()
         self._window = SDL_CreateWindow(
             self._title.encode(),
             x,
@@ -524,6 +609,7 @@ class SDLDisplay(DisplayDriver):
 
     def _deinit(self) -> None:
         """Release SDL resources."""
+        _close_joysticks()
         if self._buffer is not None:
             SDL_DestroyTexture(self._buffer)
             self._buffer = None

--- a/src/lib/displaysys/sdldisplay/_sdl2_lib/_constants.py
+++ b/src/lib/displaysys/sdldisplay/_sdl2_lib/_constants.py
@@ -71,12 +71,26 @@ SDL_MOUSEMOTION = const(0x400)  # Mouse moved
 SDL_MOUSEBUTTONDOWN = const(0x401)  # Mouse button pressed
 SDL_MOUSEBUTTONUP = const(0x402)  # Mouse button released
 SDL_MOUSEWHEEL = const(0x403)  # Mouse wheel motion
+SDL_JOYAXISMOTION = const(0x600)  # Joystick axis motion
+SDL_JOYBALLMOTION = const(0x601)  # Joystick trackball motion
+SDL_JOYHATMOTION = const(0x602)  # Joystick hat position change
+SDL_JOYBUTTONDOWN = const(0x603)  # Joystick button pressed
+SDL_JOYBUTTONUP = const(0x604)  # Joystick button released
+SDL_JOYDEVICEADDED = const(0x605)  # A joystick was connected
+SDL_JOYDEVICEREMOVED = const(0x606)  # A joystick was disconnected
 SDL_POLLSENTINEL = const(0x7F00)  # Signals the end of an event poll cycle
 
 # SDL_MouseMotionEvent button masks
 SDL_BUTTON_LMASK = const(1 << 0)  # Left mouse button
 SDL_BUTTON_MMASK = const(1 << 1)  # Middle mouse button
 SDL_BUTTON_RMASK = const(1 << 2)  # Right mouse button
+
+# SDL_JoyHatEvent position masks
+SDL_HAT_CENTERED = const(0x00)
+SDL_HAT_UP = const(0x01)
+SDL_HAT_RIGHT = const(0x02)
+SDL_HAT_DOWN = const(0x04)
+SDL_HAT_LEFT = const(0x08)
 
 
 ###############################################################################

--- a/src/lib/displaysys/sdldisplay/_sdl2_lib/_cpython.py
+++ b/src/lib/displaysys/sdldisplay/_sdl2_lib/_cpython.py
@@ -120,6 +120,62 @@ class SDL_MouseWheelEvent(ctypes.Structure):
     _fields_ = [("type", ctypes.c_uint), ("timestamp", ctypes.c_uint), ("wheel", Wheel)]
 
 
+class SDL_JoyAxisEvent(ctypes.Structure):
+    class JAxis(ctypes.Structure):
+        _fields_ = [
+            ("which", ctypes.c_int),
+            ("axis", ctypes.c_uint8),
+            ("padding1", ctypes.c_uint8),
+            ("padding2", ctypes.c_uint8),
+            ("padding3", ctypes.c_uint8),
+            ("value", ctypes.c_int16),
+            ("padding4", ctypes.c_uint16),
+        ]
+
+    _fields_ = [("type", ctypes.c_uint), ("timestamp", ctypes.c_uint), ("jaxis", JAxis)]
+
+
+class SDL_JoyBallEvent(ctypes.Structure):
+    class JBall(ctypes.Structure):
+        _fields_ = [
+            ("which", ctypes.c_int),
+            ("ball", ctypes.c_uint8),
+            ("padding1", ctypes.c_uint8),
+            ("padding2", ctypes.c_uint8),
+            ("padding3", ctypes.c_uint8),
+            ("xrel", ctypes.c_int16),
+            ("yrel", ctypes.c_int16),
+        ]
+
+    _fields_ = [("type", ctypes.c_uint), ("timestamp", ctypes.c_uint), ("jball", JBall)]
+
+
+class SDL_JoyHatEvent(ctypes.Structure):
+    class JHat(ctypes.Structure):
+        _fields_ = [
+            ("which", ctypes.c_int),
+            ("hat", ctypes.c_uint8),
+            ("value", ctypes.c_uint8),
+            ("padding1", ctypes.c_uint8),
+            ("padding2", ctypes.c_uint8),
+        ]
+
+    _fields_ = [("type", ctypes.c_uint), ("timestamp", ctypes.c_uint), ("jhat", JHat)]
+
+
+class SDL_JoyButtonEvent(ctypes.Structure):
+    class JButton(ctypes.Structure):
+        _fields_ = [
+            ("which", ctypes.c_int),
+            ("button", ctypes.c_uint8),
+            ("state", ctypes.c_uint8),
+            ("padding1", ctypes.c_uint8),
+            ("padding2", ctypes.c_uint8),
+        ]
+
+    _fields_ = [("type", ctypes.c_uint), ("timestamp", ctypes.c_uint), ("jbutton", JButton)]
+
+
 ###############################################################################
 #                          SDL2 functions                                     #
 ###############################################################################
@@ -140,6 +196,27 @@ SDL_GetError = _libSDL2.SDL_GetError
 _libSDL2.SDL_PollEvent.argtypes = [ctypes.POINTER(SDL_CommonEvent)]
 _libSDL2.SDL_PollEvent.restype = ctypes.c_int
 SDL_PollEvent = _libSDL2.SDL_PollEvent
+
+_libSDL2.SDL_InitSubSystem.argtypes = [ctypes.c_uint]
+_libSDL2.SDL_InitSubSystem.restype = ctypes.c_int
+SDL_InitSubSystem = _libSDL2.SDL_InitSubSystem
+
+# SDL joystick functions
+_libSDL2.SDL_NumJoysticks.argtypes = []
+_libSDL2.SDL_NumJoysticks.restype = ctypes.c_int
+SDL_NumJoysticks = _libSDL2.SDL_NumJoysticks
+
+_libSDL2.SDL_JoystickOpen.argtypes = [ctypes.c_int]
+_libSDL2.SDL_JoystickOpen.restype = ctypes.c_void_p
+SDL_JoystickOpen = _libSDL2.SDL_JoystickOpen
+
+_libSDL2.SDL_JoystickClose.argtypes = [ctypes.c_void_p]
+_libSDL2.SDL_JoystickClose.restype = None
+SDL_JoystickClose = _libSDL2.SDL_JoystickClose
+
+_libSDL2.SDL_JoystickInstanceID.argtypes = [ctypes.c_void_p]
+_libSDL2.SDL_JoystickInstanceID.restype = ctypes.c_int
+SDL_JoystickInstanceID = _libSDL2.SDL_JoystickInstanceID
 
 # SDL key functions
 _libSDL2.SDL_GetKeyName.argtypes = [ctypes.c_int]
@@ -286,6 +363,11 @@ _event_struct_map = {
     SDL_MOUSEBUTTONDOWN: SDL_MouseButtonEvent,  # noqa: F405
     SDL_MOUSEBUTTONUP: SDL_MouseButtonEvent,  # noqa: F405
     SDL_MOUSEWHEEL: SDL_MouseWheelEvent,  # noqa: F405
+    SDL_JOYAXISMOTION: SDL_JoyAxisEvent,  # noqa: F405
+    SDL_JOYBALLMOTION: SDL_JoyBallEvent,  # noqa: F405
+    SDL_JOYHATMOTION: SDL_JoyHatEvent,  # noqa: F405
+    SDL_JOYBUTTONDOWN: SDL_JoyButtonEvent,  # noqa: F405
+    SDL_JOYBUTTONUP: SDL_JoyButtonEvent,  # noqa: F405
     SDL_POLLSENTINEL: SDL_CommonEvent,  # noqa: F405
 }
 

--- a/src/lib/displaysys/sdldisplay/_sdl2_lib/_ffi.py
+++ b/src/lib/displaysys/sdldisplay/_sdl2_lib/_ffi.py
@@ -111,6 +111,59 @@ SDL_MouseWheelEvent = {
     ),
 }
 
+SDL_JoyAxisEvent = {
+    "type": uctypes.UINT32 | 0,
+    "timestamp": uctypes.UINT32 | 4,
+    "jaxis": (
+        8,
+        {
+            "which": uctypes.INT32 | 0,
+            "axis": uctypes.UINT8 | 4,
+            "value": uctypes.INT16 | 8,
+        },
+    ),
+}
+
+SDL_JoyBallEvent = {
+    "type": uctypes.UINT32 | 0,
+    "timestamp": uctypes.UINT32 | 4,
+    "jball": (
+        8,
+        {
+            "which": uctypes.INT32 | 0,
+            "ball": uctypes.UINT8 | 4,
+            "xrel": uctypes.INT16 | 8,
+            "yrel": uctypes.INT16 | 10,
+        },
+    ),
+}
+
+SDL_JoyHatEvent = {
+    "type": uctypes.UINT32 | 0,
+    "timestamp": uctypes.UINT32 | 4,
+    "jhat": (
+        8,
+        {
+            "which": uctypes.INT32 | 0,
+            "hat": uctypes.UINT8 | 4,
+            "value": uctypes.UINT8 | 5,
+        },
+    ),
+}
+
+SDL_JoyButtonEvent = {
+    "type": uctypes.UINT32 | 0,
+    "timestamp": uctypes.UINT32 | 4,
+    "jbutton": (
+        8,
+        {
+            "which": uctypes.INT32 | 0,
+            "button": uctypes.UINT8 | 4,
+            "state": uctypes.UINT8 | 5,
+        },
+    ),
+}
+
 
 ###############################################################################
 #                          SDL2 functions                                     #
@@ -118,9 +171,16 @@ SDL_MouseWheelEvent = {
 
 # SDL misc functions
 SDL_Init = _libSDL2.func("i", "SDL_Init", "I")
+SDL_InitSubSystem = _libSDL2.func("i", "SDL_InitSubSystem", "I")
 SDL_Quit = _libSDL2.func("v", "SDL_Quit", "")
 SDL_GetError = _libSDL2.func("s", "SDL_GetError", "")
 SDL_PollEvent = _libSDL2.func("i", "SDL_PollEvent", "P")
+
+# SDL joystick functions
+SDL_NumJoysticks = _libSDL2.func("i", "SDL_NumJoysticks", "")
+SDL_JoystickOpen = _libSDL2.func("P", "SDL_JoystickOpen", "i")
+SDL_JoystickClose = _libSDL2.func("v", "SDL_JoystickClose", "P")
+SDL_JoystickInstanceID = _libSDL2.func("i", "SDL_JoystickInstanceID", "P")
 
 # SDL key functions
 SDL_GetKeyName = _libSDL2.func("s", "SDL_GetKeyName", "i")
@@ -170,6 +230,11 @@ _event_struct_map = {
     SDL_MOUSEBUTTONDOWN: SDL_MouseButtonEvent,  # noqa: F405
     SDL_MOUSEBUTTONUP: SDL_MouseButtonEvent,  # noqa: F405
     SDL_MOUSEWHEEL: SDL_MouseWheelEvent,  # noqa: F405
+    SDL_JOYAXISMOTION: SDL_JoyAxisEvent,  # noqa: F405
+    SDL_JOYBALLMOTION: SDL_JoyBallEvent,  # noqa: F405
+    SDL_JOYHATMOTION: SDL_JoyHatEvent,  # noqa: F405
+    SDL_JOYBUTTONDOWN: SDL_JoyButtonEvent,  # noqa: F405
+    SDL_JOYBUTTONUP: SDL_JoyButtonEvent,  # noqa: F405
     SDL_POLLSENTINEL: SDL_CommonEvent,  # noqa: F405
 }
 

--- a/src/lib/displaysys/sdldisplay/_sdl2_lib/_usdl2.py
+++ b/src/lib/displaysys/sdldisplay/_sdl2_lib/_usdl2.py
@@ -32,16 +32,11 @@ SDL_Quit = usdl2.quit
 SDL_GetError = usdl2.get_error
 SDL_PollEvent = usdl2.poll_event
 SDL_GetKeyName = usdl2.get_key_name
-
-# Joystick API (usdl2 PR #1 / pydisplay joystick parity).  Only exported when
-# the installed usdl2 build provides them; sdldisplay imports these names
-# defensively and disables joystick input when they are absent.
-if hasattr(usdl2, "init_subsystem"):
-    SDL_InitSubSystem = usdl2.init_subsystem
-    SDL_NumJoysticks = usdl2.num_joysticks
-    SDL_JoystickOpen = usdl2.joystick_open
-    SDL_JoystickClose = usdl2.joystick_close
-    SDL_JoystickInstanceID = usdl2.joystick_instance_id
+SDL_InitSubSystem = usdl2.init_subsystem
+SDL_NumJoysticks = usdl2.num_joysticks
+SDL_JoystickOpen = usdl2.joystick_open
+SDL_JoystickClose = usdl2.joystick_close
+SDL_JoystickInstanceID = usdl2.joystick_instance_id
 
 
 def SDL_CreateWindow(title, x, y, w, h, flags):

--- a/src/lib/displaysys/sdldisplay/_sdl2_lib/_usdl2.py
+++ b/src/lib/displaysys/sdldisplay/_sdl2_lib/_usdl2.py
@@ -33,6 +33,16 @@ SDL_GetError = usdl2.get_error
 SDL_PollEvent = usdl2.poll_event
 SDL_GetKeyName = usdl2.get_key_name
 
+# Joystick API (usdl2 PR #1 / pydisplay joystick parity).  Only exported when
+# the installed usdl2 build provides them; sdldisplay imports these names
+# defensively and disables joystick input when they are absent.
+if hasattr(usdl2, "init_subsystem"):
+    SDL_InitSubSystem = usdl2.init_subsystem
+    SDL_NumJoysticks = usdl2.num_joysticks
+    SDL_JoystickOpen = usdl2.joystick_open
+    SDL_JoystickClose = usdl2.joystick_close
+    SDL_JoystickInstanceID = usdl2.joystick_instance_id
+
 
 def SDL_CreateWindow(title, x, y, w, h, flags):
     return usdl2.create_window(_window_title(title), x, y, w, h, flags)

--- a/src/lib/eventsys/keys.py
+++ b/src/lib/eventsys/keys.py
@@ -621,19 +621,34 @@ _DOM_NAMED_KEYS = {
     "F12": Keys.K_F12,
 }
 
+# Right-hand variants of modifier keys, selected when the DOM key event reports
+# ``location == DOM_KEY_LOCATION_RIGHT`` (2).
+_DOM_RIGHT_KEYS = {
+    "Control": Keys.K_RCTRL,
+    "Shift": Keys.K_RSHIFT,
+    "Alt": Keys.K_RALT,
+    "Meta": Keys.K_RGUI,
+}
+
 _MOD_GROUPS = (Keys.KMOD_CTRL, Keys.KMOD_SHIFT, Keys.KMOD_ALT, Keys.KMOD_GUI)
 
 
-def key_to_keycode(key):
+def key_to_keycode(key, location=0):
     """
     Map a DOM ``KeyboardEvent.key`` value to an eventsys key code.
 
     Args:
         key (str): The ``KeyboardEvent.key`` value (e.g. ``"a"`` or ``"ArrowUp"``).
+        location (int): The ``KeyboardEvent.location`` value.  ``2`` selects the
+            right-hand variant of a modifier key (e.g. ``K_RCTRL``).
 
     Returns:
         int: The matching ``Keys.K_*`` code, or ``Keys.K_UNKNOWN``.
     """
+    if location == 2:
+        code = _DOM_RIGHT_KEYS.get(key)
+        if code is not None:
+            return code
     code = _DOM_NAMED_KEYS.get(key)
     if code is not None:
         return code

--- a/src/lib/eventsys/keys.py
+++ b/src/lib/eventsys/keys.py
@@ -569,3 +569,129 @@ class Keys:
         KMOD_ALT: "Alt",
         KMOD_GUI: "GUI",
     }
+
+
+# ---------------------------------------------------------------------------
+# Browser / DOM keyboard helpers
+#
+# Translate values from a JavaScript ``KeyboardEvent`` (as delivered by
+# PyScript or ipyevents) into the SDL-style key codes and modifier masks above,
+# so web/notebook backends can emit the same ``Key`` events as the desktop
+# SDL2 / PyGame backends.  ``KeyboardEvent.key`` holds either a single printable
+# character (mapped by code point) or a named value such as ``"ArrowUp"``
+# (mapped via the table below).
+# ---------------------------------------------------------------------------
+
+_DOM_NAMED_KEYS = {
+    "Backspace": Keys.K_BACKSPACE,
+    "Tab": Keys.K_TAB,
+    "Enter": Keys.K_RETURN,
+    "Escape": Keys.K_ESCAPE,
+    "Delete": Keys.K_DELETE,
+    "ArrowUp": Keys.K_UP,
+    "ArrowDown": Keys.K_DOWN,
+    "ArrowLeft": Keys.K_LEFT,
+    "ArrowRight": Keys.K_RIGHT,
+    "Home": Keys.K_HOME,
+    "End": Keys.K_END,
+    "PageUp": Keys.K_PAGEUP,
+    "PageDown": Keys.K_PAGEDOWN,
+    "Insert": Keys.K_INSERT,
+    "CapsLock": Keys.K_CAPSLOCK,
+    "NumLock": Keys.K_NUMLOCKCLEAR,
+    "ScrollLock": Keys.K_SCROLLLOCK,
+    "Pause": Keys.K_PAUSE,
+    "PrintScreen": Keys.K_PRINTSCREEN,
+    "ContextMenu": Keys.K_MENU,
+    "Control": Keys.K_LCTRL,
+    "Shift": Keys.K_LSHIFT,
+    "Alt": Keys.K_LALT,
+    "Meta": Keys.K_LGUI,
+    "F1": Keys.K_F1,
+    "F2": Keys.K_F2,
+    "F3": Keys.K_F3,
+    "F4": Keys.K_F4,
+    "F5": Keys.K_F5,
+    "F6": Keys.K_F6,
+    "F7": Keys.K_F7,
+    "F8": Keys.K_F8,
+    "F9": Keys.K_F9,
+    "F10": Keys.K_F10,
+    "F11": Keys.K_F11,
+    "F12": Keys.K_F12,
+}
+
+_MOD_GROUPS = (Keys.KMOD_CTRL, Keys.KMOD_SHIFT, Keys.KMOD_ALT, Keys.KMOD_GUI)
+
+
+def key_to_keycode(key):
+    """
+    Map a DOM ``KeyboardEvent.key`` value to an eventsys key code.
+
+    Args:
+        key (str): The ``KeyboardEvent.key`` value (e.g. ``"a"`` or ``"ArrowUp"``).
+
+    Returns:
+        int: The matching ``Keys.K_*`` code, or ``Keys.K_UNKNOWN``.
+    """
+    code = _DOM_NAMED_KEYS.get(key)
+    if code is not None:
+        return code
+    if key and len(key) == 1:
+        o = ord(key)
+        if 0x41 <= o <= 0x5A:  # 'A'-'Z' -> lowercase code, matching SDL
+            return o + 0x20
+        return o
+    return Keys.K_UNKNOWN
+
+
+def mod_mask(ctrl, shift, alt, meta):
+    """
+    Build an eventsys modifier mask from DOM modifier flags.
+
+    Args:
+        ctrl (bool): Whether Ctrl is held.
+        shift (bool): Whether Shift is held.
+        alt (bool): Whether Alt is held.
+        meta (bool): Whether Meta/GUI (Cmd/Win) is held.
+
+    Returns:
+        int: A mask of ``Keys.KMOD_*`` bits.
+    """
+    mask = 0
+    if shift:
+        mask |= Keys.KMOD_LSHIFT
+    if ctrl:
+        mask |= Keys.KMOD_LCTRL
+    if alt:
+        mask |= Keys.KMOD_LALT
+    if meta:
+        mask |= Keys.KMOD_LGUI
+    return mask
+
+
+def chord_matches(chord, keycode, mod):
+    """
+    Return True if ``(keycode, mod)`` satisfies a ``(key, mod_mask)`` chord.
+
+    Modifier matching is group-aware: a required ``KMOD_CTRL`` is satisfied by
+    either left or right Ctrl.  Extra modifiers beyond those required are
+    ignored.
+
+    Args:
+        chord (tuple | None): A ``(key_code, modifier_mask)`` tuple, or None.
+        keycode (int): The pressed key code.
+        mod (int): The active modifier mask.
+
+    Returns:
+        bool: Whether the chord is satisfied.
+    """
+    if not chord:
+        return False
+    chord_key, chord_mod = chord
+    if keycode != chord_key:
+        return False
+    for group in _MOD_GROUPS:
+        if (chord_mod & group) and not (mod & group):
+            return False
+    return True


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Unifies input across all display backends and brings them to feature parity.

### 1. Touch-helper cleanup
- Renamed `JNDevices`/`PSDevices` → `JNTouch`/`PSTouch`, fixed the copy-pasted `PSTouch` docstring.

### 2. Unified web/notebook input (`PSDevices` / `JNDevices`)
Combined the separate touch/keyboard helpers into one input class per backend, removing `PSTouch`/`PSKeys`/`JNTouch`/`JNKeys`. Each is registered as a single `QUEUE` device via `read()` and emits full `eventsys.events` objects matching the desktop stream:
- Pointer (mouse + touch + pen via Pointer Events on PyScript): full motion + all buttons
- Wheel (`MOUSEWHEEL`)
- Keyboard (`KEYDOWN`/`KEYUP`) with left/right modifier disambiguation
- Gamepad (`JOY*` via Gamepad API, PyScript only)
- Assignable quit chord → `events.QUIT` (default CTRL+C)

### 3. Shared keymap in `eventsys.keys`
`key_to_keycode`/`mod_mask`/`chord_matches` (with `location` for L/R modifiers) live in `eventsys/keys.py`.

### 4. Joystick/gamepad for SDL2 and PyGame (parity)
`eventsys` defined five joystick event types, but `sdldisplay` dropped them into `Unknown` and `pgdisplay` never opened joysticks. Now both desktop backends capture them:
- **sdldisplay**: added SDL joystick event/hat constants, event structs and functions to the cpython (ctypes) and ffi backends; `_convert` now produces `Joy*` events; connected joysticks opened at init via `SDL_InitSubSystem(SDL_INIT_JOYSTICK)`.
- **pgdisplay**: initializes the joystick subsystem and opens connected joysticks so PyGame posts joy events through `poll()`/`get()`.
- Hot-plug after startup is not handled (connect controllers before launching).

### 5. Native `usdl2` backend wiring
[PyDevices/usdl2#1](https://github.com/PyDevices/usdl2/pull/1) adds the C-module joystick API and `Event` subviews (`jaxis`, `jball`, `jhat`, `jbutton`) needed for MicroPython/CircuitPython unix builds. `_usdl2.py` now exports `SDL_InitSubSystem`, `SDL_NumJoysticks`, `SDL_JoystickOpen/Close/InstanceID` when the installed `usdl2` provides them (`hasattr` guard for older builds). That enables `_HAS_JOYSTICK_API` on the native path instead of silently disabling joystick input.

### Wiring & docs
- All web/notebook board configs register a single `QUEUE` device.
- `docs/concepts/displays.md`, `events.md`, and `platforms/jupyter.md` describe the unified input model and desktop joystick support.

## Testing
- `python3 -m py_compile` passes on all changed files.
- Verified SDL joystick ctypes struct offsets against the SDL2 ABI.
- Unit-tested keymap, joystick conversion, and hat→(x,y) mapping.
- Integration-tested `QUEUE` flow with mixed events including `JOYBUTTONDOWN` and `QUIT`.
- SDL2/pygame not installed in CI sandbox; usdl2 runtime requires a MicroPython/CircuitPython unix build.

## Compatibility note
Breaking: external code importing the old touch/keyboard helper names must move to the new combined `JNDevices`/`PSDevices` registered as a `QUEUE` device.

## Related
- Depends on / pairs with [usdl2#1](https://github.com/PyDevices/usdl2/pull/1) for native unix joystick support.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-de07f124-9db9-4794-a0f0-c91991bfb8a4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-de07f124-9db9-4794-a0f0-c91991bfb8a4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

