### PR TITLE
Add plug-in fbdisplay board configs for accelerated interfaces

### DIFF
--- a/board_configs/fbdisplay/cp_mimxrt1060_evk_rk043_rgb/board_config.py
+++ b/board_configs/fbdisplay/cp_mimxrt1060_evk_rk043_rgb/board_config.py
@@ -1,0 +1,70 @@
+"""NXP MIMXRT1060-EVK + RK043FN66HS-CTG 4.3\" parallel RGB — CircuitPython"""
+
+import board
+import displayio
+import time
+
+from displaysys.fbdisplay import FBDisplay
+import eventsys
+
+displayio.release_displays()
+
+try:
+    from rgbframebuffer import RGBFrameBuffer
+except ImportError as exc:
+    raise NotImplementedError(
+        "Parallel RGB scanout requires displayif rgbframebuffer cmod (mimxrt eLCDIF)"
+    ) from exc
+
+board.LCD_BACKLIGHT.value = True
+
+board.LCD_RST.value = False
+time.sleep(0.01)
+board.LCD_RST.value = True
+time.sleep(0.12)
+
+data_pins = (
+    board.LCD_D0,
+    board.LCD_D1,
+    board.LCD_D2,
+    board.LCD_D3,
+    board.LCD_D4,
+    board.LCD_D5,
+    board.LCD_D6,
+    board.LCD_D7,
+    board.LCD_D8,
+    board.LCD_D9,
+    board.LCD_D10,
+    board.LCD_D11,
+    board.LCD_D12,
+    board.LCD_D13,
+    board.LCD_D14,
+    board.LCD_D15,
+)
+
+fb = RGBFrameBuffer(
+    de=board.LCD_ENABLE,
+    vsync=board.LCD_VSYNC,
+    hsync=board.LCD_HSYNC,
+    dclk=board.LCD_CLK,
+    data=data_pins,
+    frequency=9_000_000,
+    width=480,
+    height=272,
+    hsync_pulse_width=41,
+    hsync_front_porch=4,
+    hsync_back_porch=8,
+    vsync_pulse_width=10,
+    vsync_front_porch=4,
+    vsync_back_porch=2,
+    hsync_idle_low=True,
+    vsync_idle_low=True,
+    de_idle_high=False,
+    pclk_active_high=False,
+    pclk_idle_high=False,
+)
+
+display_drv = FBDisplay(fb)
+
+broker = eventsys.Broker()
+broker.register_quit_cleanup(display_drv)

--- a/board_configs/fbdisplay/cp_mimxrt1060_evk_rk043_rgb/package.json
+++ b/board_configs/fbdisplay/cp_mimxrt1060_evk_rk043_rgb/package.json
@@ -1,0 +1,9 @@
+{
+  "urls": [
+    ["board_config.py", "github:PyDevices/pydisplay/board_configs/fbdisplay/cp_mimxrt1060_evk_rk043_rgb/board_config.py"]
+  ],
+  "deps": [
+    ["github:PyDevices/pydisplay/packages/displaysys.json", "main"]
+  ],
+  "version": "0.1"
+}

