### PR TITLE
Fix RGB888 framebuffers on MicroPython; add pixel_sim simulator + demos

### DIFF
--- a/docs/concepts/display-backends.md
+++ b/docs/concepts/display-backends.md
@@ -1,0 +1,236 @@
+# Display backend internals
+
+This document explains how pydisplay **display drivers** relate to each other: the
+shared **565 API contract**, the **two-stage draw/present** model used by desktop
+and browser simulators, **color conversion** strategies, and why each backend
+chose its implementation pattern.
+
+For a shorter “which driver do I pick?” guide, see [Displays](displays.md). For
+chip wiring and board configs, see [Board configs](../hardware/board-configs.md)
+and [Display interfaces](../hardware/display-interfaces.md).
+
+## The DisplayDriver API contract
+
+Application and example code assume a **16-bit RGB565** surface:
+
+- `display_drv.color_depth == 16` (bits per pixel)
+- Color literals like `0xFFFF`, `0xF800`, and helpers like `color565(r, g, b)`
+- Scratch buffers: `FrameBuffer(..., RGB565)` and
+  `BPP = display_drv.color_depth // 8` (2 bytes per pixel)
+- `blit_rect` source buffers sized `w * h * 2`
+- `blit_transparent` key colors as 2-byte 565 values
+
+**BusDisplay**, **FBDisplay**, and most TFT paths are **565 end-to-end** — the
+API matches the hardware framebuffer.
+
+Other backends store pixels in a **deeper native format** (RGB888 strip buffer,
+PIL RGB, canvas RGBA, SDL texture at 24/32 bpp). They still expose the **565
+API** and convert at draw time via `color_rgb` (or backend-specific blit paths).
+
+### Color encoding trap
+
+565 and 888 use **different integer layouts**:
+
+| Meaning | RGB565 int | RGB888 int |
+|---------|------------|------------|
+| White | `0xFFFF` | `0xFFFFFF` |
+| Red | `0xF800` | `0xFF0000` |
+
+RGB888 unpack (used by `PixelFramebuffer` and `graphics.RGB888`) treats the int
+as `0xRRGGBB`. Passing `0xFFFF` (565 white) through that path yields cyan
+(R=0, G=255, B=255), not white.
+
+The shared expand helper is **`color_rgb()`** in `displaysys/__init__.py`: 565
+int or 2-byte little-endian slice → `(r, g, b)` with 5/6/5 bit expansion. Tests
+live in `tests/test_color.py`.
+
+## Two-stage architecture: logical GRAM + present
+
+Four simulators — **SDLDisplay**, **PGDisplay**, **PSDisplay**, **JNDisplay**
+— mimic an **ILI9341-style** panel:
+
+```text
+  App draw API                Present path
+  ─────────────               ──────────────
+  fill_rect / blit_rect  →    self._buffer   (logical GRAM)
+                              render()       (scroll bands, scale, …)
+                              show()         (flip / widget / canvas)
+```
+
+1. **`self._buffer`** — offscreen memory at logical `width × height` (PG calls
+   this “the LCD’s internal memory”).
+2. **Draw methods** — write only into that buffer.
+3. **`render()`** — composes the buffer to the visible surface, including
+   **vertical scroll** (top fixed / scroll area / bottom fixed).
+4. **`show()`** — pushes frames to the OS window, browser canvas, or Jupyter
+   widget.
+
+Scroll emulation **requires** this split: you cannot draw directly on the window
+and still implement `vscroll` / `set_vscroll` correctly. See
+[pydisplay_demo](../examples/pydisplay_demo.md) for the redraw-at-`vscroll=0`
+rule.
+
+**PixelDisplay** is different: there is no ILI9341 scroll model. Drawing updates
+an RGB888 grid buffer; `show()` diff-flushes to the LED strip.
+
+### Vertical scroll (shared by SDL / PG / PS / JN)
+
+All four implement the same band compositing in `render()`:
+
+- **TFA** — top fixed area (pinned rows)
+- **VSA** — vertical scroll area (content that moves)
+- **BFA** — bottom fixed area
+
+`display_drv.set_vscroll(tfa, bfa)` and the `vscroll` property map to the
+controller-style `vscsad` address. On **SDLDisplay**, `render()` uses multiple
+`SDL_RenderCopy` bands (a single full-frame copy was disabled due to platform
+issues). **PGDisplay** and **PSDisplay** use the same four-step blit/drawImage
+layout when scrolled.
+
+### Rotation
+
+| Backend | Buffer rotation |
+|---------|-----------------|
+| **SDLDisplay** | `_rotation_helper` — new SDL texture + `SDL_RenderCopyEx` |
+| **PGDisplay** | `_rotation_helper` — `pg.transform.rotate` on `_buffer` |
+| **PSDisplay** | `_rotation` tracked; **no** `_rotation_helper` (surface dims swap only) |
+| **JNDisplay** | Same as PS — property only, no pixel rotation |
+| **PixelDisplay** | `rotation` on inner framebuf (grid wiring), not LCD-style |
+
+Full rotation matters for **SDL/PG** desktop LCD simulation. Browser and notebook
+backends document that rotation reshapes the surface but does not rotate pointer
+coordinates — see [Displays — Browser / notebook](displays.md#browser--notebook-pyscript-jupyter).
+
+### Scaling
+
+| Backend | Mechanism |
+|---------|-----------|
+| **PGDisplay** | Constructor `scale`; `pg.transform.scale_by` at present; `touch_scale = scale` |
+| **SDLDisplay** | Window size `width * scale`; `SDL_RenderSetLogicalSize` for logical coords |
+| **PSDisplay** | CSS layout vs canvas pixel size; `_pointer_scale()` / `touch_scale` |
+| **JNDisplay** | 1:1 (`touch_scale = 1.0`) |
+| **PixelDisplay** | N/A (tiny physical grid) |
+
+## Why each backend exists (runtime)
+
+| Backend | Typical runtime | Why it exists |
+|---------|-----------------|---------------|
+| **SDLDisplay** | CPython, MicroPython Unix, CircuitPython Unix | Native SDL2 / `usdl2`; default on MP Unix |
+| **PGDisplay** | CPython desktop | Easier install on Windows; avoids some SDL glitches on Chromebooks; default in `lib/board_config.py` when pygame imports |
+| **PSDisplay** | PyScript | HTML Canvas 2D; no SDL/pygame in the browser |
+| **JNDisplay** | Jupyter | `ipywidgets` / PNG refresh; interactive `JNDevices` |
+| **PixelDisplay** | MCU / CP | NeoPixel / DotStar grids via `displaysys.pixeldisplay` |
+
+CircuitPython Unix **SDLDisplay** forces **software rendering** when accelerated
+GL cannot attach rotated render targets (see comment in `sdldisplay.py`).
+MicroPython SDL **`show()`** may defer present on `MemoryError` when the heap is
+locked during scroll rendering.
+
+## Color conversion toolbox
+
+Backends use several patterns to map **565 API input** to **native storage**:
+
+| Pattern | Where | Description |
+|---------|-------|-------------|
+| **Bitwise expand** | `color_rgb()` | Per-color 565 → `(r,g,b)`; fills and single pixels |
+| **LUT-assisted loop** | **PSDisplay** | 65536 × 4 byte table; blit loop indexes LUT → RGBA for `putImageData` |
+| **Python pixel loop** | **PGDisplay** blit, **JNDisplay** blit | Per pixel: read 2 bytes → `color_rgb` → `set_at` / PIL `point` |
+| **Zero-copy passthrough** | **SDLDisplay** at 16 bpp | `SDL_UpdateTexture` with 565 pitch — buffer format matches texture |
+| **Raw 565 pack** | **BusDisplay**, **FBDisplay** | `(c & 0xFFFF).to_bytes(2, …)` — no expand |
+
+Not yet centralized in `displaysys`, but useful for future shared helpers:
+
+- **`frombuffer` + blit** (Pygame) — `pg.image.frombuffer(buf, (w,h), "RGB565")`
+  then `dest.blit(src, (x,y))` for **16-in / 16-stored** without a Python loop
+- **Row expand** — convert one row of 565 to RGB/RGBA, bulk-write
+- **Component mini-LUTs** — small 5/6/5-bit tables (~128 bytes) instead of 256 KB
+
+### Per-backend blit strategy (today)
+
+| Backend | Native sink | Blit path | Rationale |
+|---------|-------------|-----------|-----------|
+| **SDLDisplay** (16) | RGB565 texture | Zero-copy upload | Throughput on large blits; matches app buffers |
+| **SDLDisplay** fill | Same texture | `color_rgb` → SDL RGB draw | Draw API expects 8-bit RGB |
+| **PGDisplay** | Pygame surface (default 16) | Per-pixel `set_at` loop | Simple; partial `renderRect`; room to switch to `frombuffer`+`blit` |
+| **PSDisplay** | Canvas RGBA | LUT → `ImageData` | Browser API requires RGBA bytes; large blits |
+| **JNDisplay** | PIL RGB | Loop → `pixel` | Present is PNG-bound; blit speed secondary |
+| **PixelDisplay** | RGB888 strip buf | 565 in → `color_rgb` → inner 888 | Tiny grids; standard DisplayDriver API |
+
+### SDL vs Pygame “fast path”
+
+**SDL** at `color_depth=16` is true **16-in / 16-stored** for blits: the app’s
+565 buffer is uploaded directly into a RGB565 render-target texture.
+
+**Pygame** can match that intent (not the same mechanism) by keeping a 16-bit
+surface and using **`frombuffer` + `blit`** once per `blit_rect` call instead of
+`set_at` per pixel. The current PG implementation still expands each pixel to
+RGB for `set_at`, which quantizes back to 565 on a 16-bit surface — correct but
+slow at 320×480.
+
+### LUT size and MCUs
+
+**PSDisplay** allocates **65536 × 4 ≈ 256 KB** for `_rgba_lut` — appropriate
+in PyScript, **not** on typical MCUs (e.g. RP2040 has 264 KB SRAM total).
+
+For **PixelDisplay** (8×4, 12×6, …), a **`color_rgb` loop** over tens or hundreds
+of pixels is negligible. A full 565→888 LUT (~192 KB for 3-byte entries) would
+cost more RAM than the grid itself.
+
+## PixelDisplay specifics
+
+Addressable LED boards wire:
+
+```python
+_pixel_framebuf = PixelFramebuffer(...)  # internal; RGB888 grid + strip map
+display_drv = PixelDisplay(_pixel_framebuf)
+```
+
+**Use `display_drv` for all app drawing.** `_pixel_framebuf` is prefixed to
+discourage bypassing the DisplayDriver API (see
+[Board configs — Pixel configs](../hardware/board-configs.md#pixel--addressable-led-configs)).
+
+`PixelDisplay` exposes the usual **565 `DisplayDriver` API** (`color_depth=16`).
+The inner `PixelFramebuffer` stays **RGB888** for the strip; `fill_rect`,
+`pixel`, and `blit_rect` expand via `color_rgb` before writing the inner buffer.
+
+MicroPython uses `displaysys.pixeldisplay.PixelFramebuffer`; CircuitPython uses
+Adafruit `adafruit_pixel_framebuf` behind the same `PixelDisplay` wrapper.
+
+## Hardware drivers (brief)
+
+These follow the 565 API without a separate “present” stage in the same sense:
+
+| Class | Storage | Notes |
+|-------|---------|-------|
+| **BusDisplay** | Panel GRAM via SPI/I80 | Optional byteswap; true 565 |
+| **FBDisplay** | CircuitPython framebuf | RAM mirror + `refresh()` |
+| **BoardDisplay** | displayio Bitmap | 565 buffer → bitmap on `show()` |
+| **EPaperDisplay** | 1/2/4 bpp packed | `color_depth` matches panel |
+
+## Consolidation direction
+
+Goals discussed for displaysys maintenance:
+
+1. **One API** — all `DisplayDriver` instances report `color_depth=16` and accept
+   565 colors and blit buffers unless the hardware is genuinely sub-16-bit
+   (e-paper).
+2. **Shared conversion helpers** in `displaysys/__init__.py` — `color_rgb`
+   (exists), plus swappable **loop** vs **LUT** blit writers for benchmarking.
+3. **Keep backend-specific fast paths** where they matter:
+   - SDL: zero-copy 565 blit
+   - PS: LUT for RGBA canvas
+   - PG: consider `frombuffer`+`blit` for 565 surfaces
+   - PixelDisplay: loop expand (tiny grids)
+4. **Lazy LUT** — build only on CPython / desktop unless explicitly enabled, so
+   MCUs never allocate 256 KB silently.
+
+Internal buffer format may remain 565 (SDL), RGB (JN), RGBA (PS), or RGB888
+(strip) as long as the **public** contract stays 565.
+
+## Related reading
+
+- [Displays](displays.md) — pick a driver, input, scroll overview
+- [pydisplay_demo](../examples/pydisplay_demo.md) — scroll bands and redraw rules
+- [Architecture](architecture.md) — how `board_config` wires drivers
+- [Display interfaces](../hardware/display-interfaces.md) — hardware taxonomy
+- `tests/test_color.py` — `color_rgb` / `color565` contract tests

--- a/docs/concepts/displays.md
+++ b/docs/concepts/displays.md
@@ -177,6 +177,7 @@ Known issues: Unix SDL rotation clears the screen; scrolling while rotated has e
 
 ## Next
 
+- [Display backend internals](display-backends.md) — GRAM/present model, 565 API, color conversion per backend
 - [Events](events.md)
 - [Drawing and fonts](drawing-and-fonts.md)
 - [Display drivers (chips)](../hardware/display-drivers.md)

--- a/docs/reference/overviews/displaysys.md
+++ b/docs/reference/overviews/displaysys.md
@@ -3,6 +3,7 @@ displaysys provides display driver classes (`BusDisplay`, `SDLDisplay`, `PGDispl
 ## Narrative docs
 
 - [Displays concept](../../concepts/displays.md) — pick a driver
+- [Display backend internals](../../concepts/display-backends.md) — GRAM/present, 565 API, color conversion
 - [Architecture](../../concepts/architecture.md) — how board_config wires the display
 - [Display drivers (chips)](../../hardware/display-drivers.md) — st7789, ili9341, etc.
 

--- a/src/examples/pixel_sim/__init__.py
+++ b/src/examples/pixel_sim/__init__.py
@@ -1,0 +1,107 @@
+"""
+pixel_sim — desktop simulator for addressable-LED matrices (NeoPixel / DotStar).
+
+Develop a pixeldisplay app without hardware.  ``PixelDisplay`` draws into a
+``graphics.FrameBuffer`` (RGB888, one cell per LED); on ``show()`` that
+framebuffer is scaled up and painted as an LED matrix onto the shared desktop /
+PyScript / notebook display from ``lib/board_config.py``.
+
+The board config for this simulator is just::
+
+    from pixel_sim import display_drv, runtime
+
+Poll ``runtime`` each frame (``runtime.poll()`` / ``runtime.quit_requested``) so
+the desktop window stays closable — the simulator drives its own draw loop, so
+nothing polls for you.
+
+Grid size defaults to 64x16; override with ``PIXEL_SIM_WIDTH`` /
+``PIXEL_SIM_HEIGHT`` (honored on CPython and MicroPython).
+"""
+
+import os
+
+import graphics
+from displaysys import color565
+from displaysys.pixeldisplay import PixelDisplay
+
+# ``lib/`` is on sys.path (via lib/path.py), so import the host board_config bare
+# — ``from lib import board_config`` fails on MicroPython (no namespace packages).
+import board_config as _host  # noqa: E402
+
+
+def _env_int(name, default):
+    # MicroPython's ``os`` has no ``environ``; fall back to ``getenv``.
+    env = getattr(os, "environ", None)
+    value = env.get(name) if env is not None else None
+    if value is None and hasattr(os, "getenv"):
+        try:
+            value = os.getenv(name)
+        except Exception:
+            value = None
+    if value is None:
+        return default
+    try:
+        return int(value)
+    except (TypeError, ValueError):
+        return default
+
+
+PIXEL_WIDTH = _env_int("PIXEL_SIM_WIDTH", 64)
+PIXEL_HEIGHT = _env_int("PIXEL_SIM_HEIGHT", 16)
+
+# Reuse the standard scaled desktop/browser/notebook backend as the output surface.
+# The host board_config wires its own periodic-refresh runtime; the simulator
+# presents frames itself via PixelDisplay.show(), so stop that shared timer to
+# avoid a redundant refresh loop (and its signal-based teardown on CPython).
+# The runtime itself is kept (re-exported below) so apps can still poll it for
+# window-close / quit events; poll() is independent of the timer.
+_backend = _host.display_drv
+_host_runtime = getattr(_host, "runtime", None)
+if _host_runtime is not None and hasattr(_host_runtime, "stop_timer"):
+    _host_runtime.stop_timer()
+
+
+def _rgb565_from_888(c):
+    return color565((c >> 16) & 0xFF, (c >> 8) & 0xFF, c & 0xFF)
+
+
+class SimPixelFramebuffer(graphics.FrameBuffer):
+    """RGB888 grid framebuffer that renders scaled LED blocks to a desktop display.
+
+    A drop-in for the ``pixel_buffer`` that :class:`PixelDisplay` wraps: it
+    exposes ``width`` / ``height`` / ``rotation`` and a ``display()`` flush, but
+    instead of pushing to a physical strip it paints each cell as a large square
+    on ``backend`` (centered, square LEDs, dark gaps for a matrix look).
+    """
+
+    BOARD_COLOR = 0x0841  # near-black RGB565 "PCB" behind the LEDs
+
+    def __init__(self, width, height, backend):
+        self._backend = backend
+        buf = bytearray(width * height * 3)
+        super().__init__(buf, width, height, graphics.RGB888)
+        self.rotation = 0
+        self._block = max(1, min(backend.width // width, backend.height // height))
+        self._gap = max(1, self._block // 8)
+        self._ox = (backend.width - self._block * width) // 2
+        self._oy = (backend.height - self._block * height) // 2
+
+    def display(self):
+        b = self._backend
+        block = self._block
+        gap = self._gap
+        inner = block - 2 * gap
+        b.fill(self.BOARD_COLOR)
+        for y in range(self.height):
+            for x in range(self.width):
+                color = _rgb565_from_888(self.pixel(x, y))
+                b.fill_rect(self._ox + x * block + gap, self._oy + y * block + gap, inner, inner, color)
+        b.show()
+
+
+_pixel_framebuf = SimPixelFramebuffer(PIXEL_WIDTH, PIXEL_HEIGHT, _backend)
+display_drv = PixelDisplay(_pixel_framebuf)
+
+# Host runtime for quit/window-close handling. Its refresh timer is stopped
+# (see above); apps still call runtime.poll() each frame to stay closable.
+runtime = _host_runtime

--- a/src/examples/pixel_sim/board_config.py
+++ b/src/examples/pixel_sim/board_config.py
@@ -1,0 +1,9 @@
+"""NeoPixel / DotStar matrix simulator board config.
+
+Renders an addressable-LED grid to a scaled desktop window via ``pixel_sim``.
+Point your run at this board config (e.g. copy it to the working directory, or
+prepend ``examples/pixel_sim`` to ``sys.path`` so it shadows the default
+``board_config``) and draw with the usual RGB565 DisplayDriver API.
+"""
+
+from pixel_sim import display_drv, runtime  # noqa: F401

--- a/src/examples/pixel_sim_fire.py
+++ b/src/examples/pixel_sim_fire.py
@@ -1,0 +1,122 @@
+"""
+pixel_sim_fire.py — cellular flame effect on the NeoPixel simulator.
+
+The bottom row is a hot ember source; every frame each cell above becomes the
+average of the cells below it, minus a small cooling constant, so heat rises and
+flickers.  Heat (0..255) maps through a black -> red -> orange -> yellow -> white
+fire palette precomputed once into an RGB565 lookup table.
+
+``runtime.poll()`` runs every frame so the desktop window stays closable.
+
+Run it as the main program to loop forever (closes with the window / Ctrl-C):
+
+    cd src && python -c "import lib.path, runpy; runpy.run_path('examples/pixel_sim_fire.py', run_name='__main__')"
+
+Plain ``import pixel_sim_fire`` renders a single frame and returns.
+"""
+
+import time
+from random import getrandbits
+
+from displaysys import color565
+from graphics import RGB565, FrameBuffer
+from multimer import sleep_ms
+from pixel_sim import display_drv, runtime
+
+GRID_W = display_drv.width
+GRID_H = display_drv.height
+
+FRAME_MS = 30
+COOLING = 3  # subtracted per row as heat rises; higher = shorter flames
+
+
+def _fire_color(i):
+    """Map heat 0..255 to a fire gradient (black->red->yellow->white)."""
+    if i < 64:
+        return color565(i * 4, 0, 0)
+    if i < 128:
+        return color565(255, (i - 64) * 4, 0)
+    if i < 192:
+        return color565(255, 255, (i - 128) * 4)
+    return color565(255, 255, 255)
+
+
+# Precomputed heat -> RGB565 lookup (256 entries).
+_FIRE = [_fire_color(i) for i in range(256)]
+
+# Heat field (one byte per cell) and the RGB565 frame we blit to the LEDs.
+_heat = bytearray(GRID_W * GRID_H)
+_dest = FrameBuffer(bytearray(GRID_W * GRID_H * 2), GRID_W, GRID_H, RGB565)
+
+try:
+    import pydisplay_test_mode  # type: ignore[import-not-found]
+
+    _TEST_DURATION_S = pydisplay_test_mode.DURATION_S if pydisplay_test_mode.ENABLED else None
+except ImportError:
+    _TEST_DURATION_S = None
+
+
+_START = time.time()
+
+
+def _stop():
+    """Poll input so the window closes; True when quitting or the test times out."""
+    if runtime is not None:
+        runtime.poll()
+        if runtime.quit_requested:
+            return True
+    if _TEST_DURATION_S is not None and time.time() - _START >= _TEST_DURATION_S:
+        return True
+    return False
+
+
+def _seed_source():
+    base = (GRID_H - 1) * GRID_W
+    for x in range(GRID_W):
+        # Mostly white-hot with occasional cooler gaps for a lively base.
+        _heat[base + x] = 255 if getrandbits(3) else 160 + getrandbits(6)
+
+
+def _propagate():
+    w = GRID_W
+    heat = _heat
+    for y in range(GRID_H - 1):
+        row = y * w
+        below = row + w
+        for x in range(w):
+            b = below + x
+            left = b - 1 if x > 0 else b
+            right = b + 1 if x < w - 1 else b
+            below2 = b + w if y + 2 < GRID_H else b
+            v = (heat[b] + heat[left] + heat[right] + heat[below2]) // 4 - COOLING
+            heat[row + x] = v if v > 0 else 0
+
+
+def _paint():
+    heat = _heat
+    fire = _FIRE
+    pixel = _dest.pixel
+    for y in range(GRID_H):
+        row = y * GRID_W
+        for x in range(GRID_W):
+            pixel(x, y, fire[heat[row + x]])
+
+
+def main():
+    """Render one frame (reseed embers, propagate heat, present, pace)."""
+    _seed_source()
+    _propagate()
+    _paint()
+    display_drv.blit_rect(_dest.buffer, 0, 0, GRID_W, GRID_H)
+    display_drv.show()
+    sleep_ms(FRAME_MS)
+
+
+main()  # one frame; importing the module never loops forever
+
+if __name__ == "__main__":
+    try:
+        while not _stop():
+            main()
+    except KeyboardInterrupt:
+        pass

--- a/src/examples/pixel_sim_matrix.py
+++ b/src/examples/pixel_sim_matrix.py
@@ -1,0 +1,107 @@
+"""
+pixel_sim_matrix.py — "digital rain" on the NeoPixel simulator.
+
+Each column has a falling head that leaves a fading green trail: a bright,
+near-white head, then a gradient down to dark green, on a black background.
+Columns fall at independent speeds and respawn at the top once they scroll off.
+
+``runtime.poll()`` runs every frame so the desktop window stays closable.
+
+Run it as the main program to loop forever (closes with the window / Ctrl-C):
+
+    cd src && python -c "import lib.path, runpy; runpy.run_path('examples/pixel_sim_matrix.py', run_name='__main__')"
+
+Plain ``import pixel_sim_matrix`` renders a single frame and returns.
+"""
+
+import time
+from random import getrandbits
+
+from displaysys import color565
+from graphics import RGB565, FrameBuffer
+from multimer import sleep_ms
+from pixel_sim import display_drv, runtime
+
+GRID_W = display_drv.width
+GRID_H = display_drv.height
+
+FRAME_MS = 45
+TRAIL = 14  # trail length in cells
+BLACK = 0x0000
+HEAD = color565(200, 255, 200)  # near-white head
+
+# Precompute the fading green trail (index 0 = just behind head, brightest green).
+_TRAIL = [color565(0, max(40, 255 - i * (215 // TRAIL)), 0) for i in range(TRAIL)]
+
+
+def _randint(a, b):
+    span = b - a + 1
+    if span <= 1:
+        return a
+    bits = 0
+    n = span - 1
+    while n:
+        bits += 1
+        n >>= 1
+    return a + getrandbits(bits) % span
+
+
+# Per-column head position (in 1/8 cell fixed point) and fall speed.
+_head = [_randint(-GRID_H, 0) * 8 for _ in range(GRID_W)]
+_speed = [_randint(3, 10) for _ in range(GRID_W)]  # eighths of a cell per frame
+
+_dest = FrameBuffer(bytearray(GRID_W * GRID_H * 2), GRID_W, GRID_H, RGB565)
+
+try:
+    import pydisplay_test_mode  # type: ignore[import-not-found]
+
+    _TEST_DURATION_S = pydisplay_test_mode.DURATION_S if pydisplay_test_mode.ENABLED else None
+except ImportError:
+    _TEST_DURATION_S = None
+
+
+_START = time.time()
+
+
+def _stop():
+    """Poll input so the window closes; True when quitting or the test times out."""
+    if runtime is not None:
+        runtime.poll()
+        if runtime.quit_requested:
+            return True
+    if _TEST_DURATION_S is not None and time.time() - _START >= _TEST_DURATION_S:
+        return True
+    return False
+
+
+def _step():
+    _dest.fill(BLACK)
+    pixel = _dest.pixel
+    for x in range(GRID_W):
+        _head[x] += _speed[x]
+        head_y = _head[x] >> 3
+        for k in range(TRAIL):
+            y = head_y - k
+            if 0 <= y < GRID_H:
+                pixel(x, y, HEAD if k == 0 else _TRAIL[k])
+        if head_y - TRAIL > GRID_H:
+            _head[x] = _randint(-GRID_H, 0) * 8
+            _speed[x] = _randint(3, 10)
+
+
+def main():
+    """Render one frame (advance the rain, present, pace)."""
+    _step()
+    display_drv.blit_rect(_dest.buffer, 0, 0, GRID_W, GRID_H)
+    display_drv.show()
+    sleep_ms(FRAME_MS)
+
+
+main()  # one frame; importing the module never loops forever
+
+if __name__ == "__main__":
+    try:
+        while not _stop():
+            main()
+    except KeyboardInterrupt:
+        pass

--- a/src/examples/pixel_sim_plasma.py
+++ b/src/examples/pixel_sim_plasma.py
@@ -1,0 +1,112 @@
+"""
+pixel_sim_plasma.py — flowing rainbow plasma on the NeoPixel simulator.
+
+A classic demoscene plasma effect on the ``pixel_sim`` LED matrix.  Per pixel we
+sum a few sine waves in x, y, and (x+y), offset by an animated time value, then
+map the result through the ``palettes`` ``wheel`` (full-spectrum rainbow).
+
+The sines are precomputed into a 256-entry integer table and combined with plain
+index math (no per-pixel float ``sin``), so it stays fast and MCU-friendly.
+
+``runtime.poll()`` runs every frame so the desktop window stays closable.
+
+Run it as the main program to loop forever (closes with the window / Ctrl-C):
+
+    cd src && python -c "import lib.path, runpy; runpy.run_path('examples/pixel_sim_plasma.py', run_name='__main__')"
+
+Plain ``import pixel_sim_plasma`` renders a single frame and returns.
+"""
+
+import math
+import time
+
+from graphics import RGB565, FrameBuffer
+from multimer import sleep_ms
+from palettes import get_palette
+from pixel_sim import display_drv, runtime
+
+GRID_W = display_drv.width
+GRID_H = display_drv.height
+
+FRAME_MS = 20
+TIME_STEP = 3  # how fast the field animates
+
+# 256-entry integer sine table, 0..255 (one full period over the index range).
+_SIN = [int((math.sin(i * math.pi / 128.0) + 1.0) * 127.5) for i in range(256)]
+_MASK = 0xFF
+
+# Full-spectrum rainbow, 256 colors so a summed field maps straight to an index.
+_pal = get_palette(name="wheel", color_depth=16, length=256)
+
+# Grid-sized RGB565 buffer; composited each frame then blitted to the LEDs.
+_dest = FrameBuffer(bytearray(GRID_W * GRID_H * 2), GRID_W, GRID_H, RGB565)
+
+# Precompute the per-column base phase (x term is time-independent in shape,
+# only the time offset moves it), reused across rows each frame.
+_X1 = [(x * 6) & _MASK for x in range(GRID_W)]
+_X2 = [(x * 3) & _MASK for x in range(GRID_W)]
+
+try:
+    import pydisplay_test_mode  # type: ignore[import-not-found]
+
+    _TEST_DURATION_S = pydisplay_test_mode.DURATION_S if pydisplay_test_mode.ENABLED else None
+except ImportError:
+    _TEST_DURATION_S = None
+
+
+_START = time.time()
+
+
+def _stop():
+    """Poll input so the window closes; True when quitting or the test times out."""
+    if runtime is not None:
+        runtime.poll()
+        if runtime.quit_requested:
+            return True
+    if _TEST_DURATION_S is not None and time.time() - _START >= _TEST_DURATION_S:
+        return True
+    return False
+
+
+def _render(t):
+    sin = _SIN
+    pal = _pal
+    pixel = _dest.pixel
+    x1 = _X1
+    x2 = _X2
+    for y in range(GRID_H):
+        # Row terms: independent of x, so lift them out of the inner loop.
+        yr = (sin[(y * 6 - t) & _MASK] + sin[(y * 3 + t * 2) & _MASK]) & _MASK
+        yd = (y * 5) & _MASK
+        tx = t & _MASK
+        txy = t & _MASK
+        for x in range(GRID_W):
+            v = (
+                sin[(x1[x] + tx) & _MASK]
+                + yr
+                + sin[(x2[x] + yd + txy) & _MASK]
+            )
+            pixel(x, y, pal[v & _MASK])
+
+
+_t = 0
+
+
+def main():
+    """Render one frame (advance the field, present, pace)."""
+    global _t
+    _render(_t)
+    display_drv.blit_rect(_dest.buffer, 0, 0, GRID_W, GRID_H)
+    display_drv.show()
+    _t += TIME_STEP
+    sleep_ms(FRAME_MS)
+
+
+main()  # one frame; importing the module never loops forever
+
+if __name__ == "__main__":
+    try:
+        while not _stop():
+            main()
+    except KeyboardInterrupt:
+        pass

--- a/src/examples/pixel_sim_reel.py
+++ b/src/examples/pixel_sim_reel.py
@@ -1,0 +1,83 @@
+"""
+pixel_sim_reel.py — play every pixel_sim demo back to back on the simulator.
+
+Runs the demo reel (``scroll`` -> ``plasma`` -> ``fire`` -> ``matrix`` ->
+``starfield``) in succession, giving each ``SECONDS`` of screen time before
+advancing.  All demos share the one ``pixel_sim`` backend and ``runtime``, so it
+is **time-boxed** rather than close-to-advance: closing the window (or Ctrl-C)
+ends the whole reel.
+
+``scroll`` advances at cycle boundaries (its ``main()`` is one full
+scroll+gradient cycle); the frame-based effects advance every frame.
+
+Run it as the main program to loop the reel forever (closes with the window):
+
+    cd src && python -c "import lib.path, runpy; runpy.run_path('examples/pixel_sim_reel.py', run_name='__main__')"
+
+On MicroPython, launch ``micropython`` from ``src/``, then::
+
+    import lib.path
+    import pixel_sim_reel
+
+Plain ``import pixel_sim_reel`` plays the reel once through and returns.
+"""
+
+from multimer import ticks_add, ticks_diff, ticks_ms
+from pixel_sim import runtime
+
+DEMOS = (
+    "pixel_sim_scroll",
+    "pixel_sim_plasma",
+    "pixel_sim_fire",
+    "pixel_sim_matrix",
+    "pixel_sim_starfield",
+)
+SECONDS = 6  # screen time per demo before advancing
+
+try:
+    import pydisplay_test_mode  # type: ignore[import-not-found]
+
+    _TEST_DURATION_S = pydisplay_test_mode.DURATION_S if pydisplay_test_mode.ENABLED else None
+except ImportError:
+    _TEST_DURATION_S = None
+
+_START = ticks_ms()
+
+
+def _stop():
+    """Poll input so the window closes; True when quitting or the test times out."""
+    if runtime is not None:
+        runtime.poll()
+        if runtime.quit_requested:
+            return True
+    if _TEST_DURATION_S is not None and ticks_diff(ticks_ms(), _START) >= _TEST_DURATION_S * 1000:
+        return True
+    return False
+
+
+def _play(module, seconds):
+    """Run one demo for ``seconds``; True if the whole reel should stop."""
+    deadline = ticks_add(ticks_ms(), int(seconds * 1000))
+    while ticks_diff(deadline, ticks_ms()) > 0:
+        module.main()
+        if _stop():
+            return True
+    return False
+
+
+def main():
+    """Play every demo once, in order (returns early on quit)."""
+    for name in DEMOS:
+        module = __import__(name)
+        if _play(module, SECONDS):
+            return
+
+
+main()  # play the reel once through; importing never loops forever
+
+if __name__ == "__main__":
+    try:
+        while not _stop():
+            main()
+    except KeyboardInterrupt:
+        pass

--- a/src/examples/pixel_sim_scroll.py
+++ b/src/examples/pixel_sim_scroll.py
@@ -1,0 +1,124 @@
+"""
+pixel_sim_scroll.py — rainbow marquee + gradient scene on the NeoPixel simulator.
+
+Larger LED grid (64x16 by default) driven by ``pixel_sim`` / ``PixelDisplay``.
+
+Loop:
+  1. Scroll rainbow text (one ``palettes`` wheel color per character, rendered
+     once with ``text8`` — the ``font_simpletest.py`` render-to-buffer method)
+     all the way across and off the left edge.
+  2. Paint a vertical ``graphics.gradient_rect`` sunset and draw a sun on top
+     with ``graphics.circle``; hold it for a moment.
+  3. Repeat.
+
+``runtime.poll()`` runs every frame so the desktop window stays closable.
+
+Run it as the main program to loop forever (closes with the window / Ctrl-C):
+
+    cd src && python -c "import lib.path, runpy; runpy.run_path('examples/pixel_sim_scroll.py', run_name='__main__')"
+
+Plain ``import pixel_sim_scroll`` runs a single scroll+gradient cycle and returns.
+"""
+
+import time
+
+import graphics
+from graphics import RGB565, FrameBuffer, text8
+from multimer import sleep_ms
+from palettes import get_palette
+from pixel_sim import display_drv, runtime
+
+CHAR_W = 8
+FONT_H = 8
+GRID_W = display_drv.width
+GRID_H = display_drv.height
+Y = (GRID_H - FONT_H) // 2
+
+FRAME_MS = 30
+SCROLL_STEP = 3  # pixels per frame — higher is a faster marquee
+
+TEXT = "PyDisplay * rainbow marquee * "
+SRC_W = len(TEXT) * CHAR_W
+
+# Sunset scene colors (RGB565): warm orange sky fading to deep purple, yellow sun.
+SKY_TOP = 0xFB60
+SKY_BOTTOM = 0x480F
+SUN = 0xFFE0
+SUN_EDGE = 0xFD20
+HOLD_FRAMES = 150  # ~4.5s pause on the gradient scene
+
+# One wheel color per character across the full spectrum.
+_pal = get_palette(name="wheel", color_depth=16, length=len(TEXT))
+
+# Render the whole string once (text8 into a wide off-screen buffer, x >= 0).
+_src = FrameBuffer(bytearray(SRC_W * GRID_H * 2), SRC_W, GRID_H, RGB565)
+_src.fill(0x0000)
+for _i, _ch in enumerate(TEXT):
+    text8(_src, _ch, _i * CHAR_W, Y, _pal[_i])
+
+# Grid-sized scratch composited each frame, then blitted to the LED grid.
+_dest = FrameBuffer(bytearray(GRID_W * GRID_H * 2), GRID_W, GRID_H, RGB565)
+
+try:
+    import pydisplay_test_mode  # type: ignore[import-not-found]
+
+    _TEST_DURATION_S = pydisplay_test_mode.DURATION_S if pydisplay_test_mode.ENABLED else None
+except ImportError:
+    _TEST_DURATION_S = None
+
+
+def _present():
+    display_drv.blit_rect(_dest.buffer, 0, 0, GRID_W, GRID_H)
+    display_drv.show()
+
+
+_START = time.time()
+
+
+def _stop():
+    """Poll input so the window closes; True when quitting or the test times out."""
+    if runtime is not None:
+        runtime.poll()
+        if runtime.quit_requested:
+            return True
+    if _TEST_DURATION_S is not None and time.time() - _START >= _TEST_DURATION_S:
+        return True
+    return False
+
+
+def _draw_gradient_scene():
+    graphics.gradient_rect(_dest, 0, 0, GRID_W, GRID_H, SKY_TOP, SKY_BOTTOM, vertical=True)
+    r = max(2, min(GRID_W, GRID_H) // 4)
+    cx, cy = GRID_W // 2, GRID_H // 2
+    graphics.circle(_dest, cx, cy, r, SUN, f=True)
+    graphics.circle(_dest, cx, cy, r, SUN_EDGE)
+
+
+def main():
+    """Run one scroll+gradient cycle (returns at the end, or early on quit)."""
+    # Phase 1: text enters from the right and scrolls fully off the left.
+    for scroll in range(0, GRID_W + SRC_W + 1, SCROLL_STEP):
+        _dest.fill(0x0000)
+        _dest.blit(_src, GRID_W - scroll, 0)
+        _present()
+        if _stop():
+            return
+        sleep_ms(FRAME_MS)
+
+    # Phase 2: gradient sunset with a sun on top, held for a beat.
+    _draw_gradient_scene()
+    _present()
+    for _ in range(HOLD_FRAMES):
+        if _stop():
+            return
+        sleep_ms(FRAME_MS)
+
+
+main()  # one cycle; importing the module never loops forever
+
+if __name__ == "__main__":
+    try:
+        while not _stop():
+            main()
+    except KeyboardInterrupt:
+        pass

--- a/src/examples/pixel_sim_starfield.py
+++ b/src/examples/pixel_sim_starfield.py
@@ -1,0 +1,127 @@
+"""
+pixel_sim_starfield.py — 3D starfield flying toward the viewer.
+
+Stars stream out of a central vanishing point: each has a fixed ``x``/``y`` in
+world space and a depth ``z`` that shrinks every frame.  Perspective projection
+(``sx = W//2 + x*FOCAL//z``) spreads them outward and accelerates them as they
+approach, while brightness scales inversely with ``z`` so near stars burn bright
+white and distant ones fade to dim blue.  A star respawns at ``ZMAX`` with fresh
+random ``x``/``y`` once it passes the viewer or projects off-screen.
+
+All projection is integer math (no per-pixel floats) for MCU friendliness.
+
+``runtime.poll()`` runs every frame so the desktop window stays closable.
+
+Run it as the main program to loop forever (closes with the window / Ctrl-C):
+
+    cd src && python -c "import lib.path, runpy; runpy.run_path('examples/pixel_sim_starfield.py', run_name='__main__')"
+
+Plain ``import pixel_sim_starfield`` renders a single frame and returns.
+"""
+
+import time
+from random import getrandbits
+
+from displaysys import color565
+from graphics import RGB565, FrameBuffer
+from multimer import sleep_ms
+from pixel_sim import display_drv, runtime
+
+GRID_W = display_drv.width
+GRID_H = display_drv.height
+
+FRAME_MS = 30
+NUM_STARS = 80
+FOCAL = 48  # projection focal length; larger = flatter approach
+ZMAX = 255  # spawn depth (also caps brightness scaling)
+ZMIN = 8  # respawn once a star is closer than this
+SPEED = 4  # depth decrease per frame
+BLACK = 0x0000
+
+# Brightness ramp keyed by depth bucket: near stars are white, far stars are a
+# dim blue so the field reads as receding.  Precomputed to keep the loop float-free.
+_TINT = [color565(255 - z, 255 - z, 255) for z in range(ZMAX + 1)]
+
+
+def _randint(a, b):
+    span = b - a + 1
+    if span <= 1:
+        return a
+    bits = 0
+    n = span - 1
+    while n:
+        bits += 1
+        n >>= 1
+    return a + getrandbits(bits) % span
+
+
+def _spawn():
+    return [_randint(-GRID_W, GRID_W), _randint(-GRID_H, GRID_H), ZMAX]
+
+
+_stars = [_spawn() for _ in range(NUM_STARS)]
+
+_dest = FrameBuffer(bytearray(GRID_W * GRID_H * 2), GRID_W, GRID_H, RGB565)
+
+try:
+    import pydisplay_test_mode  # type: ignore[import-not-found]
+
+    _TEST_DURATION_S = pydisplay_test_mode.DURATION_S if pydisplay_test_mode.ENABLED else None
+except ImportError:
+    _TEST_DURATION_S = None
+
+
+_START = time.time()
+
+
+def _stop():
+    """Poll input so the window closes; True when quitting or the test times out."""
+    if runtime is not None:
+        runtime.poll()
+        if runtime.quit_requested:
+            return True
+    if _TEST_DURATION_S is not None and time.time() - _START >= _TEST_DURATION_S:
+        return True
+    return False
+
+
+def _step():
+    _dest.fill(BLACK)
+    pixel = _dest.pixel
+    cx = GRID_W // 2
+    cy = GRID_H // 2
+    tint = _TINT
+    for star in _stars:
+        star[2] -= SPEED
+        z = star[2]
+        if z <= ZMIN:
+            star[0] = _randint(-GRID_W, GRID_W)
+            star[1] = _randint(-GRID_H, GRID_H)
+            star[2] = ZMAX
+            continue
+        sx = cx + star[0] * FOCAL // z
+        sy = cy + star[1] * FOCAL // z
+        if 0 <= sx < GRID_W and 0 <= sy < GRID_H:
+            pixel(sx, sy, tint[z])
+        else:
+            star[0] = _randint(-GRID_W, GRID_W)
+            star[1] = _randint(-GRID_H, GRID_H)
+            star[2] = ZMAX
+
+
+def main():
+    """Render one frame (advance the stars, present, pace)."""
+    _step()
+    display_drv.blit_rect(_dest.buffer, 0, 0, GRID_W, GRID_H)
+    display_drv.show()
+    sleep_ms(FRAME_MS)
+
+
+main()  # one frame; importing the module never loops forever
+
+if __name__ == "__main__":
+    try:
+        while not _stop():
+            main()
+    except KeyboardInterrupt:
+        pass

--- a/src/lib/board_config.py
+++ b/src/lib/board_config.py
@@ -6,8 +6,6 @@ board_config.py file that is specific to your hardware from:
 https://github.com/PyDevices/pydisplay/tree/main/board_configs
 """
 
-import os
-
 # Default portrait panel (320x480). Games scale layout for taller/wider panels
 # (e.g. 480x800, 720x720) via display_drv.width / height.
 width = 320
@@ -15,7 +13,6 @@ height = 480
 rotation = 0
 scale = 2
 
-_TIMER_ASYNC = os.environ.get("PYDISPLAY_TIMER_ASYNC", "").lower() in ("1", "true", "yes")
 
 _ps = _jn = False
 try:
@@ -84,6 +81,6 @@ else:
         title=f"{sys.implementation.name} on {sys.platform}",
         scale=scale,
     )
-    runtime = eventsys.Runtime(display=display_drv, host_read=get_events, timer_async=_TIMER_ASYNC)
+    runtime = eventsys.Runtime(display=display_drv, host_read=get_events)
 
 display_drv.fill(0)

--- a/src/lib/displaysys/pixeldisplay.py
+++ b/src/lib/displaysys/pixeldisplay.py
@@ -5,60 +5,211 @@
 """
 displaysys.pixeldisplay — addressable LED grids (NeoPixel, DotStar, etc.).
 
-Wraps a software pixel framebuffer that flushes with ``show()`` rather than
-``refresh()``.  On CircuitPython this is typically ``adafruit_pixel_framebuf``.
+MicroPython: ``PixelFramebuffer`` (``graphics.FrameBuffer`` + grid map) and
+``PixelDisplay`` live here.  CircuitPython board configs use
+``adafruit_pixel_framebuf.PixelFramebuffer`` with pydisplay ``PixelDisplay``.
 """
 
-from displaysys import DisplayDriver
+try:
+    from micropython import const
+except ImportError:
+
+    def const(x):
+        return x
+
+
+from displaysys import DisplayDriver, color_rgb
+import graphics
+
+
+def _color888_from_565(c):
+    r, g, b = color_rgb(c)
+    return (r << 16) | (g << 8) | b
+
+
+HORIZONTAL = const(1)
+VERTICAL = const(2)
+
+
+def _horizontal_strip_gridmap(width, alternating=True):
+    def mapper(x, y):
+        if alternating and y % 2:
+            return y * width + (width - 1 - x)
+        return y * width + x
+
+    return mapper
+
+
+def _vertical_strip_gridmap(height, alternating=True):
+    def mapper(x, y):
+        if alternating and x % 2:
+            return x * height + (height - 1 - y)
+        return x * height + y
+
+    return mapper
+
+
+def _reverse_x_mapper(width, mapper):
+    max_x = width - 1
+
+    def x_mapper(x, y):
+        return mapper(max_x - x, y)
+
+    return x_mapper
+
+
+def _reverse_y_mapper(height, mapper):
+    max_y = height - 1
+
+    def y_mapper(x, y):
+        return mapper(x, max_y - y)
+
+    return y_mapper
+
+
+def _build_grid_mapper(
+    width,
+    height,
+    *,
+    orientation=HORIZONTAL,
+    alternating=True,
+    reverse_x=False,
+    reverse_y=False,
+    top=0,
+    bottom=0,
+):
+    if orientation == HORIZONTAL:
+        mapper = _horizontal_strip_gridmap(width, alternating)
+    else:
+        mapper = _vertical_strip_gridmap(height, alternating)
+
+    if reverse_x:
+        mapper = _reverse_x_mapper(width, mapper)
+    if reverse_y:
+        mapper = _reverse_y_mapper(height, mapper)
+
+    x_start = 0
+    x_end = width
+    y_start = 0
+    y_end = height
+    if top:
+        x_start, y_start = top
+    if bottom:
+        x_end, y_end = bottom
+
+    grid_width = x_end - x_start
+    grid_height = y_end - y_start
+    indices = []
+    for _y in range(grid_height):
+        for _x in range(grid_width):
+            indices.append(mapper(_x + x_start, _y + y_start))
+    return grid_width, grid_height, indices
+
+
+class PixelFramebuffer(graphics.FrameBuffer):
+    """
+    NeoPixel / DotStar grid framebuffer for MicroPython.
+
+    Same constructor signature as ``adafruit_pixel_framebuf.PixelFramebuffer``.
+    Flush changed pixels to the strip with ``display()``.
+    """
+
+    def __init__(
+        self,
+        pixels,
+        width,
+        height,
+        orientation=HORIZONTAL,
+        alternating=True,
+        reverse_x=False,
+        reverse_y=False,
+        top=0,
+        bottom=0,
+        rotation=0,
+    ):
+        self._pixels = pixels
+        grid_width, grid_height, self._indices = _build_grid_mapper(
+            width,
+            height,
+            orientation=orientation,
+            alternating=alternating,
+            reverse_x=reverse_x,
+            reverse_y=reverse_y,
+            top=top,
+            bottom=bottom,
+        )
+        self._width = grid_width
+        self._height = grid_height
+        buf = bytearray(grid_width * grid_height * 3)
+        self._double_buffer = bytearray(grid_width * grid_height * 3)
+        super().__init__(buf, grid_width, grid_height, graphics.RGB888)
+        self.rotation = rotation
+
+    @property
+    def stride(self):
+        return self._width
+
+    def blit(self):
+        raise NotImplementedError
+
+    def display(self) -> None:
+        """Copy changed pixels to the LED strip and show."""
+        stride = self.stride
+        for _y in range(self._height):
+            for _x in range(self._width):
+                index = (_y * stride + _x) * 3
+                if self._buffer[index : index + 3] != self._double_buffer[index : index + 3]:
+                    grid_index = _y * self._width + _x
+                    strip_index = self._indices[grid_index]
+                    self._pixels[strip_index] = tuple(self._buffer[index : index + 3])
+                    self._double_buffer[index : index + 3] = self._buffer[index : index + 3]
+        self._pixels.show()
 
 
 class PixelDisplay(DisplayDriver):
     """
     DisplayDriver for addressable-LED matrix layouts.
 
+    Exposes the usual RGB565 ``DisplayDriver`` API (``color_depth=16``).  The
+    inner ``PixelFramebuffer`` stores RGB888 for the LED strip; conversion uses
+    ``color_rgb``.
+
     Args:
-        pixel_buffer: Object with framebuf drawing API and ``show()`` (e.g.
-            ``PixelFramebuffer``).
-        width (int, optional): Override width; defaults to ``pixel_buffer.width``.
-        height (int, optional): Override height; defaults to ``pixel_buffer.height``.
-        color_depth (int, optional): Bits per pixel. Defaults to 24 (RGB888).
+        pixel_buffer: ``PixelFramebuffer`` (or Adafruit equivalent on CircuitPython).
     """
 
-    def __init__(self, pixel_buffer, width=None, height=None, color_depth=24):
+    def __init__(self, pixel_buffer):
         self._raw_buffer = pixel_buffer
-        self._width = width if width is not None else pixel_buffer.width
-        self._height = height if height is not None else pixel_buffer.height
-        self._rotation = 0
-        self.color_depth = color_depth
+        self._width = pixel_buffer.width
+        self._height = pixel_buffer.height
+        self._rotation = getattr(pixel_buffer, "rotation", 0)
+        self.color_depth = 16
         self._requires_byteswap = False
         super().__init__()
 
     def init(self) -> None:
         pass
 
-    def _draw(self, method, *args):
-        fn = getattr(self._raw_buffer, method, None)
-        if fn is None:
-            raise AttributeError(f"pixel buffer has no {method!r}")
-        return fn(*args)
-
     def fill_rect(self, x, y, w, h, c):
-        return self._draw("fill_rect", x, y, w, h, c)
+        return self._raw_buffer.fill_rect(x, y, w, h, _color888_from_565(c))
 
     def blit_rect(self, buf, x, y, w, h):
-        fn = getattr(self._raw_buffer, "blit", None)
-        if fn is not None:
-            return fn(buf, x, y, w, h)
-        # Fallback: per-row blit via fill_rect if buffer is raw bytes
-        bpp = max(1, self.color_depth // 8)
-        row_bytes = w * bpp
+        bpp = self.color_depth // 8
+        expected = w * h * bpp
+        if len(buf) != expected:
+            raise ValueError(
+                f"The source buffer is not the correct size (got {len(buf)} bytes, expected {expected})"
+            )
+        inner = self._raw_buffer
         for row in range(h):
-            row_buf = buf[row * row_bytes : (row + 1) * row_bytes]
-            self._draw("blit", row_buf, x, y + row, w, 1)
+            row_base = row * w * bpp
+            for col in range(w):
+                off = row_base + col * bpp
+                inner.pixel(x + col, y + row, _color888_from_565(buf[off : off + bpp]))
         return (x, y, w, h)
 
     def pixel(self, x, y, c):
-        return self._draw("pixel", x, y, c)
+        return self._raw_buffer.pixel(x, y, _color888_from_565(c))
 
     def show(self, _timer=None) -> None:
-        self._raw_buffer.show()
+        self._raw_buffer.display()

--- a/src/lib/graphics/__init__.py
+++ b/src/lib/graphics/__init__.py
@@ -37,6 +37,7 @@ from ._framebuf_plus import (
     MONO_HMSB,
     MONO_VLSB,
     RGB565,
+    RGB888,
     FrameBuffer,
 )
 from ._shapes import (

--- a/src/lib/graphics/_framebuf_plus.py
+++ b/src/lib/graphics/_framebuf_plus.py
@@ -43,8 +43,46 @@ init_capabilities(
         "GS2_HMSB",
         "GS4_HMSB",
         "GS8",
+        "RGB888",
     ],
 )
+
+
+# pydisplay extension — not in native MicroPython framebuf
+RGB888 = 7
+
+
+class _RGB888Format:
+    depth = 24
+
+    @staticmethod
+    def set_pixel(framebuf, x, y, color):
+        index = (y * framebuf._stride + x) * 3
+        framebuf._buffer[index : index + 3] = bytes(
+            ((color >> 16) & 0xFF, (color >> 8) & 0xFF, color & 0xFF)
+        )
+
+    @staticmethod
+    def get_pixel(framebuf, x, y):
+        index = (y * framebuf._stride + x) * 3
+        r, g, b = framebuf._buffer[index : index + 3]
+        return (r << 16) | (g << 8) | b
+
+    @staticmethod
+    def fill(framebuf, color):
+        rgb = bytes(((color >> 16) & 0xFF, (color >> 8) & 0xFF, color & 0xFF))
+        for i in range(0, len(framebuf._buffer), 3):
+            framebuf._buffer[i : i + 3] = rgb
+
+    @staticmethod
+    def fill_rect(framebuf, x, y, width, height, color):
+        rgb = bytes(((color >> 16) & 0xFF, (color >> 8) & 0xFF, color & 0xFF))
+        stride = framebuf._stride
+        for _y in range(y, y + height):
+            row = _y * stride
+            for _x in range(x, x + width):
+                index = (row + _x) * 3
+                framebuf._buffer[index : index + 3] = rgb
 
 
 class FrameBuffer(_FrameBuffer):
@@ -76,6 +114,29 @@ class FrameBuffer(_FrameBuffer):
     """
 
     def __init__(self, buffer, width, height, format, *args, **kwargs):
+        if format == RGB888:
+            # Native MicroPython framebuf has no RGB888 format.  When a native-framebuf
+            # subclass's __init__ never calls the native super().__init__, MicroPython
+            # falls back to invoking native make_new with the *constructor* args — which
+            # rejects RGB888 ("invalid format", or "missing N positional arguments" when
+            # a subclass has a different signature).  So on native framebuf we initialize
+            # the base as RGB565 (2 bytes/pixel, always fits our 3 bytes/pixel buffer)
+            # purely to satisfy that init; every RGB888 pixel op below is handled by
+            # _RGB888Format against self._buffer, so the native state is never used.
+            # On CPython (pure-Python _framebuf) there is no make_new fallback, so skip
+            # it and leave the buffer untouched.
+            if _NATIVE_FRAMEBUF:
+                super().__init__(buffer, width, height, RGB565)
+            self._width = width
+            self._height = height
+            self._fb_format = format
+            self._buffer = buffer
+            stride = args[0] if args else kwargs.get("stride")
+            self._stride = stride if stride is not None else width
+            self._color_depth = 24
+            self._rgb888 = True
+            return
+        self._rgb888 = False
         super().__init__(buffer, width, height, format, *args, **kwargs)
         self._width = width
         self._height = height
@@ -128,6 +189,9 @@ class FrameBuffer(_FrameBuffer):
         Returns:
             (Area): Bounding box of the filled rectangle
         """
+        if self._rgb888:
+            _RGB888Format.fill_rect(self, x, y, w, h, c)
+            return Area(x, y, w, h)
         super().fill_rect(x, y, w, h, c)
         return Area(x, y, w, h)
 
@@ -143,6 +207,11 @@ class FrameBuffer(_FrameBuffer):
         Returns:
             (Area): Bounding box of the pixel
         """
+        if self._rgb888:
+            if c is None:
+                return _RGB888Format.get_pixel(self, x, y)
+            _RGB888Format.set_pixel(self, x, y, c)
+            return Area(x, y, 1, 1)
         if c is None:
             return super().pixel(x, y)
         super().pixel(x, y, c)
@@ -158,6 +227,9 @@ class FrameBuffer(_FrameBuffer):
         Returns:
             (Area): Bounding box of the filled buffer
         """
+        if self._rgb888:
+            _RGB888Format.fill(self, c)
+            return Area(0, 0, self.width, self.height)
         super().fill(c)
         return Area(0, 0, self.width, self.height)
 

--- a/tests/test_pixeldisplay.py
+++ b/tests/test_pixeldisplay.py
@@ -1,0 +1,116 @@
+# SPDX-FileCopyrightText: 2026 Brad Barnett
+#
+# SPDX-License-Identifier: MIT
+"""Tests for displaysys.pixeldisplay."""
+
+import unittest
+
+import _env  # noqa: F401
+
+from displaysys.pixeldisplay import (
+    HORIZONTAL,
+    PixelDisplay,
+    PixelFramebuffer,
+    _build_grid_mapper,
+)
+
+
+def _horizontal_index(x, y, width, alternating):
+    if alternating and y % 2:
+        return y * width + (width - 1 - x)
+    return y * width + x
+
+
+class MockStrip:
+    def __init__(self, count):
+        self.count = count
+        self.data = [(0, 0, 0)] * count
+        self.show_calls = 0
+
+    def __setitem__(self, index, value):
+        self.data[index] = value
+
+    def show(self):
+        self.show_calls += 1
+
+
+class TestPixelGridMap(unittest.TestCase):
+    def test_8x8_alternating_horizontal(self):
+        _, _, indices = _build_grid_mapper(8, 8, orientation=HORIZONTAL, alternating=True)
+        self.assertEqual(len(indices), 64)
+        for y in range(8):
+            for x in range(8):
+                self.assertEqual(
+                    indices[y * 8 + x],
+                    _horizontal_index(x, y, 8, True),
+                )
+
+    def test_12x6_not_alternating_horizontal(self):
+        _, _, indices = _build_grid_mapper(12, 6, orientation=HORIZONTAL, alternating=False)
+        self.assertEqual(len(indices), 72)
+        for y in range(6):
+            for x in range(12):
+                self.assertEqual(indices[y * 12 + x], y * 12 + x)
+
+
+class TestPixelFramebuffer(unittest.TestCase):
+    def test_display_writes_changed_pixels(self):
+        strip = MockStrip(32)
+        fb = PixelFramebuffer(strip, 8, 4, alternating=False)
+        fb.fill(0xFF0000)
+        fb.display()
+        self.assertEqual(strip.show_calls, 1)
+        self.assertEqual(strip.data[0], (255, 0, 0))
+        self.assertEqual(strip.data[31], (255, 0, 0))
+
+        fb.display()
+        self.assertEqual(strip.show_calls, 2)
+
+        fb.pixel(0, 0, 0x0000FF)
+        fb.display()
+        self.assertEqual(strip.data[0], (0, 0, 255))
+        self.assertEqual(strip.data[1], (255, 0, 0))
+
+
+class TestPixelDisplay(unittest.TestCase):
+    def test_show_calls_display(self):
+        class Framebuf:
+            width = 4
+            height = 4
+            rotation = 0
+            display_calls = 0
+
+            def display(self):
+                Framebuf.display_calls += 1
+
+        buf = Framebuf()
+        drv = PixelDisplay(buf)
+        drv.show()
+        self.assertEqual(Framebuf.display_calls, 1)
+
+    def test_color_depth_is_16(self):
+        strip = MockStrip(32)
+        fb = PixelFramebuffer(strip, 8, 4, alternating=False)
+        drv = PixelDisplay(fb)
+        self.assertEqual(drv.color_depth, 16)
+
+    def test_fill_rect_converts_565_to_strip_rgb(self):
+        strip = MockStrip(32)
+        fb = PixelFramebuffer(strip, 8, 4, alternating=False)
+        drv = PixelDisplay(fb)
+        drv.fill_rect(0, 0, 1, 1, 0xFFFF)
+        drv.show()
+        self.assertEqual(strip.data[0], (255, 255, 255))
+
+    def test_blit_rect_converts_565_buffer(self):
+        strip = MockStrip(32)
+        fb = PixelFramebuffer(strip, 8, 4, alternating=False)
+        drv = PixelDisplay(fb)
+        buf = bytes((0x00, 0xF8))  # 565 red, little-endian
+        drv.blit_rect(buf, 1, 0, 1, 1)
+        drv.show()
+        self.assertEqual(strip.data[1], (255, 0, 0))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- **Fix RGB888 `graphics.FrameBuffer` on native MicroPython** (`graphics._framebuf_plus`): an RGB888 subclass whose `__init__` never calls the native `super().__init__` triggers MicroPython's `make_new` fallback, which rejects format `7` (`invalid format` / `missing N positional arguments`). We now initialize the native base as `RGB565` (2 bytes/pixel, always fits the 3 bytes/pixel buffer) so the fallback never fires; all RGB888 pixel ops stay routed through `_RGB888Format`. CPython (pure-Python `_framebuf`) is unaffected. This unbreaks `PixelFramebuffer` and `PixelDisplay` on MicroPython, and exports `RGB888` from `graphics`.
- **Add a NeoPixel/DotStar desktop simulator + demos** (`src/examples/pixel_sim`): `SimPixelFramebuffer` scales an RGB888 LED grid onto the shared `displaysys` backend and reuses the host runtime for a closable window. Demos: `pixel_sim_scroll`, `_plasma`, `_fire`, `_matrix`, `_starfield`, and a `_reel` that plays them in sequence. Each does one unit of work on import and only loops forever under `__main__`.
- **Align `PixelDisplay` to the 16-bit RGB565 `DisplayDriver` API** (`color_depth=16`, 565→888 internally); add `tests/test_pixeldisplay.py` and a `display-backends` concepts doc (linked from `displays.md` and the displaysys overview).
- **Drop the obsolete `PYDISPLAY_TIMER_ASYNC` / `os.environ` read** in the shared `board_config` (also crashed on MicroPython, which has no `os.environ`).

## Test plan
- [x] `graphics.FrameBuffer(..., RGB888)` round-trips on MicroPython (`0x123456` in/out, `color_depth 24`) and CPython.
- [x] Real `PixelFramebuffer` constructs and flushes on MicroPython (previously raised `missing 1 required positional arguments`).
- [x] All 5 `pixel_sim_*` demos import/render on CPython; each runs individually on MicroPython (real X display).
- [x] `.venv/bin/python -m unittest discover -s tests` passes.
- [x] `ruff check` / `ruff format --check` clean on changed files; pre-commit hooks pass.

Note: this branch intentionally does **not** include the in-progress `board_configs/ → scripts/board_config` reorganization (kept out because it currently has lint/import regressions).