### PR TITLE
Revert pyodide/TestPyPI palettes wheel name to `palettes`

### DIFF
--- a/docs/guis/palettes.md
+++ b/docs/guis/palettes.md
@@ -11,7 +11,7 @@ mip.install("palettes", index="https://PyDevices.github.io/micropython-lib/mip/P
 
 Documentation: [palettes.readthedocs.io](https://palettes.readthedocs.io)
 
-PyScript demos install `palettes` at runtime via `# pyscript mip: palettes` (micropython-lib MIP) or `# pyodide wheels: pydevices-palettes` (TestPyPI on the Pyodide loader).
+PyScript demos install `palettes` at runtime via `# pyscript mip: palettes` (micropython-lib MIP) or `# pyodide wheels: palettes` (TestPyPI on the Pyodide loader).
 
 ## Usage
 

--- a/src/examples/calc_graphics.py
+++ b/src/examples/calc_graphics.py
@@ -1,6 +1,6 @@
 # pyscript modules: calc_engine
 # pyscript mip: palettes
-# pyodide wheels: pydevices-palettes
+# pyodide wheels: palettes
 """
 calc_graphics
 ====================================================

--- a/src/examples/console_advanced_demo.py
+++ b/src/examples/console_advanced_demo.py
@@ -1,5 +1,5 @@
 # pyscript mip: palettes
-# pyodide wheels: pydevices-palettes
+# pyodide wheels: palettes
 """
 console_advanced_demo.py - Advanced demo of the mpconsole module
 """

--- a/src/examples/feathers.py
+++ b/src/examples/feathers.py
@@ -1,5 +1,5 @@
 # pyscript mip: palettes
-# pyodide wheels: pydevices-palettes
+# pyodide wheels: palettes
 """
 feathers.py
 ===========

--- a/src/examples/font_simpletest.py
+++ b/src/examples/font_simpletest.py
@@ -1,6 +1,6 @@
 # pyscript skip: gallery
 # pyscript mip: palettes
-# pyodide wheels: pydevices-palettes
+# pyodide wheels: palettes
 """
 font_simpletest.py -- Simple test of the Font class.
 inspired by Russ Hughes's hello.py

--- a/src/examples/graphics_simpletest.py
+++ b/src/examples/graphics_simpletest.py
@@ -1,5 +1,5 @@
 # pyscript mip: palettes
-# pyodide wheels: pydevices-palettes
+# pyodide wheels: palettes
 """
 Simple test example to demonstrate the use of graphics.
 """

--- a/src/examples/palettes_demo.py
+++ b/src/examples/palettes_demo.py
@@ -1,6 +1,6 @@
 # pyscript skip: gallery
 # pyscript mip: palettes
-# pyodide wheels: pydevices-palettes
+# pyodide wheels: palettes
 """
 palettes_demo.py — Palette walk cycling wheel → cube → material (no env vars).
 """

--- a/src/examples/pixel_sim_demos.py
+++ b/src/examples/pixel_sim_demos.py
@@ -1,5 +1,5 @@
 # pyscript mip: palettes
-# pyodide wheels: pydevices-palettes
+# pyodide wheels: palettes
 """
 pixel_sim_demos.py — NeoPixel simulator effects in one file.
 

--- a/src/examples/rotations.py
+++ b/src/examples/rotations.py
@@ -1,5 +1,5 @@
 # pyscript mip: palettes
-# pyodide wheels: pydevices-palettes
+# pyodide wheels: palettes
 """
 rotations.py
 ============

--- a/src/examples/scroll_touch_test.py
+++ b/src/examples/scroll_touch_test.py
@@ -1,6 +1,6 @@
 # pyscript skip: gallery
 # pyscript mip: palettes
-# pyodide wheels: pydevices-palettes
+# pyodide wheels: palettes
 # Vertical scroll + touch/click. Cycles display_drv ↔ DisplayBuffer on a timer
 # (no env vars). Chrome labels show which path is active (drv / dbuf).
 from board_config import display_drv, runtime

--- a/web/pyscript/pyodide.html
+++ b/web/pyscript/pyodide.html
@@ -517,7 +517,7 @@
                         "pdwidgets",
                         index_urls="https://test.pypi.org/simple/",
                     )
-                elif key in ("palettes", "pydevices-palettes"):
+                elif key in ("palettes",):
                     _set("Installing palettes…")
                     _log_print("micropip.install palettes from TestPyPI")
                     await micropip.install(

--- a/web/pyscript/pyodide.html
+++ b/web/pyscript/pyodide.html
@@ -519,16 +519,16 @@
                     )
                 elif key in ("palettes", "pydevices-palettes"):
                     _set("Installing palettes…")
-                    _log_print("micropip.install pydevices-palettes from TestPyPI")
+                    _log_print("micropip.install palettes from TestPyPI")
                     await micropip.install(
-                        "pydevices-palettes",
+                        "palettes",
                         index_urls="https://test.pypi.org/simple/",
                     )
                 else:
                     raise RuntimeError(
                         "Unknown # pyodide wheels: entry "
                         + repr(which)
-                        + " (supported: lvgl, pdwidgets, pydevices-palettes)"
+                        + " (supported: lvgl, pdwidgets, palettes)"
                     )
 
         async def _start(*_):


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Reverts the PyScript/Pyodide wheel name from `pydevices-palettes` back to the original **`palettes`** (TestPyPI). Pairs with the companion PR in [`PyDevices/palettes`](https://github.com/PyDevices/palettes) that renames the published wheel.

## Changes
- `web/pyscript/pyodide.html`: the Pyodide loader now `micropip.install("palettes", index_urls="https://test.pypi.org/simple/")` (was `pydevices-palettes`); log line and the "supported" error message updated. The `# pyodide wheels:` key now accepts only `palettes` (the `pydevices-palettes` alias was removed).
- `src/examples/*.py` (9 files): `# pyodide wheels: pydevices-palettes` → `# pyodide wheels: palettes` (these are the same files surfaced under `web/pyscript/src/` via symlink).
- `docs/guis/palettes.md`: annotation reference updated.

## Notes
- The loader pins `index_urls` to TestPyPI only, so `palettes` resolves to the PyDevices TestPyPI project (not the unrelated regular-PyPI `palettes`).
- CPython dev is unaffected (examples import `palettes` from the source repo on `sys.path`; the changed lines are comments/PyScript-only).
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-7b8d318d-18fb-42ac-9130-a0256ed78489"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-7b8d318d-18fb-42ac-9130-a0256ed78489"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