--- a/board_configs/fbdisplay/cp_mimxrt1170_evk_waveshare_5dsi/board_config.py
+++ b/board_configs/fbdisplay/cp_mimxrt1170_evk_waveshare_5dsi/board_config.py
@@ -1,0 +1,44 @@
+"""NXP MIMXRT1170-EVK + Waveshare 5\" DSI (800×480) on J84 — CircuitPython
+
+Board: https://circuitpython.org/board/nxp_mimxrt1170_evk/
+Waveshare 5\" DSI on J84 (15-pin RPi-style FFC) + 5 V on J85.
+"""
+
+import board
+import displayio
+
+from displaysys.fbdisplay import FBDisplay
+import eventsys
+
+displayio.release_displays()
+
+try:
+    from mipidsi import Bus, Display
+except ImportError as exc:
+    raise NotImplementedError(
+        "MIPI DSI requires displayif mipidsi cmod (mimxrt1176 port)"
+    ) from exc
+
+PANEL_INIT_SEQUENCE = b""
+
+bus = mipidsi.Bus(frequency=1_000_000_000, num_lanes=2)
+
+fb = Display(
+    bus,
+    init_sequence=PANEL_INIT_SEQUENCE,
+    width=800,
+    height=480,
+    color_depth=16,
+    pixel_clock_frequency=32_000_000,
+    hsync_pulse_width=70,
+    hsync_front_porch=40,
+    hsync_back_porch=40,
+    vsync_pulse_width=10,
+    vsync_front_porch=13,
+    vsync_back_porch=29,
+)
+
+display_drv = FBDisplay(fb)
+
+broker = eventsys.Broker()
+broker.register_quit_cleanup(display_drv)

--- a/board_configs/fbdisplay/cp_mimxrt1170_evk_waveshare_5dsi/package.json
+++ b/board_configs/fbdisplay/cp_mimxrt1170_evk_waveshare_5dsi/package.json
@@ -1,0 +1,9 @@
+{
+  "urls": [
+    ["board_config.py", "github:PyDevices/pydisplay/board_configs/fbdisplay/cp_mimxrt1170_evk_waveshare_5dsi/board_config.py"]
+  ],
+  "deps": [
+    ["github:PyDevices/pydisplay/packages/displaysys.json", "main"]
+  ],
+  "version": "0.1"
+}

--- a/board_configs/fbdisplay/cp_pico2_dvi_sock_640x480/board_config.py
+++ b/board_configs/fbdisplay/cp_pico2_dvi_sock_640x480/board_config.py
@@ -1,0 +1,32 @@
+"""Raspberry Pi Pico 2 + Adafruit DVI Sock (HSTX) — CircuitPython
+
+Pin map from Adafruit DVI Sock guide (HSTX on RP2350).
+"""
+
+import board
+import displayio
+import picodvi
+
+from displaysys.fbdisplay import FBDisplay
+import eventsys
+
+displayio.release_displays()
+
+fb = picodvi.Framebuffer(
+    width=640,
+    height=480,
+    color_depth=8,
+    clk_dp=board.GP14,
+    clk_dn=board.GP15,
+    red_dp=board.GP12,
+    red_dn=board.GP13,
+    green_dp=board.GP18,
+    green_dn=board.GP19,
+    blue_dp=board.GP16,
+    blue_dn=board.GP17,
+)
+
+display_drv = FBDisplay(fb)
+
+broker = eventsys.Broker()
+broker.register_quit_cleanup(display_drv)

--- a/board_configs/fbdisplay/cp_pico2_dvi_sock_640x480/package.json
+++ b/board_configs/fbdisplay/cp_pico2_dvi_sock_640x480/package.json
@@ -1,0 +1,9 @@
+{
+  "urls": [
+    ["board_config.py", "github:PyDevices/pydisplay/board_configs/fbdisplay/cp_pico2_dvi_sock_640x480/board_config.py"]
+  ],
+  "deps": [
+    ["github:PyDevices/pydisplay/packages/displaysys.json", "main"]
+  ],
+  "version": "0.1"
+}

--- a/board_configs/fbdisplay/cp_pimoroni_pico_dv_base_640x480/board_config.py
+++ b/board_configs/fbdisplay/cp_pimoroni_pico_dv_base_640x480/board_config.py
@@ -1,0 +1,29 @@
+"""Pimoroni Pico DV Demo Base + Raspberry Pi Pico (RP2040) — CircuitPython"""
+
+import board
+import displayio
+import picodvi
+
+from displaysys.fbdisplay import FBDisplay
+import eventsys
+
+displayio.release_displays()
+
+fb = picodvi.Framebuffer(
+    width=640,
+    height=480,
+    color_depth=8,
+    clk_dp=board.CKP,
+    clk_dn=board.CKN,
+    red_dp=board.D0P,
+    red_dn=board.D0N,
+    green_dp=board.D1P,
+    green_dn=board.D1N,
+    blue_dp=board.D2P,
+    blue_dn=board.D2N,
+)
+
+display_drv = FBDisplay(fb)
+
+broker = eventsys.Broker()
+broker.register_quit_cleanup(display_drv)

