### PR TITLE
Replace multimer type markers; fix lv_touch_test CPython race

### DIFF
--- a/docs/examples/app-starter.md
+++ b/docs/examples/app-starter.md
@@ -19,10 +19,9 @@ Save the boilerplate as `main.py` (or any name you prefer) and run it from the R
 
 === "Sync (queued / sync)"
 
-    Blocking main loop via `multimer.run_forever()`. Use on MCU, desktop CPython, and any port where your app is not asyncio-native. Tagged `# multimer types: queued, sync`.
+    Blocking main loop via `multimer.run_forever()`. Use on MCU, desktop CPython, and any port where your app is not asyncio-native.
 
     ```python
-    # multimer types: queued, sync
     """
     my_app.py — starting point for a pydisplay app.
 
@@ -83,10 +82,10 @@ Save the boilerplate as `main.py` (or any name you prefer) and run it from the R
 
 === "Async (asyncio)"
 
-    Asyncio main loop via `multimer.run_forever()`. Use on PyScript or any port where the app already runs under `asyncio` / `uasyncio`. Tagged `# multimer types: async`.
+    Asyncio main loop via `multimer.run_forever()`. Use on PyScript or any port where the app already runs under `asyncio` / `uasyncio`. For the browser gallery, add `# pyscript gallery: async`.
 
     ```python
-    # multimer types: async
+    # pyscript gallery: async
     """
     my_app_async.py — asyncio starting point for a pydisplay app.
 
@@ -147,10 +146,10 @@ Save the boilerplate as `main.py` (or any name you prefer) and run it from the R
 
 === "Dual (sync + async)"
 
-    One entry file for desktop **and** PyScript. `runtime.timer_async` selects the path; `dual_main()` calls `main_sync()` or schedules `main_async()`. Tagged `# multimer types: async` (PyScript gallery convention). Pass `async_=runtime.timer_async` to `periodic()` when you add periodic timers.
+    One entry file for desktop **and** PyScript. `runtime.timer_async` selects the path; `dual_main()` calls `main_sync()` or schedules `main_async()`. For the browser gallery, add `# pyscript gallery: async`. Pass `async_=runtime.timer_async` to `periodic()` when you add periodic timers.
 
     ```python
-    # multimer types: async
+    # pyscript gallery: async
     """
     my_app_dual.py — one file for sync desktop and async PyScript.
 

--- a/docs/examples/index.md
+++ b/docs/examples/index.md
@@ -11,60 +11,27 @@ Use `import lib.path` first in a development clone (see [full clone](../installa
 !!! tip "Start here"
     New to pydisplay? Copy the [**App starter**](app-starter.md) boilerplate to begin your first app, then read the [**pydisplay_demo** guide](pydisplay_demo.md) for rotation, scrolling, and buffered text.
 
-## multimer portability markers
+## PyScript gallery markers
 
-As examples are reviewed for [multimer](../concepts/multimer.md) portability (sync, queued, and async timer patterns), each updated script gets a **first-line comment** tagging which timer styles it supports:
+Examples that appear in the [browser gallery](https://PyDevices.github.io/pydisplay/pyscript/) carry a header comment used by `scripts/pyscript_gen_packages.py`:
 
 ```python
-# multimer types: all
+# pyscript gallery: all
 ```
 
-Every runnable example (top-level scripts under `src/examples/*.py` and the subdirectory demos) carries a marker. Shared modules and test harnesses are tagged `NA`.
+| Tag | Gallery section |
+|-----|-----------------|
+| `async` | Async demos (asyncio / `dual_main` / `timer_async`) |
+| `all` | Blocking or dual-path demos that still run after **Run** in the browser |
 
-### Tag values
-
-| Tag | Meaning |
-|-----|---------|
-| `all` | Same code on MCU, desktop sync, and PyScript/Jupyter — poll/`sleep_ms` loops with quit handling, or library helpers (`pd.run_forever`) |
-| `queued, sync` | Explicit `run_forever`/`periodic` timer loop or game/LVGL test (`pydisplay_demo`, `testris`, `lv_test_timer`) |
-| `sync` | Sync-only or one-shot on the main thread (`console_advanced_demo.py` uses `os.dupterm` + one `display_drv.show()`) |
-| `async` | `runtime.timer_async` + `asyncio` main loop |
-| `NA` | Not applicable — shared module or test harness, not a runnable portability example |
+Omit the marker (or use `# pyscript skip: gallery`) to keep a script out of the card grid. Binary-dependent demos use `# pyscript binaries:` and are excluded automatically. See [PyScript local development](../guides/pyscript.md).
 
 ### Search commands
 
-List all marked examples:
-
 ```bash
-rg '^# multimer types:' src/examples/*.py
-```
-
-List examples tagged for every timer style:
-
-```bash
-rg '^# multimer types: all' src/examples/*.py
-```
-
-List unmarked top-level examples:
-
-```bash
-comm -23 \
-  <(ls -1 src/examples/*.py | xargs -I{} basename {} | sort) \
-  <(rg -l '# multimer types:' src/examples/*.py | xargs -I{} basename {} | sort)
-```
-
-List all marked examples (recursive, including subdirectories):
-
-```bash
-rg '^# multimer types:' src/examples/
-```
-
-List unmarked runnable scripts (path-based; excludes support modules without markers by design):
-
-```bash
-comm -23 \
-  <(find src/examples -path '*/.*' -prune -o -name '*.py' -print | sort) \
-  <(rg -l '# multimer types:' src/examples/ -g '*.py' | sort)
+rg '^# pyscript gallery:' src/examples/
+rg '^# pyscript gallery: async' src/examples/
+rg '^# pyscript gallery: all' src/examples/
 ```
 
 ### Canonical patterns
@@ -144,11 +111,11 @@ pd.run_forever()
 
 ### Notes
 
-- `displaysys_simpletest.py` handles `events.QUIT` in its poll loop (tagged `all`). Same quit pattern as [`scroll_touch_test_displaybuf.py`](https://github.com/PyDevices/pydisplay/blob/main/src/examples/scroll_touch_test_displaybuf.py).
+- `displaysys_simpletest.py` handles `events.QUIT` in its poll loop. Same quit pattern as [`scroll_touch_test_displaybuf.py`](https://github.com/PyDevices/pydisplay/blob/main/src/examples/scroll_touch_test_displaybuf.py).
 - `font_simpletest.py` — string-sized `FrameBuffer`, opaque background, one `blit_rect` per draw (see [Font rendering patterns](../concepts/graphics.md#choosing-a-font-rendering-pattern)).
 - `font_simpletest2.py` — `Font.text(display_drv, …)`; transparent, per-pixel (slowest bus pattern).
 - `font_simpletest3.py` — `DisplayBuffer` + `show(dirty)`; transparent, best when RAM allows a full-screen buffer.
-- `nano_gui_simpletest.py` is tagged `all`; requires upstream [`gui/`](../guis/nano-gui.md) in `add_ons/`.
+- `nano_gui_simpletest.py` requires upstream [`gui/`](../guis/nano-gui.md) in `add_ons/`.
 **Legend:** Platforms = CPython · MCU · PyScript · Wokwi · Packages = core · add_ons · LVGL
 
 ## Suggested learning order
@@ -252,17 +219,17 @@ PyScript requires asyncio — see [PyScript asyncio guide](../guides/pyscript-as
 
 ## Subdirectories
 
-Runnable demos in subfolders use the same multimer markers as top-level examples (`# multimer types: …` first line).
+Runnable demos in subfolders may use the same `# pyscript gallery:` markers as top-level examples.
 
