### PR TITLE
Fix TestPyPI publish for multimer nested _backends package

### DIFF
--- a/scripts/publish_make_pyproject.py
+++ b/scripts/publish_make_pyproject.py
@@ -103,8 +103,13 @@ def build(manifest_path, output_path):
             sys.exit(1)
 
         # "foo/bar/baz.py" --> "foo"
+        # "foo/nested/bar/baz.py" --> "foo" (not "foo/nested")
         # "baz.py" --> ""
-        result_package = os.path.split(result.target_path)[0]
+        normalized = result.target_path.replace("\\", "/")
+        if "/" in normalized:
+            result_package = normalized.split("/", 1)[0]
+        else:
+            result_package = ""
 
         if not result_package:
             # This is a standalone .py file.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

The `v0.0.7` publish workflow failed when building the `multimer` TestPyPI wheel:

```
Error: More than one top-level package: multimer/_backends, multimer.
```

`publish_make_pyproject.py` used `os.path.split()` on each file path, which treats the immediate parent directory as the top-level package. For `multimer/_backends/*.py` that incorrectly yields `multimer/_backends` instead of `multimer`.

## Fix

Use only the first path component when validating the package layout and generating `[tool.hatch.build] packages`.

## Verification

Reproduced locally with a synthetic micropython-lib `multimer` tree; `publish_make_pyproject.py` now completes and emits `packages = ["multimer"]`.

## After merge

Re-run the publish workflow (workflow_dispatch with version `0.0.7`, or tag `v0.0.8` if you prefer a clean semver bump).
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-a5fccd37-a13b-4312-86f3-539cdd127b24"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-a5fccd37-a13b-4312-86f3-539cdd127b24"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