--- a/board_configs/fbdisplay/cp_pimoroni_pico_dv_base_640x480/package.json
+++ b/board_configs/fbdisplay/cp_pimoroni_pico_dv_base_640x480/package.json
@@ -1,0 +1,9 @@
+{
+  "urls": [
+    ["board_config.py", "github:PyDevices/pydisplay/board_configs/fbdisplay/cp_pimoroni_pico_dv_base_640x480/board_config.py"]
+  ],
+  "deps": [
+    ["github:PyDevices/pydisplay/packages/displaysys.json", "main"]
+  ],
+  "version": "0.1"
+}

--- a/board_configs/fbdisplay/feather_rp2040_rgb_matrix_64x32/board_config.py
+++ b/board_configs/fbdisplay/feather_rp2040_rgb_matrix_64x32/board_config.py
@@ -1,0 +1,30 @@
+"""Adafruit Feather RP2040 + RGB Matrix FeatherWing 64×32 — MicroPython
+
+Plug-in stack (Feather headers only):
+- Adafruit Feather RP2040: https://circuitpython.org/board/adafruit_feather_rp2040/
+- Adafruit RGB Matrix FeatherWing on Feather socket
+
+Pin map matches CircuitPython ``cp_rgb_matrix_featherwing_64x32``.
+
+CircuitPython sibling: ``cp_feather_rp2040_rgb_matrix_64x32``.
+"""
+
+import rgbmatrix
+from displaysys.fbdisplay import FBDisplay
+import eventsys
+
+matrix = rgbmatrix.RGBMatrix(
+    width=64,
+    height=32,
+    bit_depth=4,
+    rgb_pins=(26, 27, 28, 29, 18, 19),  # A0..A3, SCK/MOSI as A4/A5
+    addr_pins=(8, 9, 10, 11),  # D6, D9, D10, D11
+    clock_pin=12,  # D12
+    latch_pin=1,  # D0
+    output_enable_pin=0,  # D1
+)
+
+display_drv = FBDisplay(matrix, width=64, height=32)
+
+broker = eventsys.Broker()
+broker.register_quit_cleanup(display_drv)

--- a/board_configs/fbdisplay/feather_rp2040_rgb_matrix_64x32/package.json
+++ b/board_configs/fbdisplay/feather_rp2040_rgb_matrix_64x32/package.json
@@ -1,0 +1,9 @@
+{
+  "urls": [
+    ["board_config.py", "github:PyDevices/pydisplay/board_configs/fbdisplay/feather_rp2040_rgb_matrix_64x32/board_config.py"]
+  ],
+  "deps": [
+    ["github:PyDevices/pydisplay/packages/displaysys.json", "main"]
+  ],
+  "version": "0.1"
+}

