### PR TITLE
Add Android platform docs for pydisplay_android

### DIFF
--- a/docs/platforms/android.md
+++ b/docs/platforms/android.md
@@ -1,0 +1,51 @@
+# Android (CPython)
+
+Platform notes for building pydisplay APKs with **python-for-android** and **buildozer**.
+
+## Overview
+
+On Android there is no MicroPython port. pydisplay runs under **CPython** in a **python-for-android** APK with the **SDL2 bootstrap**. The `import usdl2` API comes from the ctypes FFI package in [usdl2](https://github.com/PyDevices/usdl2) (`python/usdl2/`). pydisplay's existing `SDLDisplay` backend works unchanged once `usdl2` is installed.
+
+APK integration — demo project, build scripts, and p4a recipes for `pydisplay` and `lvgl-cpython` — lives in [**pydisplay_android**](https://github.com/PyDevices/pydisplay_android). usdl2 keeps only the ctypes package and `p4a_recipes/usdl2/`.
+
+## Workspace
+
+Clone as siblings (e.g. under a [cmods](https://github.com/PyDevices/cmods) workspace):
+
+```bash
+git clone https://github.com/PyDevices/usdl2.git
+git clone https://github.com/PyDevices/pydisplay.git
+git clone https://github.com/PyDevices/pydisplay_android.git
+git clone https://github.com/PyDevices/lv_cpython_mod.git   # optional, for LVGL demo
+```
+
+## Quick start
+
+Prerequisites: [Android SDK + NDK](https://python-for-android.readthedocs.io/en/latest/quickstart.html), `pip install buildozer`.
+
+```bash
+cd pydisplay_android/android_demo
+./build_apk.sh
+adb install -r bin/*.apk
+```
+
+Desktop smoke test (Xvfb, before building an APK):
+
+```bash
+cd pydisplay_android/android_demo
+./test_desktop.sh
+```
+
+## LVGL on Android
+
+Prebuilt **`lvgl-cpython`** wheels for Android (`android_21_arm64_v8a`, etc.) are on [TestPyPI](https://test.pypi.org/project/lvgl-cpython/). The `lvglcpython` p4a recipe in pydisplay_android installs a matching wheel when `p4a.extra_index_url` points at TestPyPI, or cross-compiles from [lv_cpython_mod](https://github.com/PyDevices/lv_cpython_mod) when `P4A_lvgl_cpython_DIR` is set.
+
+See [pydisplay_android README](https://github.com/PyDevices/pydisplay_android/blob/main/README.md) for demo entry points (`main_lvgl.py`, `board_config.py`) and recipe details.
+
+## Timers
+
+On Android, **multimer** selects the **`_sdl2`** backend (SDL timers on the UI thread) when `usdl2` is available — not `_threading`. See [multimer](../concepts/multimer.md#sdl2-bindings-usdl2).
+
+## Your own app
+
+Copy `pydisplay_android/android_demo/board_config.py`, add `pydisplay` and `usdl2` to your `buildozer.spec`, point `p4a.local_recipes` at pydisplay_android's `p4a_recipes/` (run `build_apk.sh` once to link the `usdl2` recipe from a sibling clone), and write your main loop with `display_drv` / `broker` as usual.

--- a/docs/platforms/index.md
+++ b/docs/platforms/index.md
@@ -4,11 +4,11 @@ Portability is PyDisplay's defining feature. Write your display, input, and timi
 
 ## Where PyDisplay runs
 
-| Runtime | Microcontrollers | Unix / Linux | Windows | Browser | Jupyter Notebook |
-|---------|:----------------:|:------------:|:-------:|:-------:|:----------------:|
-| **[MicroPython](micropython.md)** | ✅ | ✅ | ✅ | ✅ [PyScript](pyscript.md) · [Wokwi](../guides/wokwi.md) | — |
-| **[CircuitPython](circuitpython.md)** | ✅ | ✅ | — | — | — |
-| **[CPython](cpython-desktop.md)** | — | ✅ | ✅ | — | ✅ [Jupyter](jupyter.md) |
+| Runtime | Microcontrollers | Unix / Linux | Windows | Android | Browser | Jupyter Notebook |
+|---------|:----------------:|:------------:|:-------:|:-------:|:-------:|:----------------:|
+| **[MicroPython](micropython.md)** | ✅ | ✅ | ✅ | — | ✅ [PyScript](pyscript.md) · [Wokwi](../guides/wokwi.md) | — |
+| **[CircuitPython](circuitpython.md)** | ✅ | ✅ | — | — | — | — |
+| **[CPython](cpython-desktop.md)** | — | ✅ | ✅ | ✅ [Android](android.md) | — | ✅ [Jupyter](jupyter.md) |
 
 ## How portability works
 
@@ -38,6 +38,7 @@ See [Displays](../concepts/displays.md) for backend details and [Architecture](.
 - [MicroPython](micropython.md) — MCUs, Unix, Windows, bus drivers, frozen firmware.
 - [CircuitPython](circuitpython.md) — MCUs and Unix; `framebufferio` and the `framebuf` shim.
 - [CPython desktop](cpython-desktop.md) — SDL2 / PyGame setup for Linux, macOS, and Windows.
+- [Android](android.md) — CPython APK builds with python-for-android and buildozer.
 - [Jupyter Notebook](jupyter.md) — interactive display widget and async execution model.
 - [Run the notebook interactively](jupyter-run.md) — JupyterLab / VS Code setup (the RTD notebook page is static).
 - [PyScript](pyscript.md) — running in the browser.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -104,6 +104,7 @@ nav:
     - MicroPython: platforms/micropython.md
     - CircuitPython: platforms/circuitpython.md
     - CPython desktop: platforms/cpython-desktop.md
+    - Android: platforms/android.md
     - Jupyter: platforms/jupyter.md
     - Run interactively: platforms/jupyter-run.md
     - Jupyter notebook: platforms/jupyter-notebook.ipynb


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds platform documentation for Android CPython APK builds, pointing to the new [pydisplay_android](https://github.com/PyDevices/pydisplay_android) repo.

## Changes

- New `docs/platforms/android.md` — workspace layout, quick start, LVGL notes
- Updated `docs/platforms/index.md` — Android column in platform matrix
- Updated `mkdocs.yml` nav

No multimer code changes (handled separately).

## Related

- https://github.com/PyDevices/pydisplay_android
- usdl2 trim PR (removes android_demo from usdl2)
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-5727508b-9448-4254-8184-95edcd10d8c1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-5727508b-9448-4254-8184-95edcd10d8c1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

