### PR TITLE
Prefer multimer _sdl2 backend on Android CPython

### DIFF
--- a/src/lib/multimer/__init__.py
+++ b/src/lib/multimer/__init__.py
@@ -100,16 +100,29 @@ except ImportError:
             _BACKEND = Timer.BACKEND
             _NEEDS_PUMP = Timer.NEEDS_PUMP
         except ImportError:
-            try:
-                from ._threading import Timer
+            if sys.platform == "android":
+                # SDL UI thread: prefer SDL_AddTimer (_sdl2) over threading.Timer.
+                try:
+                    from ._sdl2 import Timer
 
-                _BACKEND = Timer.BACKEND
-                _NEEDS_PUMP = Timer.NEEDS_PUMP
-            except ImportError:
-                from ._sdl2 import Timer
+                    _BACKEND = Timer.BACKEND
+                    _NEEDS_PUMP = Timer.NEEDS_PUMP
+                except ImportError:
+                    from ._threading import Timer
 
-                _BACKEND = Timer.BACKEND
-                _NEEDS_PUMP = Timer.NEEDS_PUMP
+                    _BACKEND = Timer.BACKEND
+                    _NEEDS_PUMP = Timer.NEEDS_PUMP
+            else:
+                try:
+                    from ._threading import Timer
+
+                    _BACKEND = Timer.BACKEND
+                    _NEEDS_PUMP = Timer.NEEDS_PUMP
+                except ImportError:
+                    from ._sdl2 import Timer
+
+                    _BACKEND = Timer.BACKEND
+                    _NEEDS_PUMP = Timer.NEEDS_PUMP
     elif sys.implementation.name == "circuitpython" and Timer is None:
         try:
             from ._threading import Timer


### PR DESCRIPTION
## Summary
Recovered from cloud agent `bc-04feb0e2`. Prefer multimer `_sdl2` backend on Android CPython for SDL2 timer integration.

## Test plan
- [ ] Android CPython pydisplay smoke test with multimer

Related: PyDevices/cmods#3