--- a/board_configs/fbdisplay/mimxrt1060_evk_rk043_rgb/board_config.py
+++ b/board_configs/fbdisplay/mimxrt1060_evk_rk043_rgb/board_config.py
@@ -1,0 +1,85 @@
+"""NXP MIMXRT1060-EVK + RK043FN66HS-CTG 4.3\" parallel RGB — MicroPython
+
+Hardware (plug-in, no breadboard wiring):
+- MIMXRT1060-EVK / EVKB: https://circuitpython.org/board/imxrt1060_evk/
+- RK043FN66HS-CTG shield on J49 (40-pin parallel FPC + 6-pin touch I2C)
+
+Targets displayif ``rgbframebuffer`` (NXP eLCDIF) on mimxrt.  Pin names match
+CircuitPython ``board.LCD_*`` on imxrt1060_evk; MicroPython uses ``GPIO_B*`` cpu
+pin names from the NXP EVK LCDIF mux (MCUXpresso BOARD_InitLCDPins).
+
+CircuitPython sibling: ``cp_mimxrt1060_evk_rk043_rgb``.
+"""
+
+from machine import Pin
+import time
+
+from displaysys.fbdisplay import FBDisplay
+import eventsys
+
+try:
+    from rgbframebuffer import RGBFrameBuffer
+except ImportError as exc:
+    raise NotImplementedError(
+        "Parallel RGB scanout requires displayif rgbframebuffer cmod (mimxrt eLCDIF)"
+    ) from exc
+
+# RK043 panel control (EVK routes through shield / EVK GPIO)
+LCD_BACKLIGHT = Pin("GPIO_B1_15", Pin.OUT, value=1)
+LCD_RESET = Pin("GPIO_AD_B0_02", Pin.OUT, value=1)
+
+LCD_RESET.value(0)
+time.sleep_ms(10)
+LCD_RESET.value(1)
+time.sleep_ms(120)
+
+# 16-bit RGB565 on LCD_D0..LCD_D15 (NXP SDK default for this shield)
+tft_pins = {
+    "de": Pin("GPIO_B0_01"),
+    "vsync": Pin("GPIO_B0_03"),
+    "hsync": Pin("GPIO_B0_02"),
+    "dclk": Pin("GPIO_B0_00"),
+    "data": (
+        Pin("GPIO_B0_04"),
+        Pin("GPIO_B0_05"),
+        Pin("GPIO_B0_06"),
+        Pin("GPIO_B0_07"),
+        Pin("GPIO_B0_08"),
+        Pin("GPIO_B0_09"),
+        Pin("GPIO_B0_10"),
+        Pin("GPIO_B0_11"),
+        Pin("GPIO_B0_12"),
+        Pin("GPIO_B0_13"),
+        Pin("GPIO_B0_14"),
+        Pin("GPIO_B0_15"),
+        Pin("GPIO_B1_00"),
+        Pin("GPIO_B1_01"),
+        Pin("GPIO_B1_02"),
+        Pin("GPIO_B1_03"),
+    ),
+}
+
+# Timings from NXP ELCDIF_RgbModeGetDefaultConfig (480×272 RK043)
+tft_timings = {
+    "frequency": 9_000_000,
+    "width": 480,
+    "height": 272,
+    "hsync_pulse_width": 41,
+    "hsync_front_porch": 4,
+    "hsync_back_porch": 8,
+    "vsync_pulse_width": 10,
+    "vsync_front_porch": 4,
+    "vsync_back_porch": 2,
+    "hsync_idle_low": True,
+    "vsync_idle_low": True,
+    "de_idle_high": False,
+    "pclk_active_high": False,
+    "pclk_idle_high": False,
+}
+
+fb = RGBFrameBuffer(**tft_pins, **tft_timings)
+
+display_drv = FBDisplay(fb)
+
+broker = eventsys.Broker()
+broker.register_quit_cleanup(display_drv)

--- a/board_configs/fbdisplay/mimxrt1060_evk_rk043_rgb/package.json
+++ b/board_configs/fbdisplay/mimxrt1060_evk_rk043_rgb/package.json
@@ -1,0 +1,9 @@
+{
+  "urls": [
+    ["board_config.py", "github:PyDevices/pydisplay/board_configs/fbdisplay/mimxrt1060_evk_rk043_rgb/board_config.py"]
+  ],
+  "deps": [
+    ["github:PyDevices/pydisplay/packages/displaysys.json", "main"]
+  ],
+  "version": "0.1"
+}