-| Directory | Script | Tag | Platforms | Notes |
-|-----------|--------|-----|-----------|-------|
-| `alien/` | `alien.py` | `all` | CPython · MP · MCU | Sprite bounce; `runtime.poll()` quit each frame |
-| `chango/` | `chango.py` | `all` | CPython · MP · MCU · PyScript | One-shot font demo; `runtime.poll()` after draws |
-| `noto_fonts/` | `noto_fonts.py` | `all` | MP · MCU · PyScript | One-shot Noto font demo; same tail as `chango` |
-| `proverbs/` | `proverbs.py` | `all` | CPython · MP · MCU | Chinese proverb slideshow; quit via `runtime.poll()` |
-| `tiny_toasters/` | `tiny_toasters.py` | `all` | CPython · MP · MCU | Sprite animation; quit via `runtime.poll()` |
-| `apollo_dsky/` | — | — | — | Support module for top-level `apollo.py` |
-| `assets/` | — | — | — | Shared fonts and images |
+| Directory | Script | Platforms | Notes |
+|-----------|--------|-----------|-------|
+| `alien/` | `alien.py` | CPython · MP · MCU | Sprite bounce; `runtime.poll()` quit each frame |
+| `chango/` | `chango.py` | CPython · MP · MCU · PyScript | One-shot font demo; `runtime.poll()` after draws |
+| `noto_fonts/` | `noto_fonts.py` | MP · MCU · PyScript | One-shot Noto font demo; same tail as `chango` |
+| `proverbs/` | `proverbs.py` | CPython · MP · MCU | Chinese proverb slideshow; quit via `runtime.poll()` |
+| `tiny_toasters/` | `tiny_toasters.py` | CPython · MP · MCU | Sprite animation; quit via `runtime.poll()` |
+| `apollo_dsky/` | — | — | Support module for top-level `apollo.py` |
+| `assets/` | — | — | Shared fonts and images |
 
 ## Screenshots and live demos
 

--- a/docs/examples/pydisplay_demo.md
+++ b/docs/examples/pydisplay_demo.md
@@ -13,7 +13,7 @@ It demonstrates:
 - **Hardware-style scrolling** — fixed top/bottom chrome with a scrolling middle panel
 - **Timers** — `multimer.Timer` with a `run_forever` / poll main loop
 
-Tagged `# multimer types: queued, sync` (not `multimer` / PyScript).
+Desktop-oriented sync demo (not in the PyScript gallery; see the async variant below).
 
 ## Run it
 
