### PR TITLE
fbdisplay: Waveshare 50H-800480-IPS timings, MP/CP pairs, touch input

### DIFF
--- a/board_configs/fbdisplay/cp_feather_rp2040_rgb_matrix_64x32/board_config.py
+++ b/board_configs/fbdisplay/cp_feather_rp2040_rgb_matrix_64x32/board_config.py
@@ -1,0 +1,42 @@
+"""Adafruit Feather RP2040 + RGB Matrix FeatherWing 64×32 — CircuitPython
+
+Plug-in stack (Feather headers only):
+- Adafruit Feather RP2040: https://circuitpython.org/board/adafruit_feather_rp2040/
+- Adafruit RGB Matrix FeatherWing on Feather socket
+
+Pin map matches MicroPython ``feather_rp2040_rgb_matrix_64x32``.
+
+CircuitPython sibling: ``feather_rp2040_rgb_matrix_64x32``.
+"""
+
+import board
+import displayio
+import rgbmatrix
+
+from displaysys.fbdisplay import FBDisplay
+import eventsys
+
+displayio.release_displays()
+
+matrix = rgbmatrix.RGBMatrix(
+    width=64,
+    height=32,
+    bit_depth=4,
+    rgb_pins=[
+        board.A0,
+        board.A1,
+        board.A2,
+        board.A3,
+        board.A4,
+        board.A5,
+    ],
+    addr_pins=[board.D6, board.D9, board.D10, board.D11],
+    clock_pin=board.D12,
+    latch_pin=board.D0,
+    output_enable_pin=board.D1,
+)
+
+display_drv = FBDisplay(matrix, width=64, height=32)
+
+broker = eventsys.Broker()
+broker.register_quit_cleanup(display_drv)

--- a/board_configs/fbdisplay/cp_feather_rp2040_rgb_matrix_64x32/package.json
+++ b/board_configs/fbdisplay/cp_feather_rp2040_rgb_matrix_64x32/package.json
@@ -1,0 +1,9 @@
+{
+  "urls": [
+    ["board_config.py", "github:PyDevices/pydisplay/board_configs/fbdisplay/cp_feather_rp2040_rgb_matrix_64x32/board_config.py"]
+  ],
+  "deps": [
+    ["github:PyDevices/pydisplay/packages/displaysys.json", "main"]
+  ],
+  "version": "0.1"
+}

--- a/board_configs/fbdisplay/cp_mimxrt1060_evk_rk043_rgb/board_config.py
+++ b/board_configs/fbdisplay/cp_mimxrt1060_evk_rk043_rgb/board_config.py
@@ -1,7 +1,14 @@
-"""NXP MIMXRT1060-EVK + RK043FN66HS-CTG 4.3\" parallel RGB — CircuitPython"""
+"""NXP MIMXRT1060-EVK + RK043FN66HS-CTG 4.3\" parallel RGB — CircuitPython
+
+Touch: Goodix GT911 on shield I2C (``board.SCL`` / ``board.SDA``), reset on
+``board.LCD_RST``, interrupt on ``board.LCD_TOUCH_INT``.
+"""
 
 import board
+import busio
 import displayio
+import digitalio
+import gt911
 import time
 
 from displaysys.fbdisplay import FBDisplay
