### PR TITLE
Fix displaysys board_config paths in micropython-lib publish

### DIFF
--- a/scripts/publish_micropython_lib.sh
+++ b/scripts/publish_micropython_lib.sh
@@ -158,6 +158,43 @@ pypi_publish_name() {
     esac
 }
 
+# Representative board_config.py for micropython-lib displaysys-* example trees.
+# Board configs live in nested directories; only a few desktop backends have a
+# flat board_configs/<name>/board_config.py path.
+displaysys_example_board_config_path() {
+    local package="$1"
+    local board_configs="$SOURCE_REPO/board_configs"
+    case "$package" in
+        displaysys-busdisplay) echo "$board_configs/busdisplay/i80/wt32sc01-plus/board_config.py" ;;
+        displaysys-fbdisplay) echo "$board_configs/fbdisplay/qualia_tl040hds20/board_config.py" ;;
+        displaysys-rgbdisplay) echo "$board_configs/fbdisplay/t-rgb_480/board_config.py" ;;
+        displaysys-epaperdisplay) echo "$board_configs/epaperdisplay/cp_magtag/board_config.py" ;;
+        displaysys-pixeldisplay) echo "$board_configs/pixeldisplay/cp_neopixel_8x8_zigzag/board_config.py" ;;
+        displaysys-jndisplay) echo "$board_configs/jndisplay/board_config.py" ;;
+        displaysys-pgdisplay) echo "$board_configs/pgdisplay/board_config.py" ;;
+        displaysys-psdisplay) echo "$board_configs/psdisplay/board_config.py" ;;
+        displaysys-sdldisplay) echo "$board_configs/sdldisplay/board_config.py" ;;
+        displaysys-boarddisplay) return 1 ;;
+        *) return 1 ;;
+    esac
+}
+
+copy_displaysys_example_board_config() {
+    local package="$1"
+    local dest_dir="$2"
+    local src=""
+
+    if ! src="$(displaysys_example_board_config_path "$package")"; then
+        echo "Skipping example board_config for $package"
+        return 0
+    fi
+    if [[ ! -f "$src" ]]; then
+        echo "Warning: example board_config not found for $package: $src" >&2
+        return 0
+    fi
+    cp "$src" "$dest_dir/"
+}
+
 copy_source_tree() {
     local src="$1"
     local dest="$2"
@@ -308,15 +345,7 @@ EOF
         # hatch build
         # twine upload --repository testpypi dist/*
         # popd
-        if [[ $package == displaysys-busdisplay ]]; then
-            cp $SOURCE_DIR/../board_configs/busdisplay/i80/wt32sc01-plus/board_config.py $DEST_DIR/displaysys/$package/examples/
-        else
-            if [[ $package == displaysys-fbdisplay ]]; then
-                cp $SOURCE_DIR/../board_configs/fbdisplay/qualia_tl040hds20/board_config.py $DEST_DIR/displaysys/$package/examples/
-            else
-                cp $SOURCE_DIR/../board_configs/$package_dir/board_config.py $DEST_DIR/displaysys/$package/examples/
-            fi
-        fi
+        copy_displaysys_example_board_config "$package" "$DEST_DIR/displaysys/$package/examples/"
     fi
 done
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

After the multimer fix (#48), the publish workflow failed on `displaysys-boarddisplay`:

```
cp: cannot stat '.../board_configs/boarddisplay/board_config.py': No such file or directory
```

The script assumed every `displaysys-*` package has a flat `board_configs/<name>/board_config.py`. Most backends use nested trees (`busdisplay/i80/...`, `epaperdisplay/cp_magtag`, etc.). `boarddisplay` has no config tree at all (CP-only `BoardDisplay` adapter).

## Fix

Add explicit mappings from each `displaysys-*` package to a representative example `board_config.py`, and skip `displaysys-boarddisplay` instead of failing.

## After merge

Re-run **Publish micropython-lib** (workflow_dispatch with version `0.0.7`, or tag `v0.0.8`).
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-a5fccd37-a13b-4312-86f3-539cdd127b24"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-a5fccd37-a13b-4312-86f3-539cdd127b24"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

