### PR TITLE
Add bouncing_balls graphics example

### DIFF
--- a/docs/examples/index.md
+++ b/docs/examples/index.md
@@ -232,6 +232,7 @@ PyScript requires asyncio — see [PyScript asyncio guide](../guides/pyscript-as
 | `font_list.py` | Font picker | CPython · MCU | core |
 | `fonts.py` | Page through fonts | CPython · MCU | core |
 | `boxlines.py` | Lines and boxes | CPython · MCU | core |
+| `bouncing_balls.py` | Colored balls animation | CPython · MCU · PyScript | core |
 
 ## Bitmaps and palettes
 

--- a/packages/examples.json
+++ b/packages/examples.json
@@ -29,6 +29,10 @@
       "github:PyDevices/pydisplay/src/examples/bmp565_sprite_transparent.py"
     ],
     [
+      "bouncing_balls.py",
+      "github:PyDevices/pydisplay/src/examples/bouncing_balls.py"
+    ],
+    [
       "boxlines.py",
       "github:PyDevices/pydisplay/src/examples/boxlines.py"
     ],

--- a/src/examples/bouncing_balls.py
+++ b/src/examples/bouncing_balls.py
@@ -1,0 +1,107 @@
+# multimer types: all
+"""
+bouncing_balls.py
+=================
+
+Animate colored balls bouncing inside the display.
+
+Inspired by Pimoroni's ``balls_demo.py``, adapted for pydisplay's
+``board_config.display_drv`` and ``graphics`` module so the same script runs on
+desktop (SDL/Pygame), MCU, and PyScript.
+
+.. note:: This example requires the following modules:
+
+  .. hlist::
+    :columns: 3
+
+    - `displaysys`
+    - `graphics`
+    - `multimer`
+
+"""
+
+from random import getrandbits
+
+from board_config import broker, display_drv
+from eventsys import poll_quit_discarding_others
+from multimer import sleep_ms
+import graphics
+
+WIDTH = display_drv.width
+HEIGHT = display_drv.height
+BG = 0x2828  # dark gray (RGB565)
+NUM_BALLS = min(100, max(20, (WIDTH * HEIGHT) // 3000))
+
+
+def randint(a, b):
+    span = b - a + 1
+    if span <= 1:
+        return a
+    bits = 0
+    n = span - 1
+    while n:
+        bits += 1
+        n >>= 1
+    return a + getrandbits(bits) % span
+
+
+def color565(r, g, b):
+    return ((r & 0xF8) << 8) | ((g & 0xFC) << 3) | (b >> 3)
+
+
+class Ball:
+    __slots__ = ("x", "y", "r", "dx", "dy", "color")
+
+    def __init__(self, x, y, r, dx, dy, color):
+        self.x = x
+        self.y = y
+        self.r = r
+        self.dx = dx
+        self.dy = dy
+        self.color = color
+
+
+def make_balls():
+    balls = []
+    for _ in range(NUM_BALLS):
+        r = randint(3, 13)
+        balls.append(
+            Ball(
+                randint(r, WIDTH - r),
+                randint(r, HEIGHT - r),
+                r,
+                (14 - r) / 2,
+                (14 - r) / 2,
+                color565(getrandbits(8), getrandbits(8), getrandbits(8)),
+            )
+        )
+    return balls
+
+
+def step(ball):
+    ball.x += ball.dx
+    ball.y += ball.dy
+    xmin, xmax = ball.r, WIDTH - ball.r
+    ymin, ymax = ball.r, HEIGHT - ball.r
+    if ball.x < xmin or ball.x > xmax:
+        ball.dx *= -1
+        ball.x = max(xmin, min(xmax, ball.x))
+    if ball.y < ymin or ball.y > ymax:
+        ball.dy *= -1
+        ball.y = max(ymin, min(ymax, ball.y))
+
+
+def main():
+    balls = make_balls()
+    while True:
+        graphics.fill(display_drv, BG)
+        for ball in balls:
+            step(ball)
+            graphics.circle(display_drv, int(ball.x), int(ball.y), ball.r, ball.color, True)
+        display_drv.show()
+        if poll_quit_discarding_others(broker):
+            break
+        sleep_ms(10)
+
+
+main()

--- a/tools/example_test_manifest.toml
+++ b/tools/example_test_manifest.toml
@@ -230,6 +230,13 @@ kind = "loop"
 quit = "poll"
 deps = ["core"]
 
+[examples.bouncing_balls]
+import = "bouncing_balls"
+script = "examples/bouncing_balls.py"
+kind = "loop"
+quit = "poll"
+deps = ["core"]
+
 [examples.console_advanced_demo]
 import = "console_advanced_demo"
 script = "examples/console_advanced_demo.py"


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Recovers the `bouncing_balls` example for pydisplay: a cross-platform animation demo that bounces many colored circles inside the display using `board_config.display_drv` and `graphics.circle`.

## Changes

- **`src/examples/bouncing_balls.py`** — quit-aware poll loop (`poll_quit_discarding_others`), `multimer types: all` marker, ball count scaled to display size
- **`packages/examples.json`** — MIP install entry (regenerated via `install_refresh_manifests.sh`)
- **`tools/example_test_manifest.toml`** — CI metadata (`loop` / `poll` / `core`)
- **`docs/examples/index.md`** — catalog entry under Drawing and fonts

## Test plan

- [ ] Run on CPython/SDL: `python src/examples/bouncing_balls.py`
- [ ] Verify `mip.install("github:PyDevices/pydisplay/packages/examples.json", target="./examples")` includes `bouncing_balls.py`
- [ ] CI example matrix picks up `[examples.bouncing_balls]` manifest entry

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-8c937ab5-e4ae-48de-9212-0b484a998008"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-8c937ab5-e4ae-48de-9212-0b484a998008"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