--- a/board_configs/fbdisplay/mimxrt1170_evk_waveshare_5dsi/board_config.py
+++ b/board_configs/fbdisplay/mimxrt1170_evk_waveshare_5dsi/board_config.py
@@ -1,0 +1,51 @@
+"""NXP MIMXRT1170-EVK + Waveshare 5\" DSI (800×480) on J84 — MicroPython
+
+Hardware (plug-in FFC, no breadboard wiring):
+- MIMXRT1170-EVK / EVKB: https://circuitpython.org/board/nxp_mimxrt1170_evk/
+- Waveshare 5\" DSI LCD (800×480, 15-pin Raspberry Pi-style DSI FFC) on EVK **J84**
+- Panel 5 V from EVK **J85** (5 V to pin 1, GND to pin 2) per NXP SDK RPi-panel notes
+- Board: 5 V on **J43**, jumper **J38** at 1–2
+
+Uses the same 15-pin DSI connector as the Raspberry Pi 7\" touch display.  The Waveshare
+5\" panel is DPI-over-DSI; panel init and DPI timings are supplied when displayif
+``mipidsi`` lands for RT1176 (NXP ``fsl_mipi_dsi`` + ``display_support`` panel table).
+
+CircuitPython sibling: ``cp_mimxrt1170_evk_waveshare_5dsi``.
+"""
+
+from displaysys.fbdisplay import FBDisplay
+import eventsys
+
+try:
+    from mipidsi import Bus, Display
+except ImportError as exc:
+    raise NotImplementedError(
+        "MIPI DSI requires displayif mipidsi cmod (mimxrt1176 port)"
+    ) from exc
+
+# Placeholder until mimxrt panel driver supplies vendor init (Waveshare / RPi DPI panel).
+PANEL_INIT_SEQUENCE = b""
+
+# MIPI DSI bus — 2 lanes, 1 Gbps/lane (tune with displayif driver / NXP BSP)
+bus = Bus(frequency=1_000_000_000, num_lanes=2)
+
+# DPI timings for 800×480 @ ~60 Hz (RPi-class panel; refine per panel driver)
+fb = Display(
+    bus,
+    init_sequence=PANEL_INIT_SEQUENCE,
+    width=800,
+    height=480,
+    color_depth=16,
+    pixel_clock_frequency=32_000_000,
+    hsync_pulse_width=70,
+    hsync_front_porch=40,
+    hsync_back_porch=40,
+    vsync_pulse_width=10,
+    vsync_front_porch=13,
+    vsync_back_porch=29,
+)
+
+display_drv = FBDisplay(fb)
+
+broker = eventsys.Broker()
+broker.register_quit_cleanup(display_drv)

--- a/board_configs/fbdisplay/mimxrt1170_evk_waveshare_5dsi/package.json
+++ b/board_configs/fbdisplay/mimxrt1170_evk_waveshare_5dsi/package.json
@@ -1,0 +1,9 @@
+{
+  "urls": [
+    ["board_config.py", "github:PyDevices/pydisplay/board_configs/fbdisplay/mimxrt1170_evk_waveshare_5dsi/board_config.py"]
+  ],
+  "deps": [
+    ["github:PyDevices/pydisplay/packages/displaysys.json", "main"]
+  ],
+  "version": "0.1"
+}

