### PR TITLE
docs: elevate PWAs as a platform (where they run)

### DIFF
--- a/docs/examples/live-demos.md
+++ b/docs/examples/live-demos.md
@@ -4,6 +4,6 @@ This content moved to **[Try pydisplay](../try/index.md)** — PyScript links, W
 
 Quick links:
 
-- [PyScript demo hub](https://PyDevices.github.io/pydisplay/pyscript/) — installable PWA ([how to build your own](../guides/pyscript-pwa.md))
+- [PyScript demo hub](https://PyDevices.github.io/pydisplay/pyscript/) — installable PWA ([where they run](../platforms/pwa.md) · [how to build your own](../guides/pyscript-pwa.md))
 - [Wokwi project](../guides/wokwi.md) (`sim/wokwi/`)
 - [Screenshot gallery](../try/index.md#screenshot-gallery)

--- a/docs/guides/pyscript-pwa.md
+++ b/docs/guides/pyscript-pwa.md
@@ -2,6 +2,8 @@
 
 **Who:** You host a pydisplay (or other PyScript) demo on GitHub Pages — or any HTTPS origin — and want users to install it like a native app and run it offline after the first visit.
 
+**Where PWAs run:** Platform notes — host matrix, install UX, PWA vs Android APK — live in [Progressive Web Apps](../platforms/pwa.md). This guide is the **how-to** (manifest, service worker, deploy).
+
 **Prerequisites:** A working PyScript HTML shell (see [PyScript guide](pyscript.md)). Basic familiarity with browser DevTools.
 
 **Live reference:** The [pydisplay PyScript gallery](https://pydevices.github.io/pydisplay/pyscript/) is a PWA. Open DevTools → **Application** to inspect its manifest and service worker, or click **Install app** in the header.
@@ -397,6 +399,7 @@ Users who install get that module every time. To ship multiple installable apps 
 
 ## Related docs
 
+- [Where PWAs run](../platforms/pwa.md) — host matrix and install UX (platform story)
 - [PyScript local development](pyscript.md) — run the gallery locally, gallery markers, deploy overview
 - [PyScript asyncio porting](pyscript-asyncio.md) — make examples work under PyScript's event loop
 - [PyScript platform notes](../platforms/pyscript.md) — board config and contribution pointers

--- a/docs/guides/pyscript.md
+++ b/docs/guides/pyscript.md
@@ -48,6 +48,7 @@ Featured starters: `pydisplay_demo`, `testris`. See `scripts/pyscript_gen_packag
 ## Next
 
 - [Make your PyScript app a PWA](pyscript-pwa.md)
+- [Where PWAs run](../platforms/pwa.md) — host matrix (desktop, Android, iOS, TVs)
 - [PyScript asyncio porting](pyscript-asyncio.md)
 - [Try pydisplay](../try/index.md)
 - [Platform notes](../platforms/pyscript.md)

--- a/docs/index.md
+++ b/docs/index.md
@@ -32,6 +32,7 @@ Develop on your laptop with a mouse, then deploy the *same* code to a touchscree
 | I want to… | Start here |
 |------------|------------|
 | Try it with no install | [Try PyDisplay](try/index.md) |
+| Install the browser gallery as an app | [Where PWAs run](platforms/pwa.md) |
 | Run on an ESP32 / MicroPython board | [ESP32 board guide](guides/esp32-board.md) |
 | Develop on desktop (CPython) | [Desktop CPython guide](guides/desktop-cpython.md) |
 | See every starting path | [Getting started](getting-started.md) |
@@ -42,6 +43,7 @@ Develop on your laptop with a mouse, then deploy the *same* code to a touchscree
 - **One API, every platform** — `framebuf`-compatible drawing on MicroPython, CircuitPython, and CPython.
 - **Unified input** — touch, mouse, keyboard, keypad, rotary encoder, and joystick all arrive as the same PyGame/SDL2-style [events](concepts/events.md).
 - **Cross-platform timers** — [`multimer`](concepts/multimer.md) gives you `machine.Timer`-style and `asyncio` timers even on hosts that have neither.
+- **Installable browser apps** — the [PyScript gallery](https://PyDevices.github.io/pydisplay/pyscript/) is a [Progressive Web App](platforms/pwa.md) (desktop, Android Chrome, iOS home screen).
 - **Batteries included** — 30 board configs, 60+ [examples](examples/index.md), a [browser demo](https://PyDevices.github.io/pydisplay/pyscript/), and a [Wokwi](guides/wokwi.md) project.
 - **Flexible install** — [full clone](installation/full-clone.md), one-line [MIP packages](installation/mip-github.md), or precompiled `.mpy` bytecode.
 

--- a/docs/platforms/android.md
+++ b/docs/platforms/android.md
@@ -2,6 +2,8 @@
 
 Platform notes for building pydisplay APKs with **python-for-android** and **buildozer**.
 
+For an **installable browser app** on Android phones (Chrome home screen, no APK), see [Progressive Web Apps](pwa.md) — that path uses PyScript/`PSDisplay`, not this APK stack.
+
 ## Overview
 
 On Android there is no MicroPython port. pydisplay runs under **CPython** in a **python-for-android** APK with the **SDL2 bootstrap**. The `import usdl2` API comes from the [usdl2](https://github.com/PyDevices/usdl2) package on TestPyPI (native `android_21_*` wheels). pydisplay's existing `SDLDisplay` backend works unchanged once `usdl2` is installed.

--- a/docs/platforms/index.md
+++ b/docs/platforms/index.md
@@ -4,11 +4,13 @@ Portability is PyDisplay's defining feature. Write your display, input, and timi
 
 ## Where PyDisplay runs
 
-| Runtime | Microcontrollers | Unix / Linux | Windows | Android | Browser | Jupyter Notebook |
-|---------|:----------------:|:------------:|:-------:|:-------:|:-------:|:----------------:|
-| **[MicroPython](micropython.md)** | ✅ | ✅ | ✅ | — | ✅ [PyScript](pyscript.md) · [Wokwi](../guides/wokwi.md) | — |
+| Runtime | Microcontrollers | Unix / Linux | Windows | Android | Browser / PWA | Jupyter Notebook |
+|---------|:----------------:|:------------:|:-------:|:-------:|:-------------:|:----------------:|
+| **[MicroPython](micropython.md)** | ✅ | ✅ | ✅ | — | ✅ [PyScript](pyscript.md) · [PWA](pwa.md) · [Wokwi](../guides/wokwi.md) | — |
 | **[CircuitPython](circuitpython.md)** | ✅ | ✅ | — | — | — | — |
-| **[CPython](cpython-desktop.md)** | — | ✅ | ✅ | ✅ [Android](android.md) | — | ✅ [Jupyter](jupyter.md) |
+| **[CPython](cpython-desktop.md)** | — | ✅ | ✅ | ✅ [Android APK](android.md) | — | ✅ [Jupyter](jupyter.md) |
+
+**Installable browser apps:** the [PyScript gallery](https://pydevices.github.io/pydisplay/pyscript/) ships as a [Progressive Web App](pwa.md) — install it on desktop Chromium, Android Chrome, or iOS home screen. That is a major distribution path, not a demo-only trick. See [where PWAs run](pwa.md#where-pwas-run).
 
 ## How portability works
 
@@ -24,9 +26,9 @@ What changes is which **display backend** `board_config` selects — automatical
 |---------|---------|-------------|
 | `BusDisplay` | MicroPython / CircuitPython MCUs (SPI / I80) | [board config](../hardware/board-configs.md) |
 | `FBDisplay` | CircuitPython framebuffer displays (RGB, USB video) | board config |
-| `SDLDisplay` | CPython, MicroPython Unix, CircuitPython Unix (SDL2) | auto / `board_configs/sdldisplay/` |
+| `SDLDisplay` | CPython, MicroPython Unix, CircuitPython Unix (SDL2); Android APK | auto / `board_configs/sdldisplay/` |
 | `PGDisplay` | CPython desktop (PyGame — easy on Windows) | auto / `board_configs/pgdisplay/` |
-| `PSDisplay` | [PyScript](pyscript.md) browser canvas | auto |
+| `PSDisplay` | [PyScript](pyscript.md) browser canvas and [PWAs](pwa.md) | auto |
 | `JNDisplay` | [Jupyter Notebook](jupyter.md) | auto |
 
 Input is just as portable: a mouse on the desktop, a finger on a touchscreen, and a tap in the browser all arrive as the same [events](../concepts/events.md). Timers come from [`multimer`](../concepts/multimer.md), which picks a backend (`machine.Timer`, librt, threads, polling, SDL, or `asyncio`) to suit the host.
@@ -39,9 +41,10 @@ See [Displays](../concepts/displays.md) for backend details and [Architecture](.
 - [CircuitPython](circuitpython.md) — MCUs and Unix; `framebufferio` and the `framebuf` shim.
 - [CPython desktop](cpython-desktop.md) — SDL2 / PyGame setup for Linux, macOS, and Windows.
 - [Android](android.md) — CPython APK builds with python-for-android and buildozer.
+- [Progressive Web Apps (PWA)](pwa.md) — **where** installable PyScript apps run (desktop, Android Chrome, iOS, TVs).
 - [Jupyter Notebook](jupyter.md) — interactive display widget and async execution model.
 - [Run the notebook interactively](jupyter-run.md) — JupyterLab / VS Code setup (the RTD notebook page is static).
-- [PyScript](pyscript.md) — running in the browser.
+- [PyScript](pyscript.md) — running in the browser (`PSDisplay`).
 
 ## Build GUIs across platforms
 

--- a/docs/platforms/pwa.md
+++ b/docs/platforms/pwa.md
@@ -1,0 +1,110 @@
+# Progressive Web Apps (PWA)
+
+Installable, offline-capable PyScript apps are a **major pydisplay feature** — the same `PSDisplay` demos you open in a browser tab can be installed like a native app on phones, tablets, and desktops.
+
+**Live gallery (already a PWA):** [pydevices.github.io/pydisplay/pyscript/](https://pydevices.github.io/pydisplay/pyscript/)
+
+**How to build one:** [Make your PyScript app a PWA](../guides/pyscript-pwa.md) — this page is about **where** those apps run and how install UX differs by host.
+
+---
+
+## What you get
+
+| Capability | Notes |
+|------------|--------|
+| **In-browser** | Tab or window — no install required |
+| **Installable** | Home screen / app launcher icon when the host supports it |
+| **Standalone window** | Chromium `display: "standalone"` hides browser chrome after install |
+| **Offline (after first visit)** | Service worker caches shell + runtime; run each demo once online so WASM/packages land in cache |
+| **Same Python** | MicroPython or Pyodide via PyScript; drawing still goes through `PSDisplay` |
+
+A PWA is still a website on HTTPS. Python runs inside the page; the browser owns install, caching, and the launcher icon.
+
+---
+
+## Where PWAs run
+
+| Host | Install UX | Typical result | Notes |
+|------|------------|----------------|-------|
+| **Chrome / Edge (Windows, macOS, Linux)** | Address-bar install icon or **Install app**; `beforeinstallprompt` | Standalone app window | Best-supported desktop path |
+| **Chrome on Android** | **Install app** / Add to Home screen | Launcher icon; standalone | Phone/tablet web install — not the same as the [Android APK](android.md) |
+| **Chromebook (Chrome OS)** | Same as desktop Chrome | Launcher / shelf icon | Treat as Chromium desktop |
+| **Safari on iOS / iPadOS** | **Share → Add to Home Screen** (no programmatic prompt) | Home-screen icon; opens fullscreen-ish WebKit | See [Apple mobile](#apple-mobile-ios--ipados) |
+| **Firefox / Safari (desktop)** | Limited or no Chromium-style install prompt | Often stays a bookmark / tab | Gallery still runs in-tab; install polish is Chromium-first |
+| **LG webOS / Samsung Tizen (TV browsers)** | Host web app / browser only | In-browser or platform web-app packaging | **Web path only** — no native `SDLDisplay` on TV OS shells |
+
+!!! tip "Try the live gallery"
+    Open the [PyScript gallery](https://pydevices.github.io/pydisplay/pyscript/) on the device you care about, then use that host’s install path from the table.
+
+---
+
+## Install UX differences
+
+### Chromium (`beforeinstallprompt`)
+
+Chrome and Edge (desktop and Android) can fire `beforeinstallprompt`. The gallery **Install app** button calls that API when available. Uninstall an earlier install of the same origin if the prompt never appears — browsers suppress it for already-installed scopes.
+
+### iOS / iPadOS (no install API)
+
+Safari never fires `beforeinstallprompt`. The gallery button shows a short **Share → Add to Home Screen** tip instead. That is expected, not a bug.
+
+### Standalone vs browser tab
+
+| Mode | What the user sees |
+|------|--------------------|
+| **Tab** | Normal browser chrome; URL bar visible |
+| **Installed standalone** | App-like window; gallery keeps same-origin demo links in one window (Chromium would otherwise open a new app window for `target="_blank"`) |
+
+Details and manifest/`pwa.js` behavior: [PWA guide — wire pages](../guides/pyscript-pwa.md#step-3--wire-your-html-pages).
+
+---
+
+## Offline and storage
+
+1. Visit **once online** and click **Run** on a demo so PyScript/Pyodide (and packages) download.
+2. The service worker caches the shell and subsequent CDN/runtime responses.
+3. Later offline reloads work for cached assets; first-run or uncached demos still need the network.
+
+Storage can reach tens to hundreds of MB. Prefer stale-while-revalidate over precaching every WASM blob — see the [PWA guide](../guides/pyscript-pwa.md).
+
+---
+
+## PWA vs native Android APK
+
+| | **PWA (this page)** | **Android APK** |
+|--|---------------------|-----------------|
+| Runtime | PyScript in the browser / WebView | CPython in [pydisplay_android](https://github.com/PyDevices/pydisplay_android) |
+| Display | `PSDisplay` | `SDLDisplay` + `usdl2` |
+| Distribution | HTTPS URL + install/home screen | Play / sideload APK |
+| Best for | Zero-install demos, cross-OS shareable links, offline gallery | Store packaging, deeper device integration |
+
+Phone Android APK notes: [Android platform guide](android.md). Android TV / Fire OS packaging is a separate pursue track on the org roadmap — still SDL/APK, not this PWA story.
+
+---
+
+## Apple mobile (iOS / iPadOS)
+
+There is **no** native iOS pydisplay app on the foreseeable roadmap. Apple phones and tablets use:
+
+- **Mobile Safari** (or another WebKit browser) → [PyScript gallery](https://pydevices.github.io/pydisplay/pyscript/) in a tab, and/or
+- **Add to Home Screen** → installed PWA-style icon launching the same `PSDisplay` site.
+
+That is the supported Apple mobile path: browser + optional home-screen install, not App Store packaging.
+
+---
+
+## Smart TVs (webOS / Tizen)
+
+LG webOS and Samsung Tizen ship Chromium-based browsers and encourage **web apps**. pydisplay’s TV story is the same PyScript/`PSDisplay` stack (large UI, remote keys) — **not** a native SDL build on those OS shells. A hosted gallery or TV web-app package can reuse the PWA assets; treat installability as host-specific.
+
+---
+
+## Related
+
+| Doc | Role |
+|-----|------|
+| [PyScript platform notes](pyscript.md) | Board config, experimental status, contribution pointers |
+| [Make your PyScript app a PWA](../guides/pyscript-pwa.md) | Manifest, service worker, COI, deploy, troubleshooting |
+| [Portability & platforms](index.md) | Full runtime × target matrix |
+| [Android](android.md) | Native APK path (contrast with PWA) |
+| [Try pydisplay](../try/index.md) | Live demo links |

--- a/docs/platforms/pyscript.md
+++ b/docs/platforms/pyscript.md
@@ -4,7 +4,7 @@ Experimental browser support via [PyScript](https://pyscript.net/) and `displays
 
 **Quick start:** [PyScript guide](../guides/pyscript.md) and [Try pydisplay](../try/index.md).
 
-**Installable / offline:** [PyScript PWA guide](../guides/pyscript-pwa.md) — manifest, service worker, and GitHub Pages deploy.
+**Installable / offline (major feature):** The live gallery is a [Progressive Web App](pwa.md). Read [where PWAs run](pwa.md#where-pwas-run) for the host matrix (desktop Chromium, Android Chrome, iOS home screen, TV web). Build your own with the [PyScript PWA guide](../guides/pyscript-pwa.md).
 
 **Asyncio porting:** [PyScript asyncio guide](../guides/pyscript-asyncio.md).
 

--- a/docs/try/index.md
+++ b/docs/try/index.md
@@ -7,6 +7,7 @@ Evaluate pydisplay without installing anything on your machine.
 | Path | Best for | Start here |
 |------|----------|------------|
 | **Browser (PyScript)** | Quick look, touch UI in the tab | [Live demo hub](https://PyDevices.github.io/pydisplay/pyscript/) |
+| **Installable PWA** | Home-screen / standalone app on phone or desktop | [Where PWAs run](../platforms/pwa.md) · [Install the gallery](https://PyDevices.github.io/pydisplay/pyscript/) |
 | **Wokwi simulator** | ESP32 + ILI9341 without hardware | [Wokwi guide](../guides/wokwi.md) · [`wokwi/`](../sim/wokwi/) |
 | **Screenshot gallery** | See what examples look like | [Gallery below](#screenshot-gallery) |
 
@@ -14,7 +15,7 @@ Evaluate pydisplay without installing anything on your machine.
 
 ### Live demo (online)
 
-**Hub:** [PyDevices.github.io/pydisplay/pyscript/](https://PyDevices.github.io/pydisplay/pyscript/)
+**Hub:** [PyDevices.github.io/pydisplay/pyscript/](https://PyDevices.github.io/pydisplay/pyscript/) — also an installable [PWA](../platforms/pwa.md) (**Install app** in the header on Chromium; on iOS use Share → Add to Home Screen).
 
 | Link | Description |
 |------|-------------|

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -113,6 +113,7 @@ nav:
     - CircuitPython: platforms/circuitpython.md
     - CPython desktop: platforms/cpython-desktop.md
     - Android: platforms/android.md
+    - Progressive Web Apps: platforms/pwa.md
     - Jupyter: platforms/jupyter.md
     - Run interactively: platforms/jupyter-run.md
     - Jupyter notebook: platforms/jupyter-notebook.ipynb


### PR DESCRIPTION
## Summary
Implements the org roadmap **Docs only** PWA workstream: treat installable PyScript apps as a first-class platform story, especially **where they run**.

## Changes
- New \`docs/platforms/pwa.md\` — host×install matrix (desktop Chromium, Android Chrome vs APK, iOS Add to Home Screen, Chromebook, webOS/Tizen web), offline notes, standalone vs tab
- Elevate PWA in \`platforms/index.md\`, home page, Try pydisplay, Android notes, and mkdocs nav
- Keep \`guides/pyscript-pwa.md\` as the how-to; point readers to the platform page for “where”

## Test plan
- [ ] Spot-check links on RTD/local mkdocs build
- [ ] Confirm nav shows **Progressive Web Apps** under Portability & platforms