### PR TITLE
Require frozen asyncio in MicroPython manifest for desktop ports

### DIFF
--- a/docs/platforms/circuitpython.md
+++ b/docs/platforms/circuitpython.md
@@ -52,15 +52,27 @@ Install `libsdl2-dev`, then symlink or copy the built binary (e.g. `ports/unix/b
 
 ### Frozen asyncio (required for multimer.AsyncTimer)
 
-CircuitPython unix pydisplay builds must **freeze** Adafruit's `asyncio` library into
-the firmware — do not rely on `circup install asyncio` at runtime. Enable
-`MICROPY_PY_ASYNC_AWAIT` / `MICROPY_PY_ASYNCIO` / `MICROPY_PY_SELECT` in the port
-config and add the asyncio library tree to `FROZEN_MPY_DIRS` (or the cmods CP
-build manifest). See [multimer building docs](https://github.com/PyDevices/multimer/blob/main/docs/building.md).
+CircuitPython unix pydisplay builds must **freeze** Adafruit's `asyncio` and
+`adafruit_ticks` libraries into the firmware — do not rely on
+`circup install asyncio` at runtime.
 
-`multimer` supplies Adafruit-compatible `ticks_*` helpers so frozen asyncio can
-use multimer ticks instead of a separate `adafruit_ticks` module where the build
-is configured for that.
+From the [cmods](https://github.com/PyDevices/cmods) workspace:
+
+```bash
+mkdir -p cp-user-config
+cp cp-user-config/user_post_mpconfigport.mk.example cp-user-config/user_post_mpconfigport.mk
+git clone https://github.com/adafruit/Adafruit_CircuitPython_asyncio.git
+git clone https://github.com/adafruit/Adafruit_CircuitPython_Ticks.git
+./build_cp.sh --port unix --variant coverage
+```
+
+`build_cp.sh` passes `-I cp-user-config/` so `user_post_mpconfigport.mk` sets
+`FROZEN_MPY_DIRS` and enables `MICROPY_PY_ASYNCIO` / `select` / `traceback`.
+See [multimer building docs](https://github.com/PyDevices/multimer/blob/main/docs/building.md)
+and [cmods README](https://github.com/PyDevices/cmods/blob/main/README.md).
+
+`multimer` supplies Adafruit-compatible `ticks_*` helpers for application code;
+frozen asyncio still uses `adafruit_ticks` internally unless the build is customized.
 
 ## framebuf shim
 

--- a/docs/platforms/circuitpython.md
+++ b/docs/platforms/circuitpython.md
@@ -50,6 +50,18 @@ cd ~/github/cmods/lv_circuitpython_mod
 
 Install `libsdl2-dev`, then symlink or copy the built binary (e.g. `ports/unix/build-coverage/micropython`) to `~/bin/circuitpython`.
 
+### Frozen asyncio (required for multimer.AsyncTimer)
+
+CircuitPython unix pydisplay builds must **freeze** Adafruit's `asyncio` library into
+the firmware — do not rely on `circup install asyncio` at runtime. Enable
+`MICROPY_PY_ASYNC_AWAIT` / `MICROPY_PY_ASYNCIO` / `MICROPY_PY_SELECT` in the port
+config and add the asyncio library tree to `FROZEN_MPY_DIRS` (or the cmods CP
+build manifest). See [multimer building docs](https://github.com/PyDevices/multimer/blob/main/docs/building.md).
+
+`multimer` supplies Adafruit-compatible `ticks_*` helpers so frozen asyncio can
+use multimer ticks instead of a separate `adafruit_ticks` module where the build
+is configured for that.
+
 ## framebuf shim
 
 CircuitPython lacks MicroPython-compatible `framebuf`. Install `add_ons/framebuf.py` or copy it to your `lib/` folder.

--- a/docs/platforms/micropython.md
+++ b/docs/platforms/micropython.md
@@ -52,4 +52,17 @@ Without **`usdl2`**, `SDLDisplay` falls back to pure-Python ffi/ctypes bindings;
 
 ## Frozen firmware
 
-The repo-root `manifest.py` lists packages for frozen MicroPython builds. See [tools/README.md](https://github.com/PyDevices/pydisplay/blob/main/tools/README.md) for maintainer details.
+The repo-root `manifest.py` lists packages for frozen MicroPython builds and
+**freezes `asyncio` on unix and windows ports** (required for `multimer.AsyncTimer`).
+
+With [cmods](https://github.com/PyDevices/cmods) `build_mp.sh`, set
+`FROZEN_MANIFEST` to this file (or copy `packaging/cmods-my-manifest.py.example`
+from the multimer repo into `cmods/my-manifest.py`). Build Windows with
+`--variant dev` so `MICROPY_PY_ASYNCIO` and `select` are enabled::
+
+```bash
+./build_mp.sh --port windows --variant dev
+./build_mp.sh --port unix
+```
+
+See [multimer building docs](https://github.com/PyDevices/multimer/blob/main/docs/building.md) and [tools/README.md](https://github.com/PyDevices/pydisplay/blob/main/tools/README.md).

--- a/manifest.py
+++ b/manifest.py
@@ -47,6 +47,11 @@ elif os.path.exists(os.path.join("$(PORT_DIR)", "boards", "manifest.py")):
 elif os.path.exists(os.path.join("$(PORT_DIR)", "variants", "standard", "manifest.py")):
     include("$(PORT_DIR)/variants/standard/manifest.py")
 
+# Frozen asyncio on desktop MicroPython ports (required for multimer.AsyncTimer).
+_port = "$(PORT_DIR)".replace("\\", "/")
+if _port.endswith("/unix") or _port.endswith("/windows"):
+    include("$(MPY_DIR)/extmod/asyncio")
+
 package("displaysys", base_path="./src/lib", opt=3)
 package("eventsys", base_path="./src/lib", opt=3)
 package("graphics", base_path="./src/lib", opt=3)


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

MicroPython desktop builds (`unix`, `windows`) need frozen `asyncio` for `multimer.AsyncTimer` and `from multimer import asyncio`. CircuitPython unix builds need frozen Adafruit `asyncio` + `adafruit_ticks` via cmods `cp-user-config/`.

## Changes

- **`manifest.py`**: Freeze `$(MPY_DIR)/extmod/asyncio` when `PORT_DIR` is `unix` or `windows`.
- **`docs/platforms/micropython.md`**: Document frozen asyncio, cmods `my-manifest.py`, and `--variant dev` for `micropython.exe`.
- **`docs/platforms/circuitpython.md`**: Document cmods `cp-user-config/user_post_mpconfigport.mk` with concrete clone/build steps.

## cmods usage

**MicroPython:**
```bash
cp my-manifest.py.example my-manifest.py
./build_mp.sh --port unix
./build_mp.sh --port windows --variant dev
```

**CircuitPython:**
```bash
cp cp-user-config/user_post_mpconfigport.mk.example cp-user-config/user_post_mpconfigport.mk
git clone https://github.com/adafruit/Adafruit_CircuitPython_asyncio.git
git clone https://github.com/adafruit/Adafruit_CircuitPython_Ticks.git
./build_cp.sh --port unix --variant coverage
```

## Related PRs (pending push access)

- [cmods](https://github.com/PyDevices/cmods) branch `cursor/frozen-asyncio-cp-config-fc55`
- [lv_circuitpython_mod](https://github.com/PyDevices/lv_circuitpython_mod) branch `cursor/cp-user-config-fc55`
- [multimer](https://github.com/PyDevices/multimer) branch `cursor/new-multimer-fc55` (repo must be created first)
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-7b761819-e8f4-470e-8ecd-cb70b35ffc55"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-7b761819-e8f4-470e-8ecd-cb70b35ffc55"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