--- a/board_configs/fbdisplay/pico2_dvi_sock_640x480/board_config.py
+++ b/board_configs/fbdisplay/pico2_dvi_sock_640x480/board_config.py
@@ -1,0 +1,44 @@
+"""Raspberry Pi Pico 2 + Adafruit DVI Sock (HSTX) — MicroPython
+
+Plug-in stack:
+- Raspberry Pi Pico 2 / Pico 2 W: https://circuitpython.org/board/raspberry_pi_pico2/
+- Adafruit DVI Sock for Pico (HSTX differential pairs on GP12–GP19, CK on GP14/15)
+
+Pimoroni Pico DV Demo Base uses a different pin map and is **not** HSTX-compatible on
+Pico 2 — use this config with the Adafruit DVI Sock instead.
+
+Targets displayif ``picodvi`` (RP2350 HSTX backend).
+
+CircuitPython sibling: ``cp_pico2_dvi_sock_640x480``.
+"""
+
+from machine import Pin
+
+from displaysys.fbdisplay import FBDisplay
+import eventsys
+
+try:
+    from picodvi import Framebuffer
+except ImportError as exc:
+    raise NotImplementedError(
+        "DVI output requires displayif picodvi cmod (rp2350 HSTX)"
+    ) from exc
+
+fb = Framebuffer(
+    width=640,
+    height=480,
+    color_depth=8,
+    clk_dp=Pin(14),
+    clk_dn=Pin(15),
+    red_dp=Pin(12),
+    red_dn=Pin(13),
+    green_dp=Pin(18),
+    green_dn=Pin(19),
+    blue_dp=Pin(16),
+    blue_dn=Pin(17),
+)
+
+display_drv = FBDisplay(fb)
+
+broker = eventsys.Broker()
+broker.register_quit_cleanup(display_drv)

--- a/board_configs/fbdisplay/pico2_dvi_sock_640x480/package.json
+++ b/board_configs/fbdisplay/pico2_dvi_sock_640x480/package.json
@@ -1,0 +1,9 @@
+{
+  "urls": [
+    ["board_config.py", "github:PyDevices/pydisplay/board_configs/fbdisplay/pico2_dvi_sock_640x480/board_config.py"]
+  ],
+  "deps": [
+    ["github:PyDevices/pydisplay/packages/displaysys.json", "main"]
+  ],
+  "version": "0.1"
+}

--- a/board_configs/fbdisplay/pimoroni_pico_dv_base_640x480/board_config.py
+++ b/board_configs/fbdisplay/pimoroni_pico_dv_base_640x480/board_config.py
@@ -1,0 +1,42 @@
+"""Pimoroni Pico DV Demo Base + Raspberry Pi Pico (RP2040) — MicroPython
+
+Plug-in stack (no breadboard wiring):
+- Raspberry Pi Pico in socket headers: https://circuitpython.org/board/raspberry_pi_pico/
+- Pimoroni Pico DV Demo Base HDMI: https://circuitpython.org/board/pimoroni_pico_dv_base/
+
+DVI pinout matches CircuitPython ``board.CKP`` / ``D0P`` aliases on pimoroni_pico_dv_base
+(GP6–GP13).  Targets displayif ``picodvi`` (PIO bit-bang on RP2040).
+
+CircuitPython sibling: ``cp_pimoroni_pico_dv_base_640x480``.
+"""
+
+from machine import Pin
+
+from displaysys.fbdisplay import FBDisplay
+import eventsys
+
+try:
+    from picodvi import Framebuffer
+except ImportError as exc:
+    raise NotImplementedError(
+        "DVI output requires displayif picodvi cmod (rp2 PIO or RP2350 HSTX)"
+    ) from exc
+
+fb = Framebuffer(
+    width=640,
+    height=480,
+    color_depth=8,
+    clk_dp=Pin(7),
+    clk_dn=Pin(6),
+    red_dp=Pin(9),
+    red_dn=Pin(8),
+    green_dp=Pin(11),
+    green_dn=Pin(10),
+    blue_dp=Pin(13),
+    blue_dn=Pin(12),
+)
+
+display_drv = FBDisplay(fb)
+
+broker = eventsys.Broker()
+broker.register_quit_cleanup(display_drv)

--- a/board_configs/fbdisplay/pimoroni_pico_dv_base_640x480/package.json
+++ b/board_configs/fbdisplay/pimoroni_pico_dv_base_640x480/package.json
@@ -1,0 +1,9 @@
+{
+  "urls": [
+    ["board_config.py", "github:PyDevices/pydisplay/board_configs/fbdisplay/pimoroni_pico_dv_base_640x480/board_config.py"]
+  ],
+  "deps": [
+    ["github:PyDevices/pydisplay/packages/displaysys.json", "main"]
+  ],
+  "version": "0.1"
+}

