### PR TITLE
docs(AGENTS): cloud-agent setup notes for palettes/pdwidgets and runtime binaries

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -67,6 +67,21 @@ is a symlink to `../../src`, so editing `src/` updates the PyScript gallery too.
 - Known pre-existing example failures on CPython (not environment issues to
   "fix"): `nano_gui_simpletest` needs the matching Hinch `gui/` package.
   `tools/png_test.py` (PNG probe) needs `PYDISPLAY_PNG_DIR` / material-design-icons.
+- **`palettes` / `pdwidgets` sibling repos** (`hello`, `color_test`, `feathers`,
+  `graphics_simpletest`, `palettes_demo`, `widgets_*`, … import `palettes` and/or
+  `pdwidgets`). These are source-only PyDevices repos, **not** pip packages — the
+  PyPI project literally named `palettes` is an unrelated "random hex color"
+  library, so do **not** `pip install palettes`. They normally arrive as
+  repositoryDependencies under `/agent/repos/{palettes,pdwidgets}` (symlinked into
+  `~/gh/pydevices/`); if that clone is missing, clone
+  `github.com/PyDevices/{palettes,pdwidgets}` into a writable dir and put their
+  `src` dirs on the venv path (e.g. a `*.pth` in `.venv/lib/*/site-packages`
+  listing `<repo>/palettes/src` and `<repo>/pdwidgets/src`, or `PYTHONPATH`).
+  `pdwidgets` also needs pydisplay's `src/lib` on path (the example harness adds it).
+- Cross-runtime binaries: `micropython`/`circuitpython` resolve via `PATH` →
+  `~/bin` → committed `repo:bin/` (see `bin/README.md`), so the matrix runs those
+  two even when they are not on the system `PATH`. `micropython.exe` / `python.exe`
+  are Windows binaries and cannot run in the Linux cloud sandbox.
 - **PyScript hangs / multimer / WASM:** read
   [`.cursor/pyscript-troubleshooting.md`](.cursor/pyscript-troubleshooting.md)
   before poking the IDE browser. Prefer Playwright helpers


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Set up the PyDisplay development environment on a fresh Cursor Cloud VM and documented two non-obvious gotchas discovered during setup. No application/source code was modified — only `AGENTS.md`.

### What was set up (not committed; captured in the VM update script)
- Repo-root `.venv` (Python 3.12) with `requirements-dev.txt` + `pygame-ce` (SDL2 fallback backend) + `lvgl-cpython` (from TestPyPI).
- `palettes` / `pdwidgets` sibling source repos made importable via a `.pth` on the venv path.

### AGENTS.md additions
- **`palettes` / `pdwidgets`**: these are source-only PyDevices repos (many core examples import them). The PyPI project literally named `palettes` is an *unrelated* "random hex color" library, so `pip install palettes` is wrong. Documented how to make them importable when the repositoryDependencies clone is missing.
- **Cross-runtime binaries**: `micropython`/`circuitpython` resolve via `PATH` → `~/bin` → committed `repo:bin/`, so the matrix runs those two even when they are not on the system `PATH`; the Windows `.exe` binaries can't run in the Linux sandbox.

## Testing
- `.venv/bin/python -m unittest discover -s tests` → 371 passed (3 skipped).
- `.venv/bin/ruff check src tests board_configs` → runs clean (pre-existing findings only; no source touched).
- Headless example matrix (`tools/example_test_kit.py --only-runtime cpython-venv`) → `hello`, `graphics_simpletest`, `bouncing_balls`, `palettes_demo`, `color_test`, `feathers`, `calc_lvgl` (LVGL), `widgets_demo` (pdwidgets) all `PGDisplay, ok`.
- Live render on `DISPLAY=:1`:

<a href="https://cursor.com/agents/bc-7b8d318d-18fb-42ac-9130-a0256ed78489/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fpydisplay_bouncing_balls_demo.mp4"><img src="https://cursor.com/artifacts/c/art-e15190ed-8994-4087-9a17-66b594ed5ba0" alt="pydisplay_bouncing_balls_demo.mp4" /></a>

![bouncing_balls window titled ](https://cursor.com/artifacts/c/art-1a87b94b-c8ec-493e-bb07-2b53dec1a6e8)
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-7b8d318d-18fb-42ac-9130-a0256ed78489"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-7b8d318d-18fb-42ac-9130-a0256ed78489"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

