### PR TITLE
feat: platform roadmap (KMS, TV web, PWA docs, quit_chord)

### DIFF
--- a/board_configs/sdldisplay/linux_kms/board_config.py
+++ b/board_configs/sdldisplay/linux_kms/board_config.py
@@ -1,0 +1,46 @@
+# SPDX-FileCopyrightText: 2026 Brad Barnett
+#
+# SPDX-License-Identifier: MIT
+"""
+Linux KMS / DRM board config (no X11/Wayland window manager).
+
+Why SDL_VIDEODRIVER=kmsdrm: bare framebuffer / HDMI scanout on Pi and similar
+SBCs without a desktop — reuse SDLDisplay + usdl2 instead of a native fbdev path.
+Must be set before SDL_Init (inside SDLDisplay).
+"""
+
+import sys
+
+from displaysys import env_set
+
+# Why: force SDL's KMS/DRM backend before SDLDisplay constructs the window.
+env_set("SDL_VIDEODRIVER", "kmsdrm")
+
+import usdl2
+from displaysys.sdldisplay import SDLDisplay as DTDisplay
+from displaysys.sdldisplay import get_events
+import eventsys
+
+# Why scale=1.0: KMS modes are typically already panel-native; avoid desktop
+# letterboxing meant for small logical FBs on large monitors.
+width = 320
+height = 480
+rotation = 0
+scale = 1.0
+
+# Why FULLSCREEN: under kmsdrm there is no window manager chrome; fullscreen
+# matches the DRM mode instead of a floating window.
+window_flags = usdl2.SDL_WINDOW_FULLSCREEN_DESKTOP | usdl2.SDL_WINDOW_ALLOW_HIGHDPI
+
+display_drv = DTDisplay(
+    width=width,
+    height=height,
+    rotation=rotation,
+    title=f"{sys.implementation.name} on linux-kms",
+    scale=scale,
+    window_flags=window_flags,
+)
+
+runtime = eventsys.Runtime(display=display_drv, host_read=get_events)
+
+display_drv.fill(0)

--- a/board_configs/sdldisplay/linux_kms/package.json
+++ b/board_configs/sdldisplay/linux_kms/package.json
@@ -1,0 +1,20 @@
+{
+  "urls": [
+    [
+      "board_config.py",
+      "github:PyDevices/pydisplay/board_configs/sdldisplay/linux_kms/board_config.py"
+    ]
+  ],
+  "deps": [
+    [
+      "github:PyDevices/pydisplay/packages/displaysys.json",
+      "main"
+    ],
+    [
+      "github:PyDevices/pydisplay/packages/eventsys.json",
+      "main"
+    ]
+  ],
+  "version": "0.1",
+  "notes": "Linux KMS/DRM via SDL_VIDEODRIVER=kmsdrm (no X11/Wayland). Requires libsdl2 built with kmsdrm and access to /dev/dri."
+}

--- a/docs/concepts/displays.md
+++ b/docs/concepts/displays.md
@@ -85,9 +85,11 @@ runtime = eventsys.Runtime(display=display_drv, host_read=get_events)
 Use `poll_event()` only for optional manual single-event checks — not as the
 `host_read=` callback (it returns one event, not a list).
 
-Default quit chord on event backends is **CTRL+Q** (`display_drv.quit_chord`);
-`HostEventsDevice` applies it when constructed with `display=`. Window-close still
-emits `events.QUIT` from SDL/PyGame.
+Default quit chord on event backends is **CTRL+Q**
+(`eventsys.default_quit_chord()`, stored as `display_drv.quit_chord`);
+`HostEventsDevice` applies it when constructed with `display=`, along with
+Android system Back (`K_AC_BACK`). Window-close still emits `events.QUIT` from
+SDL/PyGame.
 
 Pointer coordinates use `display_drv.touch_scale` (see `capabilities()` per
 backend); `HostEventsDevice` divides mouse events by that scale.