@@ -237,11 +237,11 @@ This script is intentionally **not** a multimer test, but it uses the default ti
 run_forever(handle_events)  # poll input; timer callbacks run on the active backend
 ```
 
-See [multimer](../concepts/multimer.md) for `queued` vs `sync` vs `async` tags on other examples.
+See [multimer](../concepts/multimer.md) for timer backends and `timer_async`.
 
 ## Async variant
 
-[`pydisplay_demo_async.py`](https://github.com/PyDevices/pydisplay/blob/main/src/examples/pydisplay_demo_async.py) is the same demo with an **asyncio** main loop and **`multimer.AsyncTimer`** for scrolling (tagged `# multimer types: async`). Use it on PyScript or any port where the app already runs under `asyncio` / `uasyncio`:
+[`pydisplay_demo_async.py`](https://github.com/PyDevices/pydisplay/blob/main/src/examples/pydisplay_demo_async.py) is the same demo with an **asyncio** main loop and **`multimer.AsyncTimer`** for scrolling (`# pyscript gallery: async`). Use it on PyScript or any port where the app already runs under `asyncio` / `uasyncio`:
 
 ```python
 import lib.path

--- a/docs/guides/pyscript.md
+++ b/docs/guides/pyscript.md
@@ -23,7 +23,7 @@ Examples in the [browser gallery](https://PyDevices.github.io/pydisplay/pyscript
 
 ## asyncio requirement
 
-PyScript runs on asyncio. **`async`-tagged gallery demos** (`calculator`, `paint`, `eventsys_simpletest`, …) use `multimer.dual_main` / `run_forever_async`. **`all`-tagged demos** run blocking loops after you click **Run** — many now exit on `events.QUIT` via `runtime.quit_requested` or full `runtime.poll()` dispatch. See [PyScript asyncio guide](pyscript-asyncio.md).
+PyScript runs on asyncio. **`async` gallery demos** (`calculator`, `paint`, `eventsys_simpletest`, …) use `multimer.dual_main` / `run_forever_async`. **`all` gallery demos** run blocking loops after you click **Run** — many now exit on `events.QUIT` via `runtime.quit_requested` or full `runtime.poll()` dispatch. See [PyScript asyncio guide](pyscript-asyncio.md).
 
 ## Gallery examples (2026-06)
 

--- a/docs/guis/nano-gui.md
+++ b/docs/guis/nano-gui.md
@@ -78,7 +78,7 @@ micropython -i lib/path.py examples/nano_gui_simpletest.py
 
 Desktop CPython / MicroPython unix also work when `board_config` provides an SDL or PG display.
 
-Tagged `# multimer types: all` in the [examples catalog](../examples/index.md#multimer-portability-markers).
+See `scripts/pyscript_gen_packages.py` and [examples catalog](../examples/index.md#pyscript-gallery-markers).
 
 ## Platform
 

--- a/docs/try/index.md
+++ b/docs/try/index.md
@@ -30,7 +30,7 @@ Evaluate pydisplay without installing anything on your machine.
 Full guide (asyncio porting, compatible examples, board config): [PyScript local development](../guides/pyscript.md).
 
 !!! note "Browser gallery"
-    The [live demo hub](https://PyDevices.github.io/pydisplay/pyscript/) lists examples tagged `# multimer types: async` or `all`. Click **Run** on each page — blocking loops start only after Run. Async examples (`calculator`, `paint`, …) are the smoothest fit. See [PyScript asyncio guide](../guides/pyscript-asyncio.md).
+    The [live demo hub](https://PyDevices.github.io/pydisplay/pyscript/) lists examples tagged `# pyscript gallery: async` or `all`. Click **Run** on each page — blocking loops start only after Run. Async examples (`calculator`, `paint`, …) are the smoothest fit. See [PyScript asyncio guide](../guides/pyscript-asyncio.md).
 
 ## Wokwi (simulator)
 

--- a/scripts/pyscript_gen_packages.py
+++ b/scripts/pyscript_gen_packages.py
@@ -2,7 +2,7 @@
 """
 pyscript_gen_packages.py — refresh the pydisplay PyScript browser gallery.
 
-Scans ``src/examples/`` for ``# multimer types: async|all`` headers, then
+Scans ``src/examples/`` for ``# pyscript gallery: async|all`` headers, then
 resolves PyScript file lists automatically (with optional header overrides):
 
   - **Single-file examples** — the entry ``.py`` only
@@ -20,7 +20,7 @@ Optional headers (first 10 lines):
   - ``# pyscript skip:`` — ``examples/``-relative ``.py`` paths or directories
     omitted from package auto-discovery (e.g. ``my_pkg/dev`` skips all ``.py``
     files under that tree); the token ``gallery`` excludes the example from the
-    browser card grid (multimer tag unchanged)
+    browser card grid (gallery section tag unchanged)
   - ``# pyscript modules:`` — extra ``examples/``-relative ``.py`` paths for
     multi-module loaders when import scanning is insufficient
 
@@ -353,9 +353,9 @@ def parse_example(path: Path) -> Example | None:
     text = path.read_text(encoding="utf-8", errors="replace")
     lines = text.splitlines()
     mtype = ""
-    for line in lines[:5]:
+    for line in lines[:HEADER_SCAN_LINES]:
         s = line.strip()
-        if s.startswith("# multimer types:"):
+        if s.startswith("# pyscript gallery:"):
             mtype = s.split(":", 1)[1].strip().lower()
             break
     if not mtype:

--- a/src/examples/alien/alien.py
+++ b/src/examples/alien/alien.py
@@ -1,4 +1,4 @@
-# multimer types: all
+# pyscript gallery: all
 """
 alien.py
 =========

--- a/src/examples/apollo.py
+++ b/src/examples/apollo.py
@@ -1,4 +1,4 @@
-# multimer types: async
+# pyscript gallery: async
 # pyscript binaries: apollo_dsky/Apollo_DSKY_interface.bmp
 """
 apollo.py — Apollo Guidance Computer DSKY emulator.

--- a/src/examples/bmp565_blit.py
+++ b/src/examples/bmp565_blit.py
@@ -1,4 +1,4 @@
-# multimer types: all
+# pyscript gallery: all
 # pyscript binaries: assets/warrior.bmp
 from color_setup import ssd
 from graphics import BMP565

--- a/src/examples/bmp565_scroll.py
+++ b/src/examples/bmp565_scroll.py
@@ -1,4 +1,4 @@
-# multimer types: all
+# pyscript gallery: all
 # pyscript binaries: assets/longstreet.bmp
 from board_config import display_drv, runtime
 from graphics import BMP565

--- a/src/examples/bmp565_scroll_sprite.py
+++ b/src/examples/bmp565_scroll_sprite.py
@@ -1,4 +1,4 @@
-# multimer types: all
+# pyscript gallery: all
 # pyscript binaries: assets/longstreet.bmp, assets/runner.bmp
 from collections import namedtuple
 

--- a/src/examples/bmp565_simpletest.py
+++ b/src/examples/bmp565_simpletest.py
@@ -1,4 +1,4 @@
-# multimer types: all
+# pyscript gallery: all
 # pyscript binaries: assets/warrior.bmp
 # Loads the full bitmap into memory before blitting it to the display.
 # Will raise a MemoryError on low memory boards # such as RP2040.

--- a/src/examples/bmp565_sprite.py
+++ b/src/examples/bmp565_sprite.py
@@ -1,4 +1,4 @@
-# multimer types: all
+# pyscript gallery: all
 # pyscript binaries: assets/warrior.bmp
 from collections import namedtuple
 try:

--- a/src/examples/bmp565_sprite_transparent.py
+++ b/src/examples/bmp565_sprite_transparent.py
@@ -1,4 +1,4 @@
-# multimer types: all
+# pyscript gallery: all
 # pyscript binaries: assets/warrior.bmp
 from collections import namedtuple
 try:

--- a/src/examples/bouncing_balls.py
+++ b/src/examples/bouncing_balls.py
@@ -1,4 +1,4 @@
-# multimer types: all
+# pyscript gallery: all
 """
 bouncing_balls.py
 =================

--- a/src/examples/boxlines.py
+++ b/src/examples/boxlines.py
@@ -1,5 +1,5 @@
 from board_config import runtime
-# multimer types: all
+# pyscript gallery: all
 """
 boxlines.py
 ===========

--- a/src/examples/calculator.py
+++ b/src/examples/calculator.py
@@ -1,4 +1,4 @@
-# multimer types: async
+# pyscript gallery: async
 """
 Simple calculator example to demonstrate the use of graphics.FrameBuffer
 """

--- a/src/examples/chango/chango.py
+++ b/src/examples/chango/chango.py
@@ -1,4 +1,4 @@
-# multimer types: all
+# pyscript gallery: all
 """
 chango.py
 =========

--- a/src/examples/color_test.py
+++ b/src/examples/color_test.py
@@ -1,5 +1,5 @@
 from board_config import runtime
-# multimer types: all
+# pyscript gallery: all
 """
 color_test.py
 =============

--- a/src/examples/console_advanced_demo.py
+++ b/src/examples/console_advanced_demo.py
@@ -1,4 +1,3 @@
-# multimer types: sync
 """
 console_advanced_demo.py - Advanced demo of the mpconsole module
 """

--- a/src/examples/console_simpletest.py
+++ b/src/examples/console_simpletest.py
@@ -1,4 +1,4 @@
-# multimer types: all
+# pyscript gallery: all
 """
 console_simpletest.py
 

--- a/src/examples/displaybuf_blit.py
+++ b/src/examples/displaybuf_blit.py
@@ -1,4 +1,4 @@
-# multimer types: all
+# pyscript gallery: all
 from color_setup import ssd
 from graphics import FrameBuffer, RGB565
 

--- a/src/examples/displaybuf_simpletest.py
+++ b/src/examples/displaybuf_simpletest.py
@@ -1,4 +1,4 @@
-# multimer types: all
+# pyscript gallery: all
 """
 displaybuf_simpletest.py - Simple test program for displaybuf.py
 """

--- a/src/examples/displaysys_block_test.py
+++ b/src/examples/displaysys_block_test.py
@@ -1,4 +1,4 @@
-# multimer types: all
+# pyscript gallery: all
 """displaysys_block_test.py"""
 
 from random import getrandbits

--- a/src/examples/displaysys_deinit_test.py
+++ b/src/examples/displaysys_deinit_test.py
@@ -1,4 +1,3 @@
-# multimer types: sync
 """displaysys_deinit_test.py — verify idempotent display teardown."""
 
 import sys

--- a/src/examples/displaysys_fill_rect_test.py
+++ b/src/examples/displaysys_fill_rect_test.py
@@ -1,4 +1,4 @@
-# multimer types: all
+# pyscript gallery: all
 """displaysys_fill_rect_test.py"""
 
 from random import getrandbits

--- a/src/examples/displaysys_simpletest.py
+++ b/src/examples/displaysys_simpletest.py
@@ -1,4 +1,4 @@
-# multimer types: all
+# pyscript gallery: all
 from board_config import display_drv, runtime
 from random import getrandbits
 from graphics import Area

--- a/src/examples/eventsys_encoder_test.py
+++ b/src/examples/eventsys_encoder_test.py
@@ -1,4 +1,4 @@
-# multimer types: all
+# pyscript gallery: all
 """
 A simple test of an encoder in eventsys.
 """

--- a/src/examples/eventsys_simpletest.py
+++ b/src/examples/eventsys_simpletest.py
@@ -1,4 +1,4 @@
-# multimer types: async
+# pyscript gallery: async
 from board_config import runtime
 from multimer import Timer
 from multimer.loop import dual_main, run_forever

--- a/src/examples/eventsys_touch_test.py
+++ b/src/examples/eventsys_touch_test.py
@@ -1,4 +1,4 @@
-# multimer types: all
+# pyscript gallery: all
 """
 eventsys_touch_test.py - Touch rotation test.
 Tests the touch driver and finds the correct rotation masks for the touch screen.

--- a/src/examples/feathers.py
+++ b/src/examples/feathers.py
@@ -1,5 +1,5 @@
 from board_config import runtime
-# multimer types: all
+# pyscript gallery: all
 """
 feathers.py
 ===========

--- a/src/examples/font_list.py
+++ b/src/examples/font_list.py
@@ -1,4 +1,4 @@
-# multimer types: all
+# pyscript gallery: all
 # pyscript binaries: assets/font_8x8.bin, assets/font_8x14.bin, assets/font_8x16.bin
 # SPDX-FileCopyrightText: 2024 Brad Barnett
 #

--- a/src/examples/font_simpletest.py
+++ b/src/examples/font_simpletest.py
@@ -1,4 +1,4 @@
-# multimer types: all
+# pyscript gallery: all
 # pyscript binaries: assets/font_8x8.bin, assets/font_8x14.bin, assets/font_8x16.bin
 """
 font_simpletest.py -- Simple test of the Font class.

--- a/src/examples/font_simpletest2.py
+++ b/src/examples/font_simpletest2.py
@@ -1,4 +1,4 @@
-# multimer types: all
+# pyscript gallery: all
 # pyscript binaries: assets/font_8x8.bin, assets/font_8x14.bin, assets/font_8x16.bin
 """
 font_simpletest2.py -- Simple test of the Font class.

--- a/src/examples/font_simpletest3.py
+++ b/src/examples/font_simpletest3.py
@@ -1,4 +1,4 @@
-# multimer types: all
+# pyscript gallery: all
 # pyscript binaries: assets/font_8x8.bin, assets/font_8x14.bin, assets/font_8x16.bin
 """
 font_simpletest3.py -- Simple test of the Font class.

--- a/src/examples/fonts.py
+++ b/src/examples/fonts.py
@@ -1,5 +1,5 @@
 from board_config import runtime
-# multimer types: all
+# pyscript gallery: all
 """
 fonts.py
 ========

--- a/src/examples/framebuf_simpletest.py
+++ b/src/examples/framebuf_simpletest.py
@@ -1,4 +1,4 @@
-# multimer types: all
+# pyscript gallery: all
 """
 Simple test example to demonstrate the use of framebuf.FrameBuffer.
 """

--- a/src/examples/framebuf_text_compare.py
+++ b/src/examples/framebuf_text_compare.py
@@ -1,4 +1,4 @@
-# multimer types: all
+# pyscript gallery: all
 """
 Visual text compare: framebuf and graphics, native C vs Python.
 

--- a/src/examples/graphics_area_test.py
+++ b/src/examples/graphics_area_test.py
@@ -1,4 +1,4 @@
-# multimer types: all
+# pyscript gallery: all
 """
 Test the Area return type of the shapes functions.
 

--- a/src/examples/graphics_simpletest.py
+++ b/src/examples/graphics_simpletest.py
@@ -1,4 +1,4 @@
-# multimer types: all
+# pyscript gallery: all
 """
 Simple test example to demonstrate the use of graphics.
 """

--- a/src/examples/hello.py
+++ b/src/examples/hello.py
@@ -1,5 +1,5 @@
 from board_config import runtime
-# multimer types: all
+# pyscript gallery: all
 """
 hello.py
 ========

--- a/src/examples/joystick_list_select.py
+++ b/src/examples/joystick_list_select.py
@@ -1,4 +1,4 @@
-# multimer types: all
+# pyscript gallery: all
 import board_config
 import eventsys
 import pdwidgets as pd

--- a/src/examples/keypins_simpletest.py
+++ b/src/examples/keypins_simpletest.py
@@ -1,4 +1,4 @@
-# multimer types: all
+# pyscript gallery: all
 from board_config import runtime
 from keypins import KeyPins, Keys
 

--- a/src/examples/logo.py
+++ b/src/examples/logo.py
@@ -1,4 +1,4 @@
-# multimer types: all
+# pyscript gallery: all
 from board_config import display_drv
 from palettes import get_palette
 import graphics

--- a/src/examples/lv_test_timer.py
+++ b/src/examples/lv_test_timer.py
@@ -1,4 +1,4 @@
-# multimer types: async
+# pyscript gallery: async
 """
 lv_test_timer.py
 

--- a/src/examples/lv_touch_test.py
+++ b/src/examples/lv_touch_test.py
@@ -1,4 +1,4 @@
-# multimer types: async
+# pyscript gallery: async
 """
 lv_touch_test.py
 
@@ -16,46 +16,62 @@ alignments = None  # filled in _build_ui after lvgl import
 def _build_ui():
     import lvgl as lv
 
-    global alignments
-    alignments = (
-        (lv.ALIGN.TOP_LEFT, 0, 0),
-        (lv.ALIGN.TOP_MID, 0, 0),
-        (lv.ALIGN.TOP_RIGHT, 0, 0),
-        (lv.ALIGN.LEFT_MID, 0, 0),
-        (lv.ALIGN.CENTER, 0, 0),
-        (lv.ALIGN.RIGHT_MID, 0, 0),
-        (lv.ALIGN.BOTTOM_LEFT, 0, 0),
-        (lv.ALIGN.BOTTOM_MID, 0, 0),
-        (lv.ALIGN.BOTTOM_RIGHT, 0, 0),
-    )
+    # Pause shared LVGL task_handler while constructing widgets (not re-entrant).
+    # Same pattern as lv_test_timer.build_ui — under matrix load, librt ticks
+    # during widget create can SIGSEGV on CPython (exit_-11).
+    inst = None
+    try:
+        import lv_utils
 
-    style_default = lv.style_t()
-    style_default.init()
-    style_default.set_width(lv.pct(33))
-    style_default.set_height(lv.pct(33))
-    style_default.set_bg_color(lv.palette_main(lv.PALETTE.BLUE))
+        inst = lv_utils.event_loop.current_instance()
+    except ImportError:
+        inst = None
+    if inst is not None:
+        inst.disable()
+    try:
+        global alignments
+        alignments = (
+            (lv.ALIGN.TOP_LEFT, 0, 0),
+            (lv.ALIGN.TOP_MID, 0, 0),
+            (lv.ALIGN.TOP_RIGHT, 0, 0),
+            (lv.ALIGN.LEFT_MID, 0, 0),
+            (lv.ALIGN.CENTER, 0, 0),
+            (lv.ALIGN.RIGHT_MID, 0, 0),
+            (lv.ALIGN.BOTTOM_LEFT, 0, 0),
+            (lv.ALIGN.BOTTOM_MID, 0, 0),
+            (lv.ALIGN.BOTTOM_RIGHT, 0, 0),
+        )
 
-    style_pressed = lv.style_t()
-    style_pressed.init()
-    style_pressed.set_transform_width(-10)
-    style_pressed.set_transform_height(-10)
-    style_pressed.set_bg_color(lv.palette_main(lv.PALETTE.GREEN))
+        style_default = lv.style_t()
+        style_default.init()
+        style_default.set_width(lv.pct(33))
+        style_default.set_height(lv.pct(33))
+        style_default.set_bg_color(lv.palette_main(lv.PALETTE.BLUE))
 
-    style_focused = lv.style_t()
-    style_focused.init()
-    style_focused.set_bg_color(lv.palette_main(lv.PALETTE.RED))
+        style_pressed = lv.style_t()
+        style_pressed.init()
+        style_pressed.set_transform_width(-10)
+        style_pressed.set_transform_height(-10)
+        style_pressed.set_bg_color(lv.palette_main(lv.PALETTE.GREEN))
 
-    parent = lv.screen_active()
+        style_focused = lv.style_t()
+        style_focused.init()
+        style_focused.set_bg_color(lv.palette_main(lv.PALETTE.RED))
 
-    for i, alignment in enumerate(alignments, start=1):
-        btn = lv.button(parent)
-        btn.align(*alignment)
-        btn.add_style(style_default, 0)
-        btn.add_style(style_pressed, lv.STATE.PRESSED)
-        btn.add_style(style_focused, lv.STATE.FOCUSED)
-        label = lv.label(btn)
-        label.set_text(f"Btn{i}")
-        label.center()
+        parent = lv.screen_active()
+
+        for i, alignment in enumerate(alignments, start=1):
+            btn = lv.button(parent)
+            btn.align(*alignment)
+            btn.add_style(style_default, 0)
+            btn.add_style(style_pressed, lv.STATE.PRESSED)
+            btn.add_style(style_focused, lv.STATE.FOCUSED)
+            label = lv.label(btn)
+            label.set_text(f"Btn{i}")
+            label.center()
+    finally:
+        if inst is not None:
+            inst.enable()
 
 
 def _setup():

--- a/src/examples/nano_gui_simpletest.py
+++ b/src/examples/nano_gui_simpletest.py
@@ -1,4 +1,4 @@
-# multimer types: all
+# pyscript gallery: all
 """
 nano_gui_simpletest.py - Copied from:
 https://github.com/peterhinch/micropython-nano-gui/tree/master?tab=readme-ov-file#23-verifying-hardware-configuration

--- a/src/examples/noto_fonts/noto_fonts.py
+++ b/src/examples/noto_fonts/noto_fonts.py
@@ -1,4 +1,4 @@
-# multimer types: all
+# pyscript gallery: all
 """
 noto_fonts.py
 =============

--- a/src/examples/paint.py
+++ b/src/examples/paint.py
@@ -1,4 +1,4 @@
-# multimer types: async
+# pyscript gallery: async
 """
 A simple paint application demonstrating the use of displaysys.
 """

--- a/src/examples/palettes_cube.py
+++ b/src/examples/palettes_cube.py
@@ -1,4 +1,4 @@
-# multimer types: all
+# pyscript gallery: all
 from board_config import display_drv, runtime
 from multimer import sleep_ms
 from palettes import get_palette

--- a/src/examples/palettes_material.py
+++ b/src/examples/palettes_material.py
@@ -1,4 +1,4 @@
-# multimer types: all
+# pyscript gallery: all
 from board_config import display_drv, runtime
 from multimer import sleep_ms
 from palettes import get_palette

--- a/src/examples/palettes_wheel.py
+++ b/src/examples/palettes_wheel.py
@@ -1,4 +1,4 @@
-# multimer types: all
+# pyscript gallery: all
 from board_config import display_drv, runtime
 from multimer import sleep_ms
 from palettes import get_palette

--- a/src/examples/pbm_create_new.py
+++ b/src/examples/pbm_create_new.py
@@ -1,4 +1,4 @@
-# multimer types: all
+# pyscript gallery: all
 from board_config import display_drv
 from graphics import Draw, FrameBuffer, RGB565
 from pbm import PBM

--- a/src/examples/pbm_simpletest.py
+++ b/src/examples/pbm_simpletest.py
@@ -1,4 +1,4 @@
-# multimer types: all
+# pyscript gallery: all
 # pyscript binaries: assets/micropython.pbm
 from board_config import display_drv
 from graphics import FrameBuffer, RGB565

--- a/src/examples/png_test.py
+++ b/src/examples/png_test.py
@@ -1,4 +1,4 @@
-# multimer types: all
+# pyscript gallery: all
 import os
 from collections import namedtuple
 

--- a/src/examples/proverbs/proverbs.py
+++ b/src/examples/proverbs/proverbs.py
@@ -1,4 +1,4 @@
-# multimer types: all
+# pyscript gallery: all
 """
 proverbs.py
 ===========

--- a/src/examples/pydisplay_demo.py
+++ b/src/examples/pydisplay_demo.py
@@ -1,4 +1,3 @@
-# multimer types: queued, sync
 """
 pydisplay_demo.py — minimal board_config demo: clicks, rotation, scrolling.
 

--- a/src/examples/pydisplay_demo_async.py
+++ b/src/examples/pydisplay_demo_async.py
@@ -1,4 +1,4 @@
-# multimer types: async
+# pyscript gallery: async
 """
 pydisplay_demo_async.py — asyncio version of pydisplay_demo.
 

--- a/src/examples/rotations.py
+++ b/src/examples/rotations.py
@@ -1,5 +1,5 @@
 from board_config import runtime
-# multimer types: all
+# pyscript gallery: all
 """
 rotations.py
 ============

--- a/src/examples/scroll.py
+++ b/src/examples/scroll.py
@@ -1,5 +1,5 @@
 from board_config import runtime
-# multimer types: all
+# pyscript gallery: all
 """
 scroll.py
 =========

--- a/src/examples/scroll_touch_test.py
+++ b/src/examples/scroll_touch_test.py
@@ -1,4 +1,4 @@
-# multimer types: all
+# pyscript gallery: all
 from board_config import display_drv, runtime
 from graphics import Draw
 from multimer import sleep_ms

--- a/src/examples/scroll_touch_test_displaybuf.py
+++ b/src/examples/scroll_touch_test_displaybuf.py
@@ -1,4 +1,4 @@
-# multimer types: all
+# pyscript gallery: all
 from board_config import display_drv, runtime
 from graphics import Draw
 from multimer.loop import run_forever

--- a/src/examples/testris.py
+++ b/src/examples/testris.py
@@ -1,4 +1,4 @@
-# multimer types: async
+# pyscript gallery: async
 """
 Testris game implemented in MicroPython by Brad Barnett.
 """

--- a/src/examples/tiny_hello.py
+++ b/src/examples/tiny_hello.py
@@ -1,5 +1,5 @@
 from board_config import runtime
-# multimer types: all
+# pyscript gallery: all
 """
 tiny_hello.py
 =============

--- a/src/examples/tiny_toasters/tiny_toasters.py
+++ b/src/examples/tiny_toasters/tiny_toasters.py
@@ -1,4 +1,4 @@
-# multimer types: all
+# pyscript gallery: all
 """
 tiny_toasters.py
 ================

--- a/src/examples/tower_climb/tower_climb.py
+++ b/src/examples/tower_climb/tower_climb.py
@@ -1,4 +1,4 @@
-# multimer types: all
+# pyscript gallery: all
 # pyscript binaries: tower_climb/assets/climber.bmp, tower_climb/assets/tower_tiles.bmp, tower_climb/assets/tower_bg.bmp
 """
 tower_climb.py — 1980s-style vertical scrolling platformer.

--- a/src/examples/widgets_calc.py
+++ b/src/examples/widgets_calc.py
@@ -1,4 +1,4 @@
-# multimer types: all
+# pyscript gallery: all
 import board_config
 import pdwidgets as pd
 

--- a/src/examples/widgets_console.py
+++ b/src/examples/widgets_console.py
@@ -1,4 +1,4 @@
-# multimer types: all
+# pyscript gallery: all
 import board_config
 import pdwidgets as pd
 from pdwidgets.console import Console

--- a/src/examples/widgets_demo.py
+++ b/src/examples/widgets_demo.py
@@ -1,4 +1,4 @@
-# multimer types: all
+# pyscript gallery: all
 import board_config
 import pdwidgets as pd
 

--- a/src/examples/widgets_device_panel.py
+++ b/src/examples/widgets_device_panel.py
@@ -1,4 +1,4 @@
-# multimer types: all
+# pyscript gallery: all
 """
 widgets_device_panel
 ====================================================

--- a/src/examples/widgets_list.py
+++ b/src/examples/widgets_list.py
@@ -1,4 +1,4 @@
-# multimer types: all
+# pyscript gallery: all
 """
 Test ListView widget
 """

--- a/src/examples/widgets_percent.py
+++ b/src/examples/widgets_percent.py
@@ -1,4 +1,4 @@
-# multimer types: all
+# pyscript gallery: all
 import board_config
 import pdwidgets as pd
 from pdwidgets import pct

--- a/src/examples/widgets_scrollbar.py
+++ b/src/examples/widgets_scrollbar.py
@@ -1,4 +1,4 @@
-# multimer types: all
+# pyscript gallery: all
 import board_config
 import pdwidgets as pd
 

--- a/src/examples/widgets_settings.py
+++ b/src/examples/widgets_settings.py
@@ -1,4 +1,4 @@
-# multimer types: all
+# pyscript gallery: all
 """
 widgets_settings
 ====================================================

--- a/src/examples/widgets_smartwatch.py
+++ b/src/examples/widgets_smartwatch.py
@@ -1,4 +1,4 @@
-# multimer types: all
+# pyscript gallery: all
 """
 widgets_smartwatch
 ====================================================

--- a/src/examples/widgets_stub.py
+++ b/src/examples/widgets_stub.py
@@ -1,4 +1,4 @@
-# multimer types: all
+# pyscript gallery: all
 import board_config
 import pdwidgets as pd
 

--- a/src/examples/widgets_test.py
+++ b/src/examples/widgets_test.py
@@ -1,4 +1,4 @@
-# multimer types: all
+# pyscript gallery: all
 import board_config
 import pdwidgets as pd
 

--- a/tools/run_full_matrix_all_runtimes_both_timer_modes.sh
+++ b/tools/run_full_matrix_all_runtimes_both_timer_modes.sh
@@ -18,23 +18,6 @@ RUNTIMES=(
 export SDL_VIDEODRIVER=dummy
 export SDL_AUDIODRIVER=dummy
 
-DEBUG_LOG=".cursor/debug-a4ac3e.log"
-mkdir -p .cursor
-
-# region agent log
-_debug_log() {
-  local hyp="$1" msg="$2" data="$3"
-  .venv/bin/python -c "
-import json, time
-open('${DEBUG_LOG}','a').write(json.dumps({
-  'sessionId':'a4ac3e','hypothesisId':'''${hyp}''','location':'run_full_matrix.sh',
-  'message':'''${msg}''','data':json.loads('''${data}'''),'timestamp':int(time.time()*1000),
-  'runId':'parallel-14'
-})+'\n')
-"
-}
-# endregion
-
 run_one() {
   local mode="$1"
   local rt="$2"
@@ -43,11 +26,6 @@ run_one() {
   export PYDISPLAY_TIMER_ASYNC="${mode}"
   local json=".cursor/example_test_results_rt_${safe}_async_${mode}.json"
   local log=".cursor/matrix_rt_${safe}_async_${mode}.log"
-  local t0
-  t0=$(date +%s)
-  # region agent log
-  _debug_log "B" "worker_start" "{\"mode\":\"${mode}\",\"runtime\":\"${rt}\",\"pid\":$$,\"json\":\"${json}\"}"
-  # endregion
   set +e
   .venv/bin/python tools/example_test_kit.py \
     --no-unit-tests \
@@ -58,18 +36,8 @@ run_one() {
     >"${log}" 2>&1
   local rc=$?
   set -e
-  local t1 elapsed
-  t1=$(date +%s)
-  elapsed=$((t1 - t0))
-  # region agent log
-  _debug_log "A" "worker_done" "{\"mode\":\"${mode}\",\"runtime\":\"${rt}\",\"rc\":${rc},\"elapsed_s\":${elapsed},\"json\":\"${json}\"}"
-  # endregion
   return "${rc}"
 }
-
-# region agent log
-_debug_log "A" "matrix_launch" "{\"workers\":14,\"runtimes\":7,\"modes\":2,\"layout\":\"runtime_x_mode\"}"
-# endregion
 
 echo "Starting 14 concurrent jobs (7 runtimes × timer_async 0/1), one runtime per job" >&2
 
@@ -84,10 +52,6 @@ for mode in 0 1; do
     echo "  spawned pid=${pid} ${rt} timer_async=${mode}" >&2
   done
 done
-
-# region agent log
-_debug_log "C" "all_spawned" "{\"pid_count\":${#pids[@]}}"
-# endregion
 
 status=0
 for pid in "${pids[@]}"; do
@@ -114,10 +78,6 @@ for mode in ("0", "1"):
     out.write_text(json.dumps(rows, indent=2) + "\n")
     print(f"merged {len(rows)} rows -> {out}", flush=True)
 PY
-
-# region agent log
-_debug_log "D" "matrix_complete" "{\"aggregate_exit\":${status}}"
-# endregion
 
 echo "Done (aggregate exit=${status}). Shards: .cursor/example_test_results_rt_*_async_{0,1}.json" >&2
 echo "Merged: .cursor/example_test_results_timer_async_{0,1}.json" >&2

--- a/web/pyscript/index.html
+++ b/web/pyscript/index.html
@@ -47,7 +47,7 @@
         <section class="section" id="demos">
             <div class="section-head">
                 <h2>Async demos</h2>
-                <span class="hint">examples marked <code>multimer types: async</code></span>
+                <span class="hint">examples marked <code>pyscript gallery: async</code></span>
             </div>
             <div class="grid">
                 <!-- GEN:async:start -->
@@ -67,6 +67,15 @@
                     </div>
                     <h3>Event System</h3>
                     <p>The smallest <code>eventsys</code> example &mdash; prints every pointer event it polls.</p>
+                    <span class="go">Open demo <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M5 12h14M13 6l6 6-6 6"/></svg></span>
+                </a>
+                <a class="card" href="load.html?modules=lv_touch_test">
+                    <div class="card-top">
+                        <span class="card-icon"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect x="2" y="3" width="20" height="14" rx="2"/><path d="M8 21h8M12 17v4"/></svg></span>
+                        <span class="tag async">async</span>
+                    </div>
+                    <h3>Lv Touch Test</h3>
+                    <p>Touch/rotation grid for LVGL. Follows ``runtime.timer_async`` — does not read</p>
                     <span class="go">Open demo <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M5 12h14M13 6l6 6-6 6"/></svg></span>
                 </a>
                 <a class="card" href="load.html?modules=paint">
@@ -112,7 +121,7 @@
         <section class="section" id="all-demos">
             <div class="section-head">
                 <h2>All-mode examples</h2>
-                <span class="hint">marked <code>multimer types: all</code> — open one and click <strong>Run</strong></span>
+                <span class="hint">marked <code>pyscript gallery: all</code> — open one and click <strong>Run</strong></span>
             </div>
             <div class="grid">
                 <!-- GEN:all:start -->


### PR DESCRIPTION
## Summary
- Replace `# multimer types:` example headers with `# pyscript gallery:` and update gallery generator/docs.
- Pause LVGL `event_loop` during `lv_touch_test` UI build (same as `lv_test_timer`) to stop CPython `exit_-11` under matrix load.
- Strip leftover debug instrumentation from the 14-way matrix runner.

## Test plan
- [x] A/B: without disable → 3/16 `exit_-11`; with disable → 0 failures under parallel stress
- [ ] 14-way matrix + coverage report after merge