--- a/packages/mipidsi.json
+++ b/packages/mipidsi.json
@@ -1,0 +1,8 @@
+{
+  "urls": [],
+  "deps": [
+    ["github:PyDevices/pydisplay/packages/displaysys.json", "main"]
+  ],
+  "version": "0.1",
+  "notes": "Board configs that import displayif mipidsi (MIPI DSI host)."
+}

--- a/packages/picodvi.json
+++ b/packages/picodvi.json
@@ -1,0 +1,8 @@
+{
+  "urls": [],
+  "deps": [
+    ["github:PyDevices/pydisplay/packages/displaysys.json", "main"]
+  ],
+  "version": "0.1",
+  "notes": "Board configs that import displayif picodvi (RP2040 PIO / RP2350 HSTX DVI)."
+}

--- a/packages/rgbframebuffer.json
+++ b/packages/rgbframebuffer.json
@@ -1,0 +1,8 @@
+{
+  "urls": [],
+  "deps": [
+    ["github:PyDevices/pydisplay/packages/displaysys.json", "main"]
+  ],
+  "version": "0.1",
+  "notes": "Board configs that import displayif rgbframebuffer (parallel RGB / eLCDIF)."
+}

--- a/scripts/install_refresh_manifests.sh
+++ b/scripts/install_refresh_manifests.sh
@@ -34,6 +34,9 @@ MANUAL_PACKAGES=(
     packages/pixeldisplay.json
     packages/epaperdisplay.json
     packages/rgbdisplay.json
+    packages/rgbframebuffer.json
+    packages/mipidsi.json
+    packages/picodvi.json
     packages/tt21100.json
     packages/stmpe610.json
     packages/keypad_shift.json
@@ -65,8 +68,11 @@ Not generated here (edit manually when drivers/bus/ or drivers/touch/ changes):
   packages/boarddisplay.json
   packages/pixeldisplay.json
   packages/epaperdisplay.json
-  packages/rgbdisplay.json
-  packages/tt21100.json
+    packages/rgbdisplay.json
+    packages/rgbframebuffer.json
+    packages/mipidsi.json
+    packages/picodvi.json
+    packages/tt21100.json
   packages/stmpe610.json
   packages/keypad_shift.json
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds MicroPython and CircuitPython `board_config.py` pairs for plug-in hardware (no breadboard wiring), using board references from [circuitpython.org/downloads](https://circuitpython.org/downloads).

| Config | Module | Hardware |
|--------|--------|----------|
| `mimxrt1060_evk_rk043_rgb` | `rgbframebuffer` | MIMXRT1060-EVK + RK043FN66HS-CTG shield (J49) |
| `mimxrt1170_evk_waveshare_5dsi` | `mipidsi` | MIMXRT1170-EVK + Waveshare 5" DSI on J84 |
| `pimoroni_pico_dv_base_640x480` | `picodvi` | RP2040 Pico in Pimoroni Pico DV Base |
| `pico2_dvi_sock_640x480` | `picodvi` | Pico 2 + Adafruit DVI Sock (HSTX pins) |
| `feather_rp2040_rgb_matrix_64x32` | `rgbmatrix` | Feather RP2040 + RGB Matrix FeatherWing |

Also adds MIP package manifests: `rgbframebuffer.json`, `mipidsi.json`, `picodvi.json`.

Configs import native displayif modules and raise `NotImplementedError` until the matching SDK backends land (see companion displayif PR).

## Test plan

- [ ] Verify board_config.py syntax (`python3 -m py_compile` on new configs)
- [ ] Hardware validation after displayif drivers are implemented
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-347dece3-c28e-419c-ad8e-5a1d1541d50b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-347dece3-c28e-419c-ad8e-5a1d1541d50b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