@@ -125,13 +127,14 @@ Each captures:
   `JOYBUTTONUP`, polled from the Gamepad API on each `read()`.
 - **Quit** — an assignable key chord emits `events.QUIT` (the equivalent of
   clicking an SDL window's close button; the broker then deinitializes the
-  display and exits). It defaults to **CTRL+C**; reassign if the host intercepts
-  it:
+  display and exits). The default is **CTRL+Q** from
+  `eventsys.default_quit_chord()`; Android Back (`K_AC_BACK`) also quits.
+  Reassign if the host intercepts Ctrl+Q:
 
 ```python
 from eventsys.keys import Keys
 
-devices_drv.quit_chord = (Keys.K_q, Keys.KMOD_CTRL)  # use CTRL+Q instead
+display_drv.quit_chord = (Keys.K_c, Keys.KMOD_CTRL)  # e.g. CTRL+C on Jupyter
 ```
 
 > **Caveat:** key events require the canvas/widget to be focused (click it

--- a/docs/examples/live-demos.md
+++ b/docs/examples/live-demos.md
@@ -4,6 +4,6 @@ This content moved to **[Try pydisplay](../try/index.md)** — PyScript links, W
 
 Quick links:
 
-- [PyScript demo hub](https://PyDevices.github.io/pydisplay/pyscript/) — installable PWA ([how to build your own](../guides/pyscript-pwa.md))
+- [PyScript demo hub](https://PyDevices.github.io/pydisplay/pyscript/) — installable PWA ([where they run](../platforms/pwa.md) · [how to build your own](../guides/pyscript-pwa.md))
 - [Wokwi project](../guides/wokwi.md) (`sim/wokwi/`)
 - [Screenshot gallery](../try/index.md#screenshot-gallery)

--- a/docs/guides/pyscript-pwa.md
+++ b/docs/guides/pyscript-pwa.md
@@ -2,6 +2,8 @@
 
 **Who:** You host a pydisplay (or other PyScript) demo on GitHub Pages — or any HTTPS origin — and want users to install it like a native app and run it offline after the first visit.
 
+**Where PWAs run:** Platform notes — host matrix, install UX, PWA vs Android APK — live in [Progressive Web Apps](../platforms/pwa.md). This guide is the **how-to** (manifest, service worker, deploy).
+
 **Prerequisites:** A working PyScript HTML shell (see [PyScript guide](pyscript.md)). Basic familiarity with browser DevTools.
 
 **Live reference:** The [pydisplay PyScript gallery](https://pydevices.github.io/pydisplay/pyscript/) is a PWA. Open DevTools → **Application** to inspect its manifest and service worker, or click **Install app** in the header.
@@ -397,6 +399,7 @@ Users who install get that module every time. To ship multiple installable apps 
 
 ## Related docs
 
+- [Where PWAs run](../platforms/pwa.md) — host matrix and install UX (platform story)
 - [PyScript local development](pyscript.md) — run the gallery locally, gallery markers, deploy overview
 - [PyScript asyncio porting](pyscript-asyncio.md) — make examples work under PyScript's event loop
 - [PyScript platform notes](../platforms/pyscript.md) — board config and contribution pointers

--- a/docs/guides/pyscript.md
+++ b/docs/guides/pyscript.md
@@ -48,6 +48,7 @@ Featured starters: `pydisplay_demo`, `testris`. See `scripts/pyscript_gen_packag
 ## Next
 
 - [Make your PyScript app a PWA](pyscript-pwa.md)
+- [Where PWAs run](../platforms/pwa.md) — host matrix (desktop, Android, iOS, TVs)
 - [PyScript asyncio porting](pyscript-asyncio.md)
 - [Try pydisplay](../try/index.md)
 - [Platform notes](../platforms/pyscript.md)

--- a/docs/hardware/board-configs.md
+++ b/docs/hardware/board-configs.md
@@ -154,6 +154,7 @@ Tri-color / 4-gray configs use `color_depth=2` (0=white, 1=black, 2=accent). ACe
 | Directory | Platform |
 |-----------|----------|
 | `sdldisplay` | CPython / MicroPython Unix — SDL2 (`SDLDisplay`) |
+| `sdldisplay/linux_kms` | Linux KMS/DRM (no X11/Wayland) — `SDL_VIDEODRIVER=kmsdrm` |
 | `pgdisplay` | CPython — PyGame (`PGDisplay`) |
 | `jndisplay` | Jupyter Notebook |
 | `psdisplay` | PyScript browser |

--- a/docs/index.md
+++ b/docs/index.md
@@ -32,6 +32,7 @@ Develop on your laptop with a mouse, then deploy the *same* code to a touchscree
 | I want to… | Start here |
 |------------|------------|
 | Try it with no install | [Try PyDisplay](try/index.md) |
+| Install the browser gallery as an app | [Where PWAs run](platforms/pwa.md) |
 | Run on an ESP32 / MicroPython board | [ESP32 board guide](guides/esp32-board.md) |
 | Develop on desktop (CPython) | [Desktop CPython guide](guides/desktop-cpython.md) |
 | See every starting path | [Getting started](getting-started.md) |
@@ -42,6 +43,7 @@ Develop on your laptop with a mouse, then deploy the *same* code to a touchscree
 - **One API, every platform** — `framebuf`-compatible drawing on MicroPython, CircuitPython, and CPython.
 - **Unified input** — touch, mouse, keyboard, keypad, rotary encoder, and joystick all arrive as the same PyGame/SDL2-style [events](concepts/events.md).
 - **Cross-platform timers** — [`multimer`](concepts/multimer.md) gives you `machine.Timer`-style and `asyncio` timers even on hosts that have neither.
+- **Installable browser apps** — the [PyScript gallery](https://PyDevices.github.io/pydisplay/pyscript/) is a [Progressive Web App](platforms/pwa.md) (desktop, Android Chrome, iOS home screen).
 - **Batteries included** — 30 board configs, 60+ [examples](examples/index.md), a [browser demo](https://PyDevices.github.io/pydisplay/pyscript/), and a [Wokwi](guides/wokwi.md) project.
 - **Flexible install** — [full clone](installation/full-clone.md), one-line [MIP packages](installation/mip-github.md), or precompiled `.mpy` bytecode.
 

--- a/docs/platforms/android.md
+++ b/docs/platforms/android.md
@@ -2,6 +2,8 @@
 
 Platform notes for building pydisplay APKs with **python-for-android** and **buildozer**.
 
+For an **installable browser app** on Android phones (Chrome home screen, no APK), see [Progressive Web Apps](pwa.md) — that path uses PyScript/`PSDisplay`, not this APK stack.
+
 ## Overview
 
 On Android there is no MicroPython port. pydisplay runs under **CPython** in a **python-for-android** APK with the **SDL2 bootstrap**. The `import usdl2` API comes from the [usdl2](https://github.com/PyDevices/usdl2) package on TestPyPI (native `android_21_*` wheels). pydisplay's existing `SDLDisplay` backend works unchanged once `usdl2` is installed.

--- a/docs/platforms/android.md
+++ b/docs/platforms/android.md
@@ -68,6 +68,32 @@ See [pydisplay_android README](https://github.com/PyDevices/pydisplay_android/bl
 
 On Android, **multimer** selects the **`_sdl2`** backend (SDL timers on the UI thread) when `usdl2` is available — not `_threading`. See [multimer](../concepts/multimer.md#sdl2-bindings-usdl2).
 
+## Android TV / Fire OS
+
+Same CPython + SDL2 APK stack as phones, with **leanback** packaging and a landscape board config for 10-foot UI.
+
+**Packaging** ([pydisplay_android](https://github.com/PyDevices/pydisplay_android)):
+
+- `p4a_app/intent_filters_tv.xml` — `LEANBACK_LAUNCHER` so the app appears on the TV launcher (phone `LAUNCHER` remains).
+- `p4a_app/tv_features.xml` — `android.software.leanback` and `android.hardware.touchscreen` with `required="false"` so non-touch sticks can install.
+- `scripts/emulator_tv.sh` — install/launch helper for android-tv AVDs.
+
+**Board config:** `p4a_app/board_config_tv.py` — 1280×720 landscape, fullscreen on device. Copy over `board_config.py` (or import it from `main.py`) before a TV-oriented build. Phone paint stays on the portrait config by default.
+
+**Remote → eventsys** (SDL Android keyboard map; no extra remap required today):
+
+| TV remote | eventsys |
+|-----------|----------|
+| D-pad | `K_UP` / `K_DOWN` / `K_LEFT` / `K_RIGHT` |
+| Center / Enter | `K_RETURN` |
+| Back | `K_AC_BACK` → `QUIT` via `HostEventsDevice` |
+
+Why Back → quit: matches phone Android Back and the shared `eventsys.key_triggers_quit` path.
+
+**Fire Stick / sideload:** build the APK, `adb connect <stick-ip>`, then `./scripts/emulator_tv.sh` or `adb install -r …` and launch from the Apps row.
+
+TV **web** browsers (webOS / Tizen) are a different path — PyScript / [PWA](pwa.md), not this APK.
+
 ## Your own app
 
 Use `pydisplay_android/p4a_app/` as the template: adapt `board_config.py`, replace `paint.py` (and the `import …` in `main.py`), add TestPyPI packages to `buildozer.spec`, and keep `p4a.local_recipes` pointed at this repo's `p4a_recipes/`.

--- a/docs/platforms/cpython-desktop.md
+++ b/docs/platforms/cpython-desktop.md
@@ -90,6 +90,37 @@ Install SDL2/PyGame for your OS first; MicroPython Unix builds vary in bundled m
 
 Mouse events map to touch events. Keyboard and encoder brokers work on desktop the same as on embedded targets.
 
+## Linux KMS (no window manager)
+
+For embedded Linux **without** X11/Wayland (Pi console, kiosk, headless HDMI), use SDL’s **kmsdrm** video driver with the existing `SDLDisplay` + `usdl2` stack — not a native `/dev/fb0` path.
+
+**Board config:** `board_configs/sdldisplay/linux_kms/` sets `SDL_VIDEODRIVER=kmsdrm` before `SDLDisplay` initializes and opens a fullscreen window.
+
+```bash
+# Install the KMS config (clone or MIP), then run as usual from src/
+cp ../board_configs/sdldisplay/linux_kms/board_config.py lib/board_config.py
+# or: mip.install("github:PyDevices/pydisplay/board_configs/sdldisplay/linux_kms")
+cd pydisplay/src
+python3 -i path.py
+```
+
+**Prerequisites**
+
+- `libsdl2` built with the **kmsdrm** backend (stock Debian/Raspberry Pi OS packages usually are)
+- Access to `/dev/dri/*` (user in `video` / `render` group, or root)
+- A free VT / no competing DRM master (stop the desktop session first)
+- Input via SDL (evdev keyboards, mice, gamepads)
+
+**Contrast**
+
+| Path | Env / config | Use when |
+|------|----------------|----------|
+| Desktop Linux (this page above) | default SDL (x11/wayland) | Normal desktop session |
+| **KMS** | `SDL_VIDEODRIVER=kmsdrm` + `sdldisplay/linux_kms` | No WM; direct scanout |
+| Headless CI | `SDL_VIDEODRIVER=dummy` | No display hardware |
+
+Native Linux fbdev/DRM modules are **out of scope** until this SDL KMS path is insufficient.
+
 ## Single-board computers
 
-CircuitPython with Blinka on Raspberry Pi and similar boards is planned but not fully tested. Track progress on the [roadmap](https://github.com/PyDevices/pydisplay#roadmap).
+CircuitPython with Blinka on Raspberry Pi and similar boards is planned but not fully tested. For **CPython + HDMI without a desktop**, prefer [Linux KMS](#linux-kms-no-window-manager) above. Track other SBC work on the [roadmap](https://github.com/PyDevices/pydisplay#roadmap).

--- a/docs/platforms/index.md
+++ b/docs/platforms/index.md
@@ -4,11 +4,13 @@ Portability is PyDisplay's defining feature. Write your display, input, and timi
 
 ## Where PyDisplay runs
 
-| Runtime | Microcontrollers | Unix / Linux | Windows | Android | Browser | Jupyter Notebook |
-|---------|:----------------:|:------------:|:-------:|:-------:|:-------:|:----------------:|
-| **[MicroPython](micropython.md)** | ✅ | ✅ | ✅ | — | ✅ [PyScript](pyscript.md) · [Wokwi](../guides/wokwi.md) | — |
+| Runtime | Microcontrollers | Unix / Linux | Windows | Android | Browser / PWA | Jupyter Notebook |
+|---------|:----------------:|:------------:|:-------:|:-------:|:-------------:|:----------------:|
+| **[MicroPython](micropython.md)** | ✅ | ✅ | ✅ | — | ✅ [PyScript](pyscript.md) · [PWA](pwa.md) · [Wokwi](../guides/wokwi.md) | — |
 | **[CircuitPython](circuitpython.md)** | ✅ | ✅ | — | — | — | — |
-| **[CPython](cpython-desktop.md)** | — | ✅ | ✅ | ✅ [Android](android.md) | — | ✅ [Jupyter](jupyter.md) |
+| **[CPython](cpython-desktop.md)** | — | ✅ | ✅ | ✅ [Android APK](android.md) | — | ✅ [Jupyter](jupyter.md) |
+
+**Installable browser apps:** the [PyScript gallery](https://pydevices.github.io/pydisplay/pyscript/) ships as a [Progressive Web App](pwa.md) — install it on desktop Chromium, Android Chrome, or iOS home screen. That is a major distribution path, not a demo-only trick. See [where PWAs run](pwa.md#where-pwas-run).
 
 ## How portability works
 
@@ -24,9 +26,9 @@ What changes is which **display backend** `board_config` selects — automatical
 |---------|---------|-------------|
 | `BusDisplay` | MicroPython / CircuitPython MCUs (SPI / I80) | [board config](../hardware/board-configs.md) |
 | `FBDisplay` | CircuitPython framebuffer displays (RGB, USB video) | board config |
-| `SDLDisplay` | CPython, MicroPython Unix, CircuitPython Unix (SDL2) | auto / `board_configs/sdldisplay/` |
+| `SDLDisplay` | CPython, MicroPython Unix, CircuitPython Unix (SDL2); Android APK | auto / `board_configs/sdldisplay/` |
 | `PGDisplay` | CPython desktop (PyGame — easy on Windows) | auto / `board_configs/pgdisplay/` |
-| `PSDisplay` | [PyScript](pyscript.md) browser canvas | auto |
+| `PSDisplay` | [PyScript](pyscript.md) browser canvas and [PWAs](pwa.md) | auto |
 | `JNDisplay` | [Jupyter Notebook](jupyter.md) | auto |
 
 Input is just as portable: a mouse on the desktop, a finger on a touchscreen, and a tap in the browser all arrive as the same [events](../concepts/events.md). Timers come from [`multimer`](../concepts/multimer.md), which picks a backend (`machine.Timer`, librt, threads, polling, SDL, or `asyncio`) to suit the host.
@@ -39,9 +41,10 @@ See [Displays](../concepts/displays.md) for backend details and [Architecture](.
 - [CircuitPython](circuitpython.md) — MCUs and Unix; `framebufferio` and the `framebuf` shim.
 - [CPython desktop](cpython-desktop.md) — SDL2 / PyGame setup for Linux, macOS, and Windows.
 - [Android](android.md) — CPython APK builds with python-for-android and buildozer.
+- [Progressive Web Apps (PWA)](pwa.md) — **where** installable PyScript apps run (desktop, Android Chrome, iOS, TVs).
 - [Jupyter Notebook](jupyter.md) — interactive display widget and async execution model.
 - [Run the notebook interactively](jupyter-run.md) — JupyterLab / VS Code setup (the RTD notebook page is static).
-- [PyScript](pyscript.md) — running in the browser.
+- [PyScript](pyscript.md) — running in the browser (`PSDisplay`).
 
 ## Build GUIs across platforms
 

--- a/docs/platforms/index.md
+++ b/docs/platforms/index.md
@@ -26,7 +26,7 @@ What changes is which **display backend** `board_config` selects — automatical
 |---------|---------|-------------|
 | `BusDisplay` | MicroPython / CircuitPython MCUs (SPI / I80) | [board config](../hardware/board-configs.md) |
 | `FBDisplay` | CircuitPython framebuffer displays (RGB, USB video) | board config |
-| `SDLDisplay` | CPython, MicroPython Unix, CircuitPython Unix (SDL2); Android APK | auto / `board_configs/sdldisplay/` |
+| `SDLDisplay` | CPython, MicroPython Unix, CircuitPython Unix (SDL2); Android APK; [Linux KMS](cpython-desktop.md#linux-kms-no-window-manager) | auto / `board_configs/sdldisplay/` · `sdldisplay/linux_kms/` |
 | `PGDisplay` | CPython desktop (PyGame — easy on Windows) | auto / `board_configs/pgdisplay/` |
 | `PSDisplay` | [PyScript](pyscript.md) browser canvas and [PWAs](pwa.md) | auto |
 | `JNDisplay` | [Jupyter Notebook](jupyter.md) | auto |

--- a/docs/platforms/jupyter.md
+++ b/docs/platforms/jupyter.md
@@ -29,7 +29,7 @@ Board config: `board_configs/jndisplay/board_config.py` (registers `JNDevices` a
 
 Touch examples (e.g. [`eventsys_touch_test.py`](https://github.com/PyDevices/pydisplay/blob/main/src/examples/eventsys_touch_test.py)) render a single interactive **ipywidgets Image** — click on that widget.
 
-`JNDevices` captures mouse (motion/buttons), wheel, and keyboard input on that Image widget via `ipyevents`. The widget must be focused (clicked) to receive key events, and some keys may be consumed by the notebook front end. It also captures an assignable quit chord (default **CTRL+C**) that emits a `QUIT` event; reassign `devices_drv.quit_chord` if the front end intercepts it. See [Displays → How displays expose input](../concepts/displays.md#how-displays-expose-input).
+`JNDevices` captures mouse (motion/buttons), wheel, and keyboard input on that Image widget via `ipyevents`. The widget must be focused (clicked) to receive key events, and some keys may be consumed by the notebook front end. Quit uses `eventsys.default_quit_chord()` (**CTRL+Q** by default) on `display_drv.quit_chord`; reassign if the front end intercepts it. See [Displays → How displays expose input](../concepts/displays.md#how-displays-expose-input).
 
 ## Async execution model
 

--- a/docs/platforms/pwa.md
+++ b/docs/platforms/pwa.md
@@ -1,0 +1,110 @@
+# Progressive Web Apps (PWA)
+
+Installable, offline-capable PyScript apps are a **major pydisplay feature** — the same `PSDisplay` demos you open in a browser tab can be installed like a native app on phones, tablets, and desktops.
+
+**Live gallery (already a PWA):** [pydevices.github.io/pydisplay/pyscript/](https://pydevices.github.io/pydisplay/pyscript/)
+
+**How to build one:** [Make your PyScript app a PWA](../guides/pyscript-pwa.md) — this page is about **where** those apps run and how install UX differs by host.
+
+---
+
+## What you get
+
+| Capability | Notes |
+|------------|--------|
+| **In-browser** | Tab or window — no install required |
+| **Installable** | Home screen / app launcher icon when the host supports it |
+| **Standalone window** | Chromium `display: "standalone"` hides browser chrome after install |
+| **Offline (after first visit)** | Service worker caches shell + runtime; run each demo once online so WASM/packages land in cache |
+| **Same Python** | MicroPython or Pyodide via PyScript; drawing still goes through `PSDisplay` |
+
+A PWA is still a website on HTTPS. Python runs inside the page; the browser owns install, caching, and the launcher icon.
+
+---
+
+## Where PWAs run
+
+| Host | Install UX | Typical result | Notes |
+|------|------------|----------------|-------|
+| **Chrome / Edge (Windows, macOS, Linux)** | Address-bar install icon or **Install app**; `beforeinstallprompt` | Standalone app window | Best-supported desktop path |
+| **Chrome on Android** | **Install app** / Add to Home screen | Launcher icon; standalone | Phone/tablet web install — not the same as the [Android APK](android.md) |
+| **Chromebook (Chrome OS)** | Same as desktop Chrome | Launcher / shelf icon | Treat as Chromium desktop |
+| **Safari on iOS / iPadOS** | **Share → Add to Home Screen** (no programmatic prompt) | Home-screen icon; opens fullscreen-ish WebKit | See [Apple mobile](#apple-mobile-ios--ipados) |
+| **Firefox / Safari (desktop)** | Limited or no Chromium-style install prompt | Often stays a bookmark / tab | Gallery still runs in-tab; install polish is Chromium-first |
+| **LG webOS / Samsung Tizen (TV browsers)** | Host web app / browser only | In-browser or platform web-app packaging | **Web path only** — no native `SDLDisplay` on TV OS shells |
+
+!!! tip "Try the live gallery"
+    Open the [PyScript gallery](https://pydevices.github.io/pydisplay/pyscript/) on the device you care about, then use that host’s install path from the table.
+
+---
+
+## Install UX differences
+
+### Chromium (`beforeinstallprompt`)
+
+Chrome and Edge (desktop and Android) can fire `beforeinstallprompt`. The gallery **Install app** button calls that API when available. Uninstall an earlier install of the same origin if the prompt never appears — browsers suppress it for already-installed scopes.
+
+### iOS / iPadOS (no install API)
+
+Safari never fires `beforeinstallprompt`. The gallery button shows a short **Share → Add to Home Screen** tip instead. That is expected, not a bug.
+
+### Standalone vs browser tab
+
+| Mode | What the user sees |
+|------|--------------------|
+| **Tab** | Normal browser chrome; URL bar visible |
+| **Installed standalone** | App-like window; gallery keeps same-origin demo links in one window (Chromium would otherwise open a new app window for `target="_blank"`) |
+
+Details and manifest/`pwa.js` behavior: [PWA guide — wire pages](../guides/pyscript-pwa.md#step-3--wire-your-html-pages).
+
+---
+
+## Offline and storage
+
+1. Visit **once online** and click **Run** on a demo so PyScript/Pyodide (and packages) download.
+2. The service worker caches the shell and subsequent CDN/runtime responses.
+3. Later offline reloads work for cached assets; first-run or uncached demos still need the network.
+
+Storage can reach tens to hundreds of MB. Prefer stale-while-revalidate over precaching every WASM blob — see the [PWA guide](../guides/pyscript-pwa.md).
+
+---
+
+## PWA vs native Android APK
+
+| | **PWA (this page)** | **Android APK** |
+|--|---------------------|-----------------|
+| Runtime | PyScript in the browser / WebView | CPython in [pydisplay_android](https://github.com/PyDevices/pydisplay_android) |
+| Display | `PSDisplay` | `SDLDisplay` + `usdl2` |
+| Distribution | HTTPS URL + install/home screen | Play / sideload APK |
+| Best for | Zero-install demos, cross-OS shareable links, offline gallery | Store packaging, deeper device integration |
+
+Phone Android APK notes: [Android platform guide](android.md). Android TV / Fire OS packaging is a separate pursue track on the org roadmap — still SDL/APK, not this PWA story.
+
+---
+
+## Apple mobile (iOS / iPadOS)
+
+There is **no** native iOS pydisplay app on the foreseeable roadmap. Apple phones and tablets use:
+
+- **Mobile Safari** (or another WebKit browser) → [PyScript gallery](https://pydevices.github.io/pydisplay/pyscript/) in a tab, and/or
+- **Add to Home Screen** → installed PWA-style icon launching the same `PSDisplay` site.
+
+That is the supported Apple mobile path: browser + optional home-screen install, not App Store packaging.
+
+---
+
+## Smart TVs (webOS / Tizen)
+
+LG webOS and Samsung Tizen ship Chromium-based browsers and encourage **web apps**. pydisplay’s TV story is the same PyScript/`PSDisplay` stack (large UI, remote keys) — **not** a native SDL build on those OS shells. A hosted gallery or TV web-app package can reuse the PWA assets; treat installability as host-specific.
+
+---
+
+## Related
+
+| Doc | Role |
+|-----|------|
+| [PyScript platform notes](pyscript.md) | Board config, experimental status, contribution pointers |
+| [Make your PyScript app a PWA](../guides/pyscript-pwa.md) | Manifest, service worker, COI, deploy, troubleshooting |
+| [Portability & platforms](index.md) | Full runtime × target matrix |
+| [Android](android.md) | Native APK path (contrast with PWA) |
+| [Try pydisplay](../try/index.md) | Live demo links |

--- a/docs/platforms/pwa.md
+++ b/docs/platforms/pwa.md
@@ -97,6 +97,12 @@ That is the supported Apple mobile path: browser + optional home-screen install,
 
 LG webOS and Samsung Tizen ship Chromium-based browsers and encourage **web apps**. pydisplay’s TV story is the same PyScript/`PSDisplay` stack (large UI, remote keys) — **not** a native SDL build on those OS shells. A hosted gallery or TV web-app package can reuse the PWA assets; treat installability as host-specific.
 
+**Example:** [`tv_remote_menu`](https://pydevices.github.io/pydisplay/pyscript/micropython.html?modules=tv_remote_menu) — large-row D-pad menu. Remote key notes: [`web/pyscript/tv/README.md`](https://github.com/PyDevices/pydisplay/blob/main/web/pyscript/tv/README.md).
+
+TV Back (`BrowserBack` / `GoBack` / `Back`) maps to `K_AC_BACK` in `eventsys.keys` so quit matches Android remotes.
+
+Native Android TV / Fire OS APKs are separate — see [Android TV / Fire OS](android.md#android-tv--fire-os).
+
 ---
 
 ## Related

--- a/docs/platforms/pyscript.md
+++ b/docs/platforms/pyscript.md
@@ -4,7 +4,7 @@ Experimental browser support via [PyScript](https://pyscript.net/) and `displays
 
 **Quick start:** [PyScript guide](../guides/pyscript.md) and [Try pydisplay](../try/index.md).
 
-**Installable / offline:** [PyScript PWA guide](../guides/pyscript-pwa.md) — manifest, service worker, and GitHub Pages deploy.
+**Installable / offline (major feature):** The live gallery is a [Progressive Web App](pwa.md). Read [where PWAs run](pwa.md#where-pwas-run) for the host matrix (desktop Chromium, Android Chrome, iOS home screen, TV web). Build your own with the [PyScript PWA guide](../guides/pyscript-pwa.md).
 
 **Asyncio porting:** [PyScript asyncio guide](../guides/pyscript-asyncio.md).
 

--- a/docs/platforms/pyscript.md
+++ b/docs/platforms/pyscript.md
@@ -15,6 +15,14 @@ Experimental browser support via [PyScript](https://pyscript.net/) and `displays
 
 `board_configs/psdisplay/board_config.py` — 320×480 canvas with touch broker.
 
+## Apple mobile (iOS / iPadOS)
+
+There is no native iOS app on the foreseeable roadmap. Use **Mobile Safari** (or another WebKit browser) with the [PyScript gallery](https://PyDevices.github.io/pydisplay/pyscript/), optionally **Add to Home Screen** as a [PWA](pwa.md#apple-mobile-ios--ipados).
+
+## Smart TVs (webOS / Tizen)
+
+Browser / PyScript only — see [PWA — Smart TVs](pwa.md#smart-tvs-webos--tizen) and the [`tv_remote_menu`](https://PyDevices.github.io/pydisplay/pyscript/micropython.html?modules=tv_remote_menu) example. Do not expect `SDLDisplay` on those OS shells.
+
 ## Contributing
 
 Pull requests welcome for `displaysys/psdisplay.py`, asyncio example ports, and files under `web/pyscript/`.

--- a/docs/try/index.md
+++ b/docs/try/index.md
@@ -7,6 +7,7 @@ Evaluate pydisplay without installing anything on your machine.
 | Path | Best for | Start here |
 |------|----------|------------|
 | **Browser (PyScript)** | Quick look, touch UI in the tab | [Live demo hub](https://PyDevices.github.io/pydisplay/pyscript/) |
+| **Installable PWA** | Home-screen / standalone app on phone or desktop | [Where PWAs run](../platforms/pwa.md) · [Install the gallery](https://PyDevices.github.io/pydisplay/pyscript/) |
 | **Wokwi simulator** | ESP32 + ILI9341 without hardware | [Wokwi guide](../guides/wokwi.md) · [`wokwi/`](../sim/wokwi/) |
 | **Screenshot gallery** | See what examples look like | [Gallery below](#screenshot-gallery) |
 
@@ -14,7 +15,7 @@ Evaluate pydisplay without installing anything on your machine.
 
 ### Live demo (online)
 
-**Hub:** [PyDevices.github.io/pydisplay/pyscript/](https://PyDevices.github.io/pydisplay/pyscript/)
+**Hub:** [PyDevices.github.io/pydisplay/pyscript/](https://PyDevices.github.io/pydisplay/pyscript/) — also an installable [PWA](../platforms/pwa.md) (**Install app** in the header on Chromium; on iOS use Share → Add to Home Screen).
 
 | Link | Description |
 |------|-------------|

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -113,6 +113,7 @@ nav:
     - CircuitPython: platforms/circuitpython.md
     - CPython desktop: platforms/cpython-desktop.md
     - Android: platforms/android.md
+    - Progressive Web Apps: platforms/pwa.md
     - Jupyter: platforms/jupyter.md
     - Run interactively: platforms/jupyter-run.md
     - Jupyter notebook: platforms/jupyter-notebook.ipynb

--- a/src/examples/tv_remote_menu.py
+++ b/src/examples/tv_remote_menu.py
@@ -1,0 +1,104 @@
+# pyscript featured
+# SPDX-FileCopyrightText: 2026 Brad Barnett
+#
+# SPDX-License-Identifier: MIT
+"""
+tv_remote_menu.py — 10-foot / remote-friendly menu for PyScript TV browsers.
+
+Why large rows + D-pad only: webOS / Tizen (and Android TV web) are remote-first;
+touch targets sized for phones are unusable from the sofa. Arrow keys move
+focus; Enter selects; Escape / AC Back quits (same as eventsys quit path).
+
+Desktop keyboards stand in for remotes during development.
+"""
+
+from board_config import display_drv, runtime
+
+from displaysys import color565
+from eventsys.keys import Keys
+from graphics import RGB565, Font, FrameBuffer
+
+# Why tall rows: 10-foot UI — readable labels and large focus highlight.
+ROW_H = 48
+PAD = 16
+TITLE_H = 40
+
+BLACK = 0
+INK = color565(0xF7, 0xF7, 0xF4)
+CHROME = color565(0x3B, 0x3A, 0x33)
+FOCUS = color565(0xF5, 0x4E, 0x00)
+MUTED = color565(0xA0, 0x9C, 0x92)
+SURFACE = color565(0x2A, 0x29, 0x26)
+
+# Why these labels: stand-ins for TV app sections; keep short for large fonts.
+ITEMS = (
+    "Watch demos",
+    "Settings",
+    "About pydisplay",
+    "Quit",
+)
+
+FONT = Font(height=16)
+BPP = display_drv.color_depth // 8
+_MAX_CHARS = max(len(s) for s in ITEMS) + 8
+_TEXT_BUF = bytearray(_MAX_CHARS * FONT.width * FONT.height * BPP)
+
+state = {"index": 0, "status": "Use arrows + Enter"}
+
+
+def blit_text(s, x, y, fg, bg):
+    w = len(s) * FONT.width
+    h = FONT.height
+    buf = memoryview(_TEXT_BUF)[: w * h * BPP]
+    fb = FrameBuffer(buf, w, h, RGB565)
+    fb.fill(bg)
+    FONT.text(fb, s, 0, 0, fg)
+    display_drv.blit_rect(buf, x, y, w, h)
+
+
+def redraw():
+    w = display_drv.width
+    h = display_drv.height
+    display_drv.fill(BLACK)
+    display_drv.fill_rect(0, 0, w, TITLE_H, SURFACE)
+    blit_text("TV remote menu", PAD, 12, INK, SURFACE)
+
+    y = TITLE_H + PAD
+    for i, label in enumerate(ITEMS):
+        bg = FOCUS if i == state["index"] else CHROME
+        fg = BLACK if i == state["index"] else INK
+        display_drv.fill_rect(PAD, y, w - 2 * PAD, ROW_H - 4, bg)
+        blit_text(label, PAD + 12, y + (ROW_H - 4 - FONT.height) // 2, fg, bg)
+        y += ROW_H
+
+    display_drv.fill_rect(0, h - 28, w, 28, SURFACE)
+    blit_text(state["status"][:40], PAD, h - 22, MUTED, SURFACE)
+    display_drv.show()
+
+
+def on_key(e):
+    # Why map AC_BACK like Escape: TV remotes / webOS Back should leave the app
+    # the same way Android SDL Back becomes QUIT in HostEventsDevice.
+    if e.key in (Keys.K_ESCAPE, Keys.K_AC_BACK):
+        display_drv.quit()
+        return
+    if e.key == Keys.K_UP:
+        state["index"] = (state["index"] - 1) % len(ITEMS)
+        state["status"] = ITEMS[state["index"]]
+    elif e.key == Keys.K_DOWN:
+        state["index"] = (state["index"] + 1) % len(ITEMS)
+        state["status"] = ITEMS[state["index"]]
+    elif e.key in (Keys.K_RETURN, Keys.K_SPACE):
+        choice = ITEMS[state["index"]]
+        if choice == "Quit":
+            display_drv.quit()
+            return
+        state["status"] = f"Selected: {choice}"
+    else:
+        return
+    redraw()
+
+
+redraw()
+runtime.on(runtime.events.KEYDOWN, on_key)
+runtime.run_forever()

--- a/src/lib/displaysys/__init__.py
+++ b/src/lib/displaysys/__init__.py
@@ -42,7 +42,6 @@ __all__ = [
     "color565",
     "color565_swapped",
     "color_rgb",
-    "default_quit_chord",
     "env_bool",
     "env_get",
     "env_int",
@@ -211,13 +210,6 @@ def capabilities():
             },
         },
     }
-
-
-def default_quit_chord():
-    """Default CTRL+Q quit chord for event-backend displays (lazy-imports eventsys.keys)."""
-    from eventsys.keys import Keys
-
-    return (Keys.K_q, Keys.KMOD_CTRL)
 
 
 def alloc_buffer(size):

--- a/src/lib/displaysys/jndisplay.py
+++ b/src/lib/displaysys/jndisplay.py
@@ -11,7 +11,8 @@ from io import BytesIO
 from IPython.display import display, update_display
 from PIL import Image, ImageDraw
 
-from displaysys import DisplayDriver, color_rgb, default_quit_chord
+from displaysys import DisplayDriver, color_rgb
+from eventsys.keys import default_quit_chord
 from eventsys import events
 from eventsys.keys import Keys, key_to_keycode, mod_mask
 
@@ -82,8 +83,9 @@ class JNDevices:
       modifier masks (left/right modifier variants via key location).
 
     Quit chord handling is configured on :class:`JNDisplay` via ``quit_chord``
-    (default CTRL+Q); :class:`eventsys.QueueDevice` applies it when ``data=``
-    is the display driver.
+    (default from :func:`eventsys.keys.default_quit_chord`, CTRL+Q).
+    :class:`~eventsys.HostEventsDevice` applies the chord and Android Back
+    (``K_AC_BACK``) when constructed with ``display=``.
 
     This class also owns the display widget: ``JNDisplay`` pushes frames to it
     via :meth:`update_buffer`.

--- a/src/lib/displaysys/pgdisplay.py
+++ b/src/lib/displaysys/pgdisplay.py
@@ -11,11 +11,11 @@ import pygame as pg
 from displaysys import (
     DisplayDriver,
     color_rgb,
-    default_quit_chord,
     fit_scale_to_desktop,
     notify_board_config_scale_override,
 )
 from eventsys import events
+from eventsys.keys import default_quit_chord
 
 __all__ = ["FFmpegFrameRecorder", "PGDisplay", "get_events", "poll_event"]
 

--- a/src/lib/displaysys/psdisplay.py
+++ b/src/lib/displaysys/psdisplay.py
@@ -9,7 +9,8 @@ displaysys.psdisplay
 from js import console, document
 from pyscript.ffi import create_proxy
 
-from displaysys import DisplayDriver, color_rgb, default_quit_chord
+from displaysys import DisplayDriver, color_rgb
+from eventsys.keys import default_quit_chord
 from eventsys import events
 from eventsys.keys import Keys, dom_key_scrolls_page, key_to_keycode, mod_mask
 
@@ -50,8 +51,9 @@ class PSDevices:
       ``JOYBUTTONDOWN`` / ``JOYBUTTONUP``.
 
     Quit chord handling is configured on :class:`PSDisplay` via ``quit_chord``
-    (default CTRL+Q); :class:`eventsys.QueueDevice` applies it when ``data=``
-    is the display driver.
+    (default from :func:`eventsys.keys.default_quit_chord`, CTRL+Q).
+    :class:`~eventsys.HostEventsDevice` applies the chord and Android Back
+    (``K_AC_BACK``) when constructed with ``display=``.
 
     Note:
         The element must be focused to receive key events.  The constructor sets

--- a/src/lib/displaysys/sdldisplay.py
+++ b/src/lib/displaysys/sdldisplay.py
@@ -14,11 +14,11 @@ import usdl2
 from displaysys import (
     DisplayDriver,
     color_rgb,
-    default_quit_chord,
     fit_scale_to_desktop,
     notify_board_config_scale_override,
 )
 from eventsys import events
+from eventsys.keys import default_quit_chord
 
 _JOYSTICK_API = (
     "SDL_InitSubSystem",

--- a/src/lib/eventsys/__init__.py
+++ b/src/lib/eventsys/__init__.py
@@ -35,6 +35,9 @@ from ._runtime import DEFAULT_REFRESH_MS, Runtime
 from ._touch import TouchDevice
 
 Keys = keys.Keys
+default_quit_chord = keys.default_quit_chord
+key_triggers_quit = keys.key_triggers_quit
+chord_matches = keys.chord_matches
 
 # Device type constants (also available as eventsys.types.*)
 HOST = types.HOST
@@ -87,7 +90,10 @@ __all__ = [
     "TouchDevice",
     "VirtualDevices",
     "capabilities",
+    "chord_matches",
+    "default_quit_chord",
     "events",
+    "key_triggers_quit",
     "register_device",
     "register_event",
     "types",

--- a/src/lib/eventsys/_host.py
+++ b/src/lib/eventsys/_host.py
@@ -43,7 +43,9 @@ class HostEventsDevice(Device):
             chord_key = quit_chord[0] if quit_chord else None
             for event in dev_events:
                 if event.type == events.KEYDOWN:
-                    # Quit chord (default Ctrl+Q) and Android Back → QUIT.
+                    # Quit chord (default Ctrl+Q) and Android / TV Back → QUIT.
+                    # Why K_AC_BACK: Android SDL maps KEYCODE_BACK here; PyScript
+                    # TV browsers map BrowserBack/GoBack/Back to the same code.
                     if key_triggers_quit(
                         event.type, event.key, event.mod, quit_chord
                     ):

--- a/src/lib/eventsys/_host.py
+++ b/src/lib/eventsys/_host.py
@@ -5,7 +5,7 @@
 
 from ._device import Device, register_device_class, types
 from ._events import events
-from .keys import Keys, chord_matches
+from .keys import Keys, key_triggers_quit
 
 
 class HostEventsDevice(Device):
@@ -43,12 +43,14 @@ class HostEventsDevice(Device):
             chord_key = quit_chord[0] if quit_chord else None
             for event in dev_events:
                 if event.type == events.KEYDOWN:
-                    # Android system Back (SDLK_AC_BACK) → quit, same as quit_chord.
-                    if event.key == Keys.K_AC_BACK or (
-                        quit_chord and chord_matches(quit_chord, event.key, event.mod)
+                    # Quit chord (default Ctrl+Q) and Android Back → QUIT.
+                    if key_triggers_quit(
+                        event.type, event.key, event.mod, quit_chord
                     ):
                         event = events.Quit(events.QUIT)
                 elif event.type == events.KEYUP:
+                    # Swallow key-up for quit keys so apps do not see a dangling
+                    # KEYUP after the KEYDOWN was converted to QUIT.
                     if event.key == Keys.K_AC_BACK:
                         continue
                     if quit_chord and event.key == chord_key:

--- a/src/lib/eventsys/keys.py
+++ b/src/lib/eventsys/keys.py
@@ -714,10 +714,21 @@ def chord_matches(chord, keycode, mod):
     return all(not (chord_mod & group and not mod & group) for group in _MOD_GROUPS)
 
 
+def default_quit_chord():
+    """Default CTRL+Q quit chord for host event backends.
+
+    Owned by eventsys alongside Android Back (``K_AC_BACK``) quit handling in
+    :func:`key_triggers_quit` / ``HostEventsDevice``. Display drivers may copy
+    this onto ``display.quit_chord`` so the host device can read it.
+    """
+    return (Keys.K_q, Keys.KMOD_CTRL)
+
+
 def key_triggers_quit(event_type, key, mod, quit_chord):
     """Return True when ``event_type`` is KEYDOWN and quit should fire.
 
-    Matches ``quit_chord`` (e.g. Ctrl+Q) or Android system Back (``K_AC_BACK``).
+    Matches ``quit_chord`` (e.g. Ctrl+Q from :func:`default_quit_chord`) or
+    Android system Back (``K_AC_BACK``).
     """
     from ._events import events
 

--- a/src/lib/eventsys/keys.py
+++ b/src/lib/eventsys/keys.py
@@ -597,6 +597,12 @@ _DOM_NAMED_KEYS = {
     "ArrowDown": Keys.K_DOWN,
     "ArrowLeft": Keys.K_LEFT,
     "ArrowRight": Keys.K_RIGHT,
+    # Why BrowserBack/GoBack/Back → K_AC_BACK: webOS / Tizen / some Chromium TV
+    # remotes emit these DOM key names for the Back button; match Android SDL
+    # Back so HostEventsDevice can turn them into QUIT.
+    "BrowserBack": Keys.K_AC_BACK,
+    "GoBack": Keys.K_AC_BACK,
+    "Back": Keys.K_AC_BACK,
     "Home": Keys.K_HOME,
     "End": Keys.K_END,
     "PageUp": Keys.K_PAGEUP,

--- a/tests/test_displaysys_lifecycle.py
+++ b/tests/test_displaysys_lifecycle.py
@@ -10,9 +10,7 @@ from unittest import mock
 import _env  # noqa: F401
 from _support import make_fbdisplay, quiet
 
-from displaysys import DisplayDriver, default_quit_chord
-from displaysys.fbdisplay import FBDisplay
-from eventsys.keys import Keys
+from displaysys import DisplayDriver
 
 
 class CountingDriver(DisplayDriver):
@@ -73,11 +71,6 @@ class TestBackendIsolation(unittest.TestCase):
         ):
             if name not in before:
                 self.assertNotIn(name, sys.modules)
-
-
-class TestEventBackendDefaults(unittest.TestCase):
-    def test_default_quit_chord_is_ctrl_q(self):
-        self.assertEqual(default_quit_chord(), (Keys.K_q, Keys.KMOD_CTRL))
 
 
 if __name__ == "__main__":

--- a/tests/test_eventsys_quit.py
+++ b/tests/test_eventsys_quit.py
@@ -10,16 +10,24 @@ from _support import scripted
 
 import eventsys
 from eventsys import HostEventsDevice, Runtime, events
-from eventsys.keys import Keys, key_triggers_quit
+from eventsys.keys import Keys, default_quit_chord, key_triggers_quit
+
+
+class TestDefaultQuitChord(unittest.TestCase):
+    def test_default_quit_chord_is_ctrl_q(self):
+        self.assertEqual(default_quit_chord(), (Keys.K_q, Keys.KMOD_CTRL))
+
+    def test_exported_from_eventsys(self):
+        self.assertEqual(eventsys.default_quit_chord(), (Keys.K_q, Keys.KMOD_CTRL))
 
 
 class TestKeyTriggersQuit(unittest.TestCase):
     def test_keydown_matching_chord(self):
-        chord = (Keys.K_q, Keys.KMOD_CTRL)
+        chord = default_quit_chord()
         self.assertTrue(key_triggers_quit(events.KEYDOWN, Keys.K_q, Keys.KMOD_CTRL, chord))
 
     def test_keyup_never_triggers(self):
-        chord = (Keys.K_q, Keys.KMOD_CTRL)
+        chord = default_quit_chord()
         self.assertFalse(key_triggers_quit(events.KEYUP, Keys.K_q, Keys.KMOD_CTRL, chord))
 
     def test_none_chord_disabled(self):
@@ -68,7 +76,7 @@ class TestRuntimeQuitLifecycle(unittest.TestCase):
 class TestHostEventsDeviceQuitChord(unittest.TestCase):
     def test_chord_keydown_becomes_quit(self):
         class Data:
-            quit_chord = (Keys.K_q, Keys.KMOD_CTRL)
+            quit_chord = default_quit_chord()
 
         ev = events.Key(events.KEYDOWN, "q", Keys.K_q, Keys.KMOD_CTRL, 0, None)
         dev = HostEventsDevice(host_read=scripted([ev]), display=Data())
@@ -78,7 +86,7 @@ class TestHostEventsDeviceQuitChord(unittest.TestCase):
 
     def test_chord_keyup_filtered(self):
         class Data:
-            quit_chord = (Keys.K_q, Keys.KMOD_CTRL)
+            quit_chord = default_quit_chord()
 
         ev = events.Key(events.KEYUP, "q", Keys.K_q, Keys.KMOD_CTRL, 0, None)
         dev = HostEventsDevice(host_read=scripted([ev]), display=Data())
@@ -88,7 +96,7 @@ class TestHostEventsDeviceQuitChord(unittest.TestCase):
         """Android system Back (SDLK_AC_BACK) maps to QUIT without a chord."""
 
         class Data:
-            quit_chord = (Keys.K_q, Keys.KMOD_CTRL)
+            quit_chord = default_quit_chord()
 
         ev = events.Key(events.KEYDOWN, "AC Back", Keys.K_AC_BACK, 0, 0, None)
         dev = HostEventsDevice(host_read=scripted([ev]), display=Data())

--- a/tests/test_keys.py
+++ b/tests/test_keys.py
@@ -7,7 +7,7 @@ import unittest
 
 import _env  # noqa: F401
 
-from eventsys.keys import Keys
+from eventsys.keys import Keys, key_to_keycode
 
 
 class TestKeyTables(unittest.TestCase):
@@ -40,6 +40,17 @@ class TestKeyTables(unittest.TestCase):
     def test_constants_are_ints(self):
         for name in ("K_a", "K_SPACE", "K_F12", "KMOD_LALT"):
             self.assertIsInstance(getattr(Keys, name), int)
+
+
+class TestDomNamedKeys(unittest.TestCase):
+    def test_arrows_and_enter(self):
+        self.assertEqual(key_to_keycode("ArrowUp"), Keys.K_UP)
+        self.assertEqual(key_to_keycode("Enter"), Keys.K_RETURN)
+
+    def test_tv_back_aliases_map_to_ac_back(self):
+        # Why: webOS / Tizen / Chromium TV remotes — see platforms/pwa.md.
+        for name in ("BrowserBack", "GoBack", "Back"):
+            self.assertEqual(key_to_keycode(name), Keys.K_AC_BACK, name)
 
 
 if __name__ == "__main__":

--- a/tools/pyscript_autotest.py
+++ b/tools/pyscript_autotest.py
@@ -260,7 +260,7 @@ def run_autotest(
                 "console_errors": soak_errors[:20],
             }
 
-        # --- quit chord: Ctrl+Q (displaysys.default_quit_chord) ---
+        # --- quit chord: Ctrl+Q (eventsys.default_quit_chord) ---
         try:
             canvas = page.locator("#display_canvas")
             canvas.click(timeout=5000)

--- a/web/pyscript/index.html
+++ b/web/pyscript/index.html
@@ -84,6 +84,15 @@
                     <p>Testris game implemented in MicroPython by Brad Barnett.</p>
                     <span class="go">Open demo <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M5 12h14M13 6l6 6-6 6"/></svg></span>
                 </a>
+                <a class="card" href="micropython.html?modules=tv_remote_menu">
+                    <div class="card-top">
+                        <span class="card-icon"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect x="2" y="3" width="20" height="14" rx="2"/><path d="M8 21h8M12 17v4"/></svg></span>
+                        <span class="tag featured">featured</span>
+                    </div>
+                    <h3>Tv Remote Menu</h3>
+                    <p>tv_remote_menu.py — 10-foot / remote-friendly menu for PyScript TV browsers.</p>
+                    <span class="go">Open demo <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M5 12h14M13 6l6 6-6 6"/></svg></span>
+                </a>
                 <a class="card" href="micropython.html?manifests=alien&mip=palettes">
                     <div class="card-top">
                         <span class="card-icon"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect x="2" y="3" width="20" height="14" rx="2"/><path d="M8 21h8M12 17v4"/></svg></span>

--- a/web/pyscript/tv/README.md
+++ b/web/pyscript/tv/README.md
@@ -1,0 +1,34 @@
+# Why this hub: roadmap TV web path is PyScript-only (no native SDL on webOS /
+# Tizen). Python demos live under src/examples/ so the gallery loader can see
+# them; this folder holds remote-key notes for TV browsers.
+
+# TV remote / PyScript notes (webOS / Tizen)
+
+pydisplay on LG **webOS** and Samsung **Tizen** is **browser / PyScript only** —
+use `PSDisplay`, not native `SDLDisplay` / `usdl2`.
+
+## Try the demo
+
+From the [PyScript gallery](../index.html) or:
+
+- [tv_remote_menu](../micropython.html?modules=tv_remote_menu) — large-row menu, D-pad / Enter / Back
+
+Desktop arrow keys stand in for the remote during development.
+
+## Expected key → eventsys mapping
+
+| Remote / DOM `KeyboardEvent.key` | eventsys | Notes |
+|----------------------------------|----------|--------|
+| ArrowUp / ArrowDown / ArrowLeft / ArrowRight | `K_UP` … `K_RIGHT` | D-pad |
+| Enter | `K_RETURN` | Select / OK |
+| Escape | `K_ESCAPE` | Often Back on desktop |
+| BrowserBack, GoBack, Back | `K_AC_BACK` | Why: TV Back should match Android SDL Back → quit |
+| ColorF0Red … (optional) | unmapped unless a demo needs them | Host-specific |
+
+Mappings live in `eventsys.keys._DOM_NAMED_KEYS`. Unknown TV keys arrive as
+`K_UNKNOWN` until added with a why-comment.
+
+## Related
+
+- [Where PWAs run — Smart TVs](https://pydisplay.readthedocs.io/en/latest/platforms/pwa.html)
+- [PyScript platform notes](https://pydisplay.readthedocs.io/en/latest/platforms/pyscript.html)


### PR DESCRIPTION
## Summary
Implements org roadmap pursue + docs tracks in pydisplay.

## Changes
- **PWA docs** — `platforms/pwa.md` where-they-run matrix; elevated in portability/home/Try
- **Linux KMS Phase 0** — `board_configs/sdldisplay/linux_kms/` + cpython-desktop notes
- **webOS/Tizen** — `tv_remote_menu` example, `web/pyscript/tv/` notes, DOM Back→`K_AC_BACK`
- **Android TV docs** — section in `platforms/android.md` (packaging lives in pydisplay_android)
- **iOS docs-only** — note under `platforms/pyscript.md`
- **refactor** — `default_quit_chord` moved to eventsys (with Android Back)

## Test plan
- [x] `unittest test_keys test_eventsys_quit`
- [x] `pyscript_gen_packages.py` (gallery includes tv_remote_menu)
- [ ] Spot-check RTD links after merge