### PR TITLE
docs(AGENTS): explain why palettes/pdwidgets are missing on cloud VMs

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -78,6 +78,18 @@ is a symlink to `../../src`, so editing `src/` updates the PyScript gallery too.
   `src` dirs on the venv path (e.g. a `*.pth` in `.venv/lib/*/site-packages`
   listing `<repo>/palettes/src` and `<repo>/pdwidgets/src`, or `PYTHONPATH`).
   `pdwidgets` also needs pydisplay's `src/lib` on path (the example harness adds it).
+  **Why they are usually missing (recurring gotcha):** they are listed in the
+  committed `.github` / `cmods` `.cursor/environment.json` `repositoryDependencies`,
+  but the cloud VM materializes `/agent/repos/*` from the **saved "Pydevices Cloud
+  Workspace" environment snapshot's repo list**, which is stale (12 repos, no
+  `palettes`/`pdwidgets`). Editing/committing `repositoryDependencies` alone does
+  **not** fix this. Durable fix: re-record the saved environment (dashboard →
+  Cloud Agents → Environments → *Pydevices Cloud Workspace* → **New Setup Run**)
+  selecting all repos incl. `palettes`+`pdwidgets` and **save** the new snapshot;
+  first confirm the Cursor GitHub App installation actually has access to both
+  repos (they are public but must be in the App's repo scope to appear in the
+  picker). Until then the update-script fallback clones them into
+  `~/gh/pd-extra` and adds their `src` to the venv via a `.pth`.
 - Cross-runtime binaries: `micropython`/`circuitpython` resolve via `PATH` →
   `~/bin` → committed `repo:bin/` (see `bin/README.md`), so the matrix runs those
   two even when they are not on the system `PATH`. `micropython.exe` / `python.exe`


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Why

Setting up the PyDevices cloud dev environment repeatedly failed to pick up the `palettes` and `pdwidgets` sibling repos, even though both are listed in the committed `.cursor/environment.json` `repositoryDependencies` (and re-running setup didn't help).

## Root cause (verified via `cursor-cloud` environment-info)

Cloud VMs materialize `/agent/repos/*` from the **saved "Pydevices Cloud Workspace" environment snapshot's repo list**, not from the live committed `repositoryDependencies`. That saved snapshot is stale — it holds **12 repos and is missing `palettes`/`pdwidgets`** (`source: "Override"`, `recordedVia: "REQUEST_OVERRIDE_OBSERVED"`). Editing/committing `repositoryDependencies` alone therefore does nothing for already-saved environments.

## Change

Adds a short "recurring gotcha" note to the pydisplay `AGENTS.md` palettes/pdwidgets bullet documenting:
- why they go missing (stale snapshot repo list vs. committed `repositoryDependencies`),
- the durable fix (re-record the saved environment via a **New Setup Run** selecting all repos + save the snapshot; first verify the Cursor GitHub App has access to both repos so they appear in the picker),
- the update-script fallback (clone into `~/gh/pd-extra`, add `src` to the venv via a `.pth`).

Docs-only; no code changes.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-7ac46c28-2b9e-43fe-81d9-18fd0716ea71"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-7ac46c28-2b9e-43fe-81d9-18fd0716ea71"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