@@ -66,5 +73,28 @@ fb = RGBFrameBuffer(
 
 display_drv = FBDisplay(fb)
 
+i2c = busio.I2C(board.SCL, board.SDA)
+touch_rst = digitalio.DigitalInOut(board.LCD_RST)
+touch_rst.direction = digitalio.Direction.OUTPUT
+touch_drv = gt911.GT911(i2c, i2c_address=0x5D, rst_pin=touch_rst)
+
+
+def touch_read_func():
+    touches = touch_drv.touches
+    if touches:
+        return touches[0][0], touches[0][1]
+    return None
+
+
+touch_rotation_table = (0, 0, 0, 0)
+
 broker = eventsys.Broker()
+
+touch_dev = broker.create(
+    type=eventsys.TOUCH,
+    read=touch_read_func,
+    data=display_drv,
+    data2=touch_rotation_table,
+)
+
 broker.register_quit_cleanup(display_drv)

--- a/board_configs/fbdisplay/cp_mimxrt1170_evk_waveshare_5dsi/board_config.py
+++ b/board_configs/fbdisplay/cp_mimxrt1170_evk_waveshare_5dsi/board_config.py
@@ -1,10 +1,10 @@
-"""NXP MIMXRT1170-EVK + Waveshare 5\" DSI (800×480) on J84 — CircuitPython
+"""NXP MIMXRT1170-EVK + Waveshare 50H-800480-IPS DSI (800×480) on J84 — CircuitPython
 
 Board: https://circuitpython.org/board/nxp_mimxrt1170_evk/
-Waveshare 5\" DSI on J84 (15-pin RPi-style FFC) + 5 V on J85.
+Panel: https://www.waveshare.com/wiki/50H-800480-IPS#Interface_Definition
+Waveshare 50H-800480-IPS on J84 (15-pin RPi-style FFC) + 5 V on J85.
 """
 
-import board
 import displayio
 
 from displaysys.fbdisplay import FBDisplay
@@ -19,9 +19,10 @@ except ImportError as exc:
         "MIPI DSI requires displayif mipidsi cmod (mimxrt1176 port)"
     ) from exc
 
+# Empty init: displayif runs TC358762 bridge setup (RPi / Waveshare 50H-800480-IPS).
 PANEL_INIT_SEQUENCE = b""
 
-bus = mipidsi.Bus(frequency=1_000_000_000, num_lanes=2)
+bus = Bus(frequency=1_000_000_000, num_lanes=2)
 
 fb = Display(
     bus,
@@ -29,13 +30,13 @@ fb = Display(
     width=800,
     height=480,
     color_depth=16,
-    pixel_clock_frequency=32_000_000,
-    hsync_pulse_width=70,
-    hsync_front_porch=40,
-    hsync_back_porch=40,
-    vsync_pulse_width=10,
-    vsync_front_porch=13,
-    vsync_back_porch=29,
+    pixel_clock_frequency=25_979_400,
+    hsync_pulse_width=2,
+    hsync_front_porch=1,
+    hsync_back_porch=46,
+    vsync_pulse_width=2,
+    vsync_front_porch=7,
+    vsync_back_porch=21,
 )
 
 display_drv = FBDisplay(fb)

--- a/board_configs/fbdisplay/cp_mimxrt1170_evk_waveshare_5dsi/board_config.py
+++ b/board_configs/fbdisplay/cp_mimxrt1170_evk_waveshare_5dsi/board_config.py
@@ -3,9 +3,17 @@
 Board: https://circuitpython.org/board/nxp_mimxrt1170_evk/
 Panel: https://www.waveshare.com/wiki/50H-800480-IPS#Interface_Definition
 Waveshare 50H-800480-IPS on J84 (15-pin RPi-style FFC) + 5 V on J85.
+
+Touch (50H-800480-IPS-CT only): Goodix GT911 on I2C via J84 FFC pins 11–12
+(``board.SCL`` / ``board.SDA``).  Reset / interrupt on ``board.D9`` / ``board.D6``.
+Non-touch IPS panels omit the controller; display-only use still works.
 """
 
+import board
+import busio
+import digitalio
 import displayio
+import gt911
 
 from displaysys.fbdisplay import FBDisplay
 import eventsys
@@ -41,5 +49,28 @@ fb = Display(
 
 display_drv = FBDisplay(fb)
 
+i2c = busio.I2C(board.SCL, board.SDA)
+touch_rst = digitalio.DigitalInOut(board.D9)
+touch_rst.direction = digitalio.Direction.OUTPUT
+touch_drv = gt911.GT911(i2c, i2c_address=0x5D, rst_pin=touch_rst)
+
+
+def touch_read_func():
+    touches = touch_drv.touches
+    if touches:
+        return touches[0][0], touches[0][1]
+    return None
+
+
+touch_rotation_table = (0, 0, 0, 0)
+
 broker = eventsys.Broker()
+
+touch_dev = broker.create(
+    type=eventsys.TOUCH,
+    read=touch_read_func,
+    data=display_drv,
+    data2=touch_rotation_table,
+)
+
 broker.register_quit_cleanup(display_drv)

--- a/board_configs/fbdisplay/cp_qualia_tl040hds20/package.json
+++ b/board_configs/fbdisplay/cp_qualia_tl040hds20/package.json
@@ -1,0 +1,9 @@
+{
+  "urls": [
+    ["board_config.py", "github:PyDevices/pydisplay/board_configs/fbdisplay/cp_qualia_tl040hds20/board_config.py"]
+  ],
+  "deps": [
+    ["github:PyDevices/pydisplay/packages/displaysys.json", "main"]
+  ],
+  "version": "0.2"
+}

--- a/board_configs/fbdisplay/cp_rgb_matrix_featherwing_teensy41_64x32/board_config.py
+++ b/board_configs/fbdisplay/cp_rgb_matrix_featherwing_teensy41_64x32/board_config.py
@@ -1,0 +1,36 @@
+"""Adafruit RGB Matrix FeatherWing 64×32 — CircuitPython (Teensy 4.1)
+
+MicroPython sibling: ``rgb_matrix_featherwing_teensy41_64x32``.
+"""
+
+import board
+import displayio
+import rgbmatrix
+
+from displaysys.fbdisplay import FBDisplay
+import eventsys
+
+displayio.release_displays()
+
+matrix = rgbmatrix.RGBMatrix(
+    width=64,
+    height=32,
+    bit_depth=4,
+    rgb_pins=[
+        board.A0,
+        board.A1,
+        board.A2,
+        board.A3,
+        board.A4,
+        board.A5,
+    ],
+    addr_pins=[board.D6, board.D9, board.D10, board.D11],
+    clock_pin=board.D12,
+    latch_pin=board.D0,
+    output_enable_pin=board.D1,
+)
+
+display_drv = FBDisplay(matrix, width=64, height=32)
+
+broker = eventsys.Broker()
+broker.register_quit_cleanup(display_drv)

--- a/board_configs/fbdisplay/cp_rgb_matrix_featherwing_teensy41_64x32/package.json
+++ b/board_configs/fbdisplay/cp_rgb_matrix_featherwing_teensy41_64x32/package.json
@@ -1,0 +1,9 @@
+{
+  "urls": [
+    ["board_config.py", "github:PyDevices/pydisplay/board_configs/fbdisplay/cp_rgb_matrix_featherwing_teensy41_64x32/board_config.py"]
+  ],
+  "deps": [
+    ["github:PyDevices/pydisplay/packages/displaysys.json", "main"]
+  ],
+  "version": "0.1"
+}

--- a/board_configs/fbdisplay/mimxrt1060_evk_rk043_rgb/board_config.py
+++ b/board_configs/fbdisplay/mimxrt1060_evk_rk043_rgb/board_config.py
@@ -8,10 +8,15 @@ Targets displayif ``rgbframebuffer`` (NXP eLCDIF) on mimxrt.  Pin names match
 CircuitPython ``board.LCD_*`` on imxrt1060_evk; MicroPython uses ``GPIO_B*`` cpu
 pin names from the NXP EVK LCDIF mux (MCUXpresso BOARD_InitLCDPins).
 
+Touch (RK043 6-pin FPC on J49): Goodix GT911 on LPI2C1 (``board.SCL`` /
+``board.SDA``), reset on shield FPC pin 2 (``LCD_RST``), interrupt on pin 3
+(``LCD_TOUCH_INT``).
+
 CircuitPython sibling: ``cp_mimxrt1060_evk_rk043_rgb``.
 """
 
-from machine import Pin
+from gt911 import GT911
+from machine import I2C, Pin
 import time
 
 from displaysys.fbdisplay import FBDisplay
@@ -81,5 +86,34 @@ fb = RGBFrameBuffer(**tft_pins, **tft_timings)
 
 display_drv = FBDisplay(fb)
 
+# RK043FN66HS-CTG capacitive touch (GT911 on shield I2C FPC)
+i2c = I2C(0, freq=400_000)
+touch_drv = GT911(
+    i2c,
+    reset_pin="GPIO_AD_B0_02",
+    irq_pin="GPIO_AD_B0_11",
+    width=480,
+    height=272,
+    touch_points=5,
+)
+
+
+def touch_read_func():
+    n, points = touch_drv.read_points()
+    if n:
+        return points[0][0], points[0][1]
+    return None
+
+
+touch_rotation_table = (0, 0, 0, 0)
+
 broker = eventsys.Broker()
+
+touch_dev = broker.create(
+    type=eventsys.TOUCH,
+    read=touch_read_func,
+    data=display_drv,
+    data2=touch_rotation_table,
+)
+
 broker.register_quit_cleanup(display_drv)

--- a/board_configs/fbdisplay/mimxrt1060_evk_rk043_rgb/package.json
+++ b/board_configs/fbdisplay/mimxrt1060_evk_rk043_rgb/package.json
@@ -1,6 +1,7 @@
 {
   "urls": [
-    ["board_config.py", "github:PyDevices/pydisplay/board_configs/fbdisplay/mimxrt1060_evk_rk043_rgb/board_config.py"]
+    ["board_config.py", "github:PyDevices/pydisplay/board_configs/fbdisplay/mimxrt1060_evk_rk043_rgb/board_config.py"],
+    ["gt911.py", "github:PyDevices/pydisplay/drivers/touch/gt911.py"]
   ],
   "deps": [
     ["github:PyDevices/pydisplay/packages/displaysys.json", "main"]

--- a/board_configs/fbdisplay/mimxrt1170_evk_waveshare_5dsi/board_config.py
+++ b/board_configs/fbdisplay/mimxrt1170_evk_waveshare_5dsi/board_config.py
@@ -1,14 +1,15 @@
-"""NXP MIMXRT1170-EVK + Waveshare 5\" DSI (800×480) on J84 — MicroPython
+"""NXP MIMXRT1170-EVK + Waveshare 50H-800480-IPS DSI (800×480) on J84 — MicroPython
 
 Hardware (plug-in FFC, no breadboard wiring):
 - MIMXRT1170-EVK / EVKB: https://circuitpython.org/board/nxp_mimxrt1170_evk/
-- Waveshare 5\" DSI LCD (800×480, 15-pin Raspberry Pi-style DSI FFC) on EVK **J84**
+- Waveshare 50H-800480-IPS: https://www.waveshare.com/wiki/50H-800480-IPS#Interface_Definition
+  (15-pin RPi-style DSI FFC on EVK **J84**; 2-lane DSI + clock)
 - Panel 5 V from EVK **J85** (5 V to pin 1, GND to pin 2) per NXP SDK RPi-panel notes
 - Board: 5 V on **J43**, jumper **J38** at 1–2
 
-Uses the same 15-pin DSI connector as the Raspberry Pi 7\" touch display.  The Waveshare
-5\" panel is DPI-over-DSI; panel init and DPI timings are supplied when displayif
-``mipidsi`` lands for RT1176 (NXP ``fsl_mipi_dsi`` + ``display_support`` panel table).
+On Raspberry Pi this panel uses ``dtoverlay=vc4-kms-dsi-7inch`` (TC358762 DSI-to-DPI
+bridge).  displayif ``mipidsi`` programs the bridge automatically when
+``init_sequence`` is empty.
 
 CircuitPython sibling: ``cp_mimxrt1170_evk_waveshare_5dsi``.
 """
@@ -23,26 +24,26 @@ except ImportError as exc:
         "MIPI DSI requires displayif mipidsi cmod (mimxrt1176 port)"
     ) from exc
 
-# Placeholder until mimxrt panel driver supplies vendor init (Waveshare / RPi DPI panel).
+# Empty init: displayif runs TC358762 bridge setup (RPi / Waveshare 50H-800480-IPS).
 PANEL_INIT_SEQUENCE = b""
 
-# MIPI DSI bus — 2 lanes, 1 Gbps/lane (tune with displayif driver / NXP BSP)
+# 2-lane DSI (Waveshare 50H-800480-IPS pinout: D0 + D1 + clock).
 bus = Bus(frequency=1_000_000_000, num_lanes=2)
 
-# DPI timings for 800×480 @ ~60 Hz (RPi-class panel; refine per panel driver)
+# DPI timings from Raspberry Pi firmware / panel-raspberrypi-touchscreen (800×480 @ ~60 Hz).
 fb = Display(
     bus,
     init_sequence=PANEL_INIT_SEQUENCE,
     width=800,
     height=480,
     color_depth=16,
-    pixel_clock_frequency=32_000_000,
-    hsync_pulse_width=70,
-    hsync_front_porch=40,
-    hsync_back_porch=40,
-    vsync_pulse_width=10,
-    vsync_front_porch=13,
-    vsync_back_porch=29,
+    pixel_clock_frequency=25_979_400,
+    hsync_pulse_width=2,
+    hsync_front_porch=1,
+    hsync_back_porch=46,
+    vsync_pulse_width=2,
+    vsync_front_porch=7,
+    vsync_back_porch=21,
 )
 
 display_drv = FBDisplay(fb)

--- a/board_configs/fbdisplay/mimxrt1170_evk_waveshare_5dsi/board_config.py
+++ b/board_configs/fbdisplay/mimxrt1170_evk_waveshare_5dsi/board_config.py
@@ -11,8 +11,16 @@ On Raspberry Pi this panel uses ``dtoverlay=vc4-kms-dsi-7inch`` (TC358762 DSI-to
 bridge).  displayif ``mipidsi`` programs the bridge automatically when
 ``init_sequence`` is empty.
 
+Touch (50H-800480-IPS-**CT** capacitive SKU only): Goodix GT911 on I2C via J84 FFC
+pins 11–12 (``board.SDA`` / ``board.SCL``, LPI2C5).  Reset and interrupt are routed
+on ``board.D9`` / ``board.D6`` per NXP MIPI-panel touch wiring.  The non-touch IPS
+variant has no controller on that I2C bus.
+
 CircuitPython sibling: ``cp_mimxrt1170_evk_waveshare_5dsi``.
 """
+
+from gt911 import GT911
+from machine import I2C
 
 from displaysys.fbdisplay import FBDisplay
 import eventsys
@@ -48,5 +56,34 @@ fb = Display(
 
 display_drv = FBDisplay(fb)
 
+# 50H-800480-IPS-CT: Goodix GT911 on J84 FFC I2C (pins 11–12) + EVK touch GPIOs
+i2c = I2C(0, freq=400_000)
+touch_drv = GT911(
+    i2c,
+    reset_pin="GPIO_AD_01",
+    irq_pin="GPIO_AD_00",
+    width=800,
+    height=480,
+    touch_points=5,
+)
+
+
+def touch_read_func():
+    n, points = touch_drv.read_points()
+    if n:
+        return points[0][0], points[0][1]
+    return None
+
+
+touch_rotation_table = (0, 0, 0, 0)
+
 broker = eventsys.Broker()
+
+touch_dev = broker.create(
+    type=eventsys.TOUCH,
+    read=touch_read_func,
+    data=display_drv,
+    data2=touch_rotation_table,
+)
+
 broker.register_quit_cleanup(display_drv)

--- a/board_configs/fbdisplay/mimxrt1170_evk_waveshare_5dsi/package.json
+++ b/board_configs/fbdisplay/mimxrt1170_evk_waveshare_5dsi/package.json
@@ -1,6 +1,7 @@
 {
   "urls": [
-    ["board_config.py", "github:PyDevices/pydisplay/board_configs/fbdisplay/mimxrt1170_evk_waveshare_5dsi/board_config.py"]
+    ["board_config.py", "github:PyDevices/pydisplay/board_configs/fbdisplay/mimxrt1170_evk_waveshare_5dsi/board_config.py"],
+    ["gt911.py", "github:PyDevices/pydisplay/drivers/touch/gt911.py"]
   ],
   "deps": [
     ["github:PyDevices/pydisplay/packages/displaysys.json", "main"]

--- a/board_configs/fbdisplay/rgb_matrix_featherwing_teensy41_64x32/board_config.py
+++ b/board_configs/fbdisplay/rgb_matrix_featherwing_teensy41_64x32/board_config.py
@@ -1,4 +1,7 @@
-"""Adafruit RGB Matrix FeatherWing 64x32 — MicroPython (Teensy 4.1)"""
+"""Adafruit RGB Matrix FeatherWing 64x32 — MicroPython (Teensy 4.1)
+
+CircuitPython sibling: ``cp_rgb_matrix_featherwing_teensy41_64x32``.
+"""
 
 from machine import Pin
 import rgbmatrix

--- a/board_configs/fbdisplay/rgb_matrix_featherwing_teensy41_64x32/package.json
+++ b/board_configs/fbdisplay/rgb_matrix_featherwing_teensy41_64x32/package.json
@@ -2,5 +2,8 @@
   "urls": [
     ["board_config.py", "github:PyDevices/pydisplay/board_configs/fbdisplay/rgb_matrix_featherwing_teensy41_64x32/board_config.py"]
   ],
+  "deps": [
+    ["github:PyDevices/pydisplay/packages/displaysys.json", "main"]
+  ],
   "version": "0.1"
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Board config updates for displayif accelerated interfaces:

- **Waveshare 50H-800480-IPS** ([wiki](https://www.waveshare.com/wiki/50H-800480-IPS)): RPi `vc4-kms-dsi-7inch` DPI timings (25.98 MHz pixel clock); empty init relies on displayif TC358762 bridge setup
- **GT911 touch** on RK043 (mimxrt1060) and Waveshare -CT variant (mimxrt1170)
- **Missing CP pairs**: `cp_feather_rp2040_rgb_matrix_64x32`, `cp_rgb_matrix_featherwing_teensy41_64x32`
- **`cp_qualia_tl040hds20/package.json`** added

## Board audit

| Board | MP | CP | Input |
|-------|----|----|-------|
| mimxrt1060_evk_rk043_rgb | ✓ | ✓ | GT911 |
| mimxrt1170_evk_waveshare_5dsi | ✓ | ✓ | GT911 (-CT) |
| pico2_dvi_sock / pimoroni_pico_dv | ✓ | ✓ | — |
| feather_rp2040_rgb_matrix | ✓ | ✓ (new) | — |
| rgb_matrix_featherwing_teensy41 | ✓ | ✓ (new) | — |
| qualia_tl040hds20 | ✓ | ✓ | FT6x36 + buttons |

**Gap:** `t-rgb_480` still MP-only (no CP dotclock port yet).
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-347dece3-c28e-419c-ad8e-5a1d1541d50b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-347dece3-c28e-419c-ad8e-5a1d1541d50b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

