### PR TITLE
Fix Pyodide gallery packaging (manifests, palettes, LVGL, Hinch GUIs)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,7 +3,7 @@ src/add_ons/gui
 # Generated from src/add_ons/framebuf.py (scripts/install_sync_framebuf.py; publish + tests)
 src/lib/graphics/framebuf.py
 
-# Local symlink created by tools/serve.py → sibling lv_cpython_mod/web/wheels
+# Optional local/dev copy of LVGL wasm wheels (not required; pyodide uses TestPyPI)
 web/pyscript/wheels
 
 # Cursor IDE throwaways (do not ignore the whole .cursor/ tree)

--- a/scripts/pyscript_gen_packages.py
+++ b/scripts/pyscript_gen_packages.py
@@ -27,8 +27,9 @@ Optional headers (first 10 lines):
     ``micropython-nano-gui``) pre-installed into ``/add_ons`` before import
   - ``# pyscript mip:`` — micropython-lib MIP names (e.g. ``pdwidgets``) installed
     from ``https://PyDevices.github.io/micropython-lib/mip/PyDevices``
-  - ``# pyodide wheels:`` — micropip wheels for ``pyodide.html`` (e.g. ``lvgl``
-    → ``lv_cpython_mod`` ``pyemscripten_2026_0`` wheel)
+  - ``# pyodide wheels:`` — PyPI / TestPyPI project names for ``pyodide.html``
+    micropip (e.g. ``palettes``, ``pdwidgets``, ``lvgl-cpython``). Emitted as
+    ``&wheels=…`` on the card URL so the Pyodide loader does not re-read headers.
   - ``# pyscript skip: gallery`` — omit from the browser card grid
   - ``# pyscript skip: binaries`` — omit from the grid (needs assets mip cannot
     install; those demos do not ship); typically combined with ``gallery``
@@ -39,7 +40,9 @@ Then:
   - Deletes stale ``web/pyscript/*.html`` from the old per-demo page generator
 
 Every gallery example opens the parametric loader at ``micropython.html?modules=…`` or
-``micropython.html?manifests=…``.
+``micropython.html?manifests=…``, plus ``&mip=`` / ``&packages=`` / ``&wheels=``
+when the corresponding headers are set. The MP↔Pyodide toggle keeps the query
+string; MicroPython ignores ``wheels=``, Pyodide ignores ``mip=``.
 
     python scripts/pyscript_gen_packages.py
     python scripts/pyscript_gen_packages.py --check
@@ -82,6 +85,13 @@ GENERIC_ICON = (
 
 HEADER_SCAN_LINES = 10
 
+# Short names sometimes used in older ``# pyodide wheels:`` lines → TestPyPI /
+# PyPI project names. Prefer writing the real project name in the header.
+WHEEL_ALIASES = {
+    "lvgl": "lvgl-cpython",
+    "lvglcpython": "lvgl-cpython",
+}
+
 LOCAL_IMPORT_RE = re.compile(
     r"^\s*(?:from\s+([\w.]+)\s+import|import\s+([\w.]+))",
     re.MULTILINE,
@@ -99,6 +109,7 @@ class Example:
         self.pyscript_files: list[str] = []
         self.pyscript_packages: list[str] = []
         self.pyscript_mip: list[str] = []
+        self.pyodide_wheels: list[str] = []
         self.featured = False
         # False when ``# pyscript skip:`` includes ``gallery`` or ``binaries``.
         self.in_gallery = True
@@ -125,7 +136,25 @@ class Example:
             href += f"&packages={','.join(self.pyscript_packages)}"
         if self.pyscript_mip:
             href += f"&mip={','.join(self.pyscript_mip)}"
+        if self.pyodide_wheels:
+            href += f"&wheels={','.join(self.pyodide_wheels)}"
         return href
+
+
+def normalize_wheel_names(names: list[str]) -> list[str]:
+    """Dedupe and map short aliases to real PyPI / TestPyPI project names."""
+    out: list[str] = []
+    seen: set[str] = set()
+    for raw in names:
+        name = raw.strip()
+        if not name:
+            continue
+        key = name.lower().replace("_", "-")
+        name = WHEEL_ALIASES.get(key, name)
+        if name not in seen:
+            seen.add(name)
+            out.append(name)
+    return out
 
 
 def parse_header_list(lines: list[str], prefix: str) -> list[str]:
@@ -295,6 +324,12 @@ def parse_example(path: Path) -> Example | None:
     ex.pyscript_files = resolve_pyscript_paths(path, kind, name, lines, text)
     ex.pyscript_packages = parse_header_list(lines, "# pyscript packages:")
     ex.pyscript_mip = parse_header_list(lines, "# pyscript mip:")
+    wheels = parse_header_list(lines, "# pyodide wheels:")
+    # Same project names are often published both as MIP and TestPyPI wheels
+    # (palettes, pdwidgets). Prefer an explicit wheels header; otherwise reuse mip.
+    if not wheels and ex.pyscript_mip:
+        wheels = list(ex.pyscript_mip)
+    ex.pyodide_wheels = normalize_wheel_names(wheels)
     for entry in ex.pyscript_files:
         if not (EXAMPLES_DIR / entry).is_file():
             raise SystemExit(f"{rel}: missing pyscript file {entry}")

--- a/src/examples/alien/alien.py
+++ b/src/examples/alien/alien.py
@@ -1,4 +1,5 @@
 # pyscript mip: palettes
+# pyodide wheels: palettes
 """
 alien.py
 =========

--- a/src/examples/boxlines.py
+++ b/src/examples/boxlines.py
@@ -1,4 +1,5 @@
 # pyscript mip: palettes
+# pyodide wheels: palettes
 """
 boxlines.py
 ===========

--- a/src/examples/calc_lvgl.py
+++ b/src/examples/calc_lvgl.py
@@ -1,5 +1,5 @@
 # pyscript modules: calc_engine
-# pyodide wheels: lvgl
+# pyodide wheels: lvgl-cpython
 """
 calc_lvgl
 ====================================================

--- a/src/examples/chango/chango.py
+++ b/src/examples/chango/chango.py
@@ -1,4 +1,5 @@
 # pyscript mip: palettes
+# pyodide wheels: palettes
 """
 chango.py
 =========

--- a/src/examples/color_test.py
+++ b/src/examples/color_test.py
@@ -1,4 +1,5 @@
 # pyscript mip: palettes
+# pyodide wheels: palettes
 """
 color_test.py
 =============

--- a/src/examples/console_advanced_demo.py
+++ b/src/examples/console_advanced_demo.py
@@ -59,9 +59,12 @@ if not _test_mode:
     try:
         import os
 
-        os.dupterm(console)
-        help()
-    except ImportError:
+        if hasattr(os, "dupterm"):
+            os.dupterm(console)
+            help()
+        else:
+            console.write("REPL not available (no os.dupterm).\n", pal.YELLOW)
+    except (ImportError, AttributeError):
         console.write("REPL not available.\n", pal.YELLOW)
 
 console.label(Console.LEFT, platform, pal.RED)

--- a/src/examples/fonts.py
+++ b/src/examples/fonts.py
@@ -1,4 +1,5 @@
 # pyscript mip: palettes
+# pyodide wheels: palettes
 """
 fonts.py
 ========

--- a/src/examples/hello.py
+++ b/src/examples/hello.py
@@ -1,4 +1,5 @@
 # pyscript mip: palettes
+# pyodide wheels: palettes
 """
 hello.py
 ========

--- a/src/examples/lv_test_timer.py
+++ b/src/examples/lv_test_timer.py
@@ -1,4 +1,4 @@
-# pyodide wheels: lvgl
+# pyodide wheels: lvgl-cpython
 """
 lv_test_timer.py
 

--- a/src/examples/noto_fonts/noto_fonts.py
+++ b/src/examples/noto_fonts/noto_fonts.py
@@ -1,4 +1,5 @@
 # pyscript mip: palettes
+# pyodide wheels: palettes
 """
 noto_fonts.py
 =============

--- a/src/examples/proverbs/proverbs.py
+++ b/src/examples/proverbs/proverbs.py
@@ -1,4 +1,5 @@
 # pyscript mip: palettes
+# pyodide wheels: palettes
 """
 proverbs.py
 ===========

--- a/src/examples/scroll.py
+++ b/src/examples/scroll.py
@@ -1,4 +1,5 @@
 # pyscript mip: palettes
+# pyodide wheels: palettes
 """
 scroll.py
 =========

--- a/src/examples/tiny_hello.py
+++ b/src/examples/tiny_hello.py
@@ -1,4 +1,5 @@
 # pyscript mip: palettes
+# pyodide wheels: palettes
 """
 tiny_hello.py
 =============

--- a/src/examples/tiny_toasters/tiny_toasters.py
+++ b/src/examples/tiny_toasters/tiny_toasters.py
@@ -1,4 +1,5 @@
 # pyscript mip: palettes
+# pyodide wheels: palettes
 """
 tiny_toasters.py
 ================

--- a/tools/serve.py
+++ b/tools/serve.py
@@ -43,6 +43,8 @@ from http.server import SimpleHTTPRequestHandler, ThreadingHTTPServer
 import json
 from pathlib import Path
 import sys
+import urllib.error
+import urllib.request
 
 REPO_ROOT = Path(__file__).resolve().parent.parent
 
@@ -52,11 +54,39 @@ DEBUG_PREFIX = "/__debug"
 
 # Same-origin path for micropip LVGL wheels (pyodide.html). When the tree does
 # not yet contain wheels/, link a sibling lv_cpython_mod build if present.
+# Last resort: mirror the published Pages index + wheel (needs CORP via this
+# server — cross-origin Pages lacks Cross-Origin-Resource-Policy under COEP).
 WHEELS_DIR = REPO_ROOT / "web" / "pyscript" / "wheels"
 SIBLING_WHEEL_DIRS = (
     REPO_ROOT.parent / "lv_cpython_mod" / "web" / "wheels",
     REPO_ROOT.parent / "cmods" / "lv_cpython_mod" / "web" / "wheels",
 )
+PAGES_WHEELS_BASE = "https://pydevices.github.io/lv_cpython_mod/wheels/"
+
+
+def _mirror_pages_wheels() -> Path | None:
+    """Download lvgl.json + wheel from lv_cpython_mod Pages into web/pyscript/wheels/."""
+    try:
+        WHEELS_DIR.mkdir(parents=True, exist_ok=True)
+        index_url = PAGES_WHEELS_BASE + "lvgl.json"
+        with urllib.request.urlopen(index_url, timeout=60) as resp:
+            raw = resp.read()
+        data = json.loads(raw)
+        wheel_name = data.get("wheel")
+        if not isinstance(wheel_name, str) or not wheel_name.endswith(".whl"):
+            raise ValueError(f"invalid wheel entry in {index_url}: {wheel_name!r}")
+        if "/" in wheel_name or wheel_name.startswith("."):
+            raise ValueError(f"unsafe wheel filename: {wheel_name!r}")
+        (WHEELS_DIR / "lvgl.json").write_bytes(raw)
+        wheel_path = WHEELS_DIR / wheel_name
+        if not wheel_path.is_file():
+            print(f"  wheels: downloading {wheel_name} from Pages…")
+            urllib.request.urlretrieve(PAGES_WHEELS_BASE + wheel_name, wheel_path)
+        print(f"  wheels:                  {WHEELS_DIR} (mirrored from Pages)")
+        return WHEELS_DIR
+    except (OSError, urllib.error.URLError, json.JSONDecodeError, ValueError) as exc:
+        print(f"warning: could not mirror LVGL wheels from Pages: {exc}", file=sys.stderr)
+        return None
 
 
 def ensure_wheels_dir() -> Path | None:
@@ -85,7 +115,7 @@ def ensure_wheels_dir() -> Path | None:
                 return None
             print(f"  wheels:                  {WHEELS_DIR} → {src}")
             return WHEELS_DIR
-    return None
+    return _mirror_pages_wheels()
 
 
 def _stamp() -> str:

--- a/tools/serve.py
+++ b/tools/serve.py
@@ -33,8 +33,8 @@ Why a custom server instead of `python -m http.server`?
 
 Everything here is CPython standard library only — no third-party deps.
 
-LVGL for Pyodide is installed from TestPyPI (`lvgl-cpython` pyemscripten
-wheel) via micropip in `pyodide.html` — this server does not provide wheels/.
+Pyodide gallery demos install third-party packages via ``?wheels=`` on
+``pyodide.html`` (micropip / TestPyPI+PyPI). This server only serves static files.
 """
 
 from __future__ import annotations

--- a/tools/serve.py
+++ b/tools/serve.py
@@ -32,6 +32,9 @@ Why a custom server instead of `python -m http.server`?
    page-side snippet printed at startup, or wire your own beacon to it.
 
 Everything here is CPython standard library only — no third-party deps.
+
+LVGL for Pyodide is installed from TestPyPI (`lvgl-cpython` pyemscripten
+wheel) via micropip in `pyodide.html` — this server does not provide wheels/.
 """
 
 from __future__ import annotations
@@ -43,80 +46,12 @@ from http.server import SimpleHTTPRequestHandler, ThreadingHTTPServer
 import json
 from pathlib import Path
 import sys
-import urllib.error
-import urllib.request
 
 REPO_ROOT = Path(__file__).resolve().parent.parent
 
 # Path prefix the page-side debug beacon POSTs to. Anything under it is treated
 # as a log sink so Cursor Debug mode tooling can pick its own sub-paths.
 DEBUG_PREFIX = "/__debug"
-
-# Same-origin path for micropip LVGL wheels (pyodide.html). When the tree does
-# not yet contain wheels/, link a sibling lv_cpython_mod build if present.
-# Last resort: mirror the published Pages index + wheel (needs CORP via this
-# server — cross-origin Pages lacks Cross-Origin-Resource-Policy under COEP).
-WHEELS_DIR = REPO_ROOT / "web" / "pyscript" / "wheels"
-SIBLING_WHEEL_DIRS = (
-    REPO_ROOT.parent / "lv_cpython_mod" / "web" / "wheels",
-    REPO_ROOT.parent / "cmods" / "lv_cpython_mod" / "web" / "wheels",
-)
-PAGES_WHEELS_BASE = "https://pydevices.github.io/lv_cpython_mod/wheels/"
-
-
-def _mirror_pages_wheels() -> Path | None:
-    """Download lvgl.json + wheel from lv_cpython_mod Pages into web/pyscript/wheels/."""
-    try:
-        WHEELS_DIR.mkdir(parents=True, exist_ok=True)
-        index_url = PAGES_WHEELS_BASE + "lvgl.json"
-        with urllib.request.urlopen(index_url, timeout=60) as resp:
-            raw = resp.read()
-        data = json.loads(raw)
-        wheel_name = data.get("wheel")
-        if not isinstance(wheel_name, str) or not wheel_name.endswith(".whl"):
-            raise ValueError(f"invalid wheel entry in {index_url}: {wheel_name!r}")
-        if "/" in wheel_name or wheel_name.startswith("."):
-            raise ValueError(f"unsafe wheel filename: {wheel_name!r}")
-        (WHEELS_DIR / "lvgl.json").write_bytes(raw)
-        wheel_path = WHEELS_DIR / wheel_name
-        if not wheel_path.is_file():
-            print(f"  wheels: downloading {wheel_name} from Pages…")
-            urllib.request.urlretrieve(PAGES_WHEELS_BASE + wheel_name, wheel_path)
-        print(f"  wheels:                  {WHEELS_DIR} (mirrored from Pages)")
-        return WHEELS_DIR
-    except (OSError, urllib.error.URLError, json.JSONDecodeError, ValueError) as exc:
-        print(f"warning: could not mirror LVGL wheels from Pages: {exc}", file=sys.stderr)
-        return None
-
-
-def ensure_wheels_dir() -> Path | None:
-    """Prefer an in-tree wheels/ dir; otherwise symlink a sibling lv_cpython_mod build."""
-    if WHEELS_DIR.is_dir() and any(WHEELS_DIR.glob("*.whl")):
-        return WHEELS_DIR
-    if WHEELS_DIR.is_symlink():
-        try:
-            WHEELS_DIR.unlink()
-        except OSError:
-            return None
-    elif WHEELS_DIR.is_dir():
-        # Empty or non-wheel dir — leave alone so we never clobber content.
-        if any(WHEELS_DIR.iterdir()):
-            return WHEELS_DIR if any(WHEELS_DIR.glob("*.whl")) else None
-        try:
-            WHEELS_DIR.rmdir()
-        except OSError:
-            return None
-    for src in SIBLING_WHEEL_DIRS:
-        if src.is_dir() and any(src.glob("*.whl")):
-            try:
-                WHEELS_DIR.symlink_to(src.resolve(), target_is_directory=True)
-            except OSError as exc:
-                print(f"warning: could not link {WHEELS_DIR} → {src}: {exc}", file=sys.stderr)
-                return None
-            print(f"  wheels:                  {WHEELS_DIR} → {src}")
-            return WHEELS_DIR
-    return _mirror_pages_wheels()
-
 
 def _stamp() -> str:
     now = datetime.datetime.now(datetime.UTC)
@@ -238,8 +173,6 @@ def main(argv: list[str] | None = None) -> int:
     print(f"pydisplay PyScript server — serving {root}")
     print(f"  cross-origin isolation: {'on' if DemoRequestHandler.coi_enabled else 'off'}")
     print(f"  debug log sink:         POST {base}{DEBUG_PREFIX}")
-    if root == REPO_ROOT:
-        ensure_wheels_dir()
     print("")
     print("Open one of:")
     print(f"  {base}/web/pyscript/index.html")

--- a/web/pyscript/index.html
+++ b/web/pyscript/index.html
@@ -93,7 +93,7 @@
                     <p>tv_remote_menu.py — 10-foot / remote-friendly menu for PyScript TV browsers.</p>
                     <span class="go">Open demo <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M5 12h14M13 6l6 6-6 6"/></svg></span>
                 </a>
-                <a class="card" href="micropython.html?manifests=alien&mip=palettes">
+                <a class="card" href="micropython.html?manifests=alien&mip=palettes&wheels=palettes">
                     <div class="card-top">
                         <span class="card-icon"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect x="2" y="3" width="20" height="14" rx="2"/><path d="M8 21h8M12 17v4"/></svg></span>
                     </div>
@@ -109,7 +109,7 @@
                     <p>Animate colored balls bouncing inside the display.</p>
                     <span class="go">Open demo <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M5 12h14M13 6l6 6-6 6"/></svg></span>
                 </a>
-                <a class="card" href="micropython.html?modules=boxlines&mip=palettes">
+                <a class="card" href="micropython.html?modules=boxlines&mip=palettes&wheels=palettes">
                     <div class="card-top">
                         <span class="card-icon"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect x="2" y="3" width="20" height="14" rx="2"/><path d="M8 21h8M12 17v4"/></svg></span>
                     </div>
@@ -117,7 +117,7 @@
                     <p>Test for lines and rectangles.</p>
                     <span class="go">Open demo <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M5 12h14M13 6l6 6-6 6"/></svg></span>
                 </a>
-                <a class="card" href="micropython.html?modules=calc_graphics,calc_engine&mip=palettes">
+                <a class="card" href="micropython.html?modules=calc_graphics,calc_engine&mip=palettes&wheels=palettes">
                     <div class="card-top">
                         <span class="card-icon"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect x="2" y="3" width="20" height="14" rx="2"/><path d="M8 21h8M12 17v4"/></svg></span>
                     </div>
@@ -125,7 +125,7 @@
                     <p>Dark-theme pocket calculator drawn with ``graphics.FrameBuffer``.</p>
                     <span class="go">Open demo <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M5 12h14M13 6l6 6-6 6"/></svg></span>
                 </a>
-                <a class="card" href="micropython.html?modules=calc_lvgl,calc_engine">
+                <a class="card" href="micropython.html?modules=calc_lvgl,calc_engine&wheels=lvgl-cpython">
                     <div class="card-top">
                         <span class="card-icon"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect x="2" y="3" width="20" height="14" rx="2"/><path d="M8 21h8M12 17v4"/></svg></span>
                     </div>
@@ -133,7 +133,7 @@
                     <p>Dark-theme pocket calculator built with LVGL.</p>
                     <span class="go">Open demo <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M5 12h14M13 6l6 6-6 6"/></svg></span>
                 </a>
-                <a class="card" href="micropython.html?modules=calc_widgets,calc_engine&mip=pdwidgets">
+                <a class="card" href="micropython.html?modules=calc_widgets,calc_engine&mip=pdwidgets&wheels=pdwidgets">
                     <div class="card-top">
                         <span class="card-icon"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect x="2" y="3" width="20" height="14" rx="2"/><path d="M8 21h8M12 17v4"/></svg></span>
                     </div>
@@ -141,7 +141,7 @@
                     <p>Dark-theme pocket calculator built with ``pdwidgets``.</p>
                     <span class="go">Open demo <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M5 12h14M13 6l6 6-6 6"/></svg></span>
                 </a>
-                <a class="card" href="micropython.html?manifests=chango&mip=palettes">
+                <a class="card" href="micropython.html?manifests=chango&mip=palettes&wheels=palettes">
                     <div class="card-top">
                         <span class="card-icon"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect x="2" y="3" width="20" height="14" rx="2"/><path d="M8 21h8M12 17v4"/></svg></span>
                     </div>
@@ -149,7 +149,7 @@
                     <p>Test for TrueType write_font_converter.</p>
                     <span class="go">Open demo <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M5 12h14M13 6l6 6-6 6"/></svg></span>
                 </a>
-                <a class="card" href="micropython.html?modules=color_test&mip=palettes">
+                <a class="card" href="micropython.html?modules=color_test&mip=palettes&wheels=palettes">
                     <div class="card-top">
                         <span class="card-icon"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect x="2" y="3" width="20" height="14" rx="2"/><path d="M8 21h8M12 17v4"/></svg></span>
                     </div>
@@ -157,7 +157,7 @@
                     <p>Test color with gradients.</p>
                     <span class="go">Open demo <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M5 12h14M13 6l6 6-6 6"/></svg></span>
                 </a>
-                <a class="card" href="micropython.html?modules=console_advanced_demo&mip=palettes">
+                <a class="card" href="micropython.html?modules=console_advanced_demo&mip=palettes&wheels=palettes">
                     <div class="card-top">
                         <span class="card-icon"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect x="2" y="3" width="20" height="14" rx="2"/><path d="M8 21h8M12 17v4"/></svg></span>
                     </div>
@@ -221,7 +221,7 @@
                     <p>eventsys_touch_test.py - Touch rotation test.</p>
                     <span class="go">Open demo <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M5 12h14M13 6l6 6-6 6"/></svg></span>
                 </a>
-                <a class="card" href="micropython.html?modules=feathers&mip=palettes">
+                <a class="card" href="micropython.html?modules=feathers&mip=palettes&wheels=palettes">
                     <div class="card-top">
                         <span class="card-icon"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect x="2" y="3" width="20" height="14" rx="2"/><path d="M8 21h8M12 17v4"/></svg></span>
                     </div>
@@ -229,7 +229,7 @@
                     <p>Modified by Brad Barnett from Russ Hughes's original to scroll vertically instead of horizontally</p>
                     <span class="go">Open demo <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M5 12h14M13 6l6 6-6 6"/></svg></span>
                 </a>
-                <a class="card" href="micropython.html?modules=fonts&mip=palettes">
+                <a class="card" href="micropython.html?modules=fonts&mip=palettes&wheels=palettes">
                     <div class="card-top">
                         <span class="card-icon"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect x="2" y="3" width="20" height="14" rx="2"/><path d="M8 21h8M12 17v4"/></svg></span>
                     </div>
@@ -253,7 +253,7 @@
                     <p>Visual text compare: framebuf and graphics, native C vs Python.</p>
                     <span class="go">Open demo <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M5 12h14M13 6l6 6-6 6"/></svg></span>
                 </a>
-                <a class="card" href="micropython.html?modules=graphics_simpletest&mip=palettes">
+                <a class="card" href="micropython.html?modules=graphics_simpletest&mip=palettes&wheels=palettes">
                     <div class="card-top">
                         <span class="card-icon"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect x="2" y="3" width="20" height="14" rx="2"/><path d="M8 21h8M12 17v4"/></svg></span>
                     </div>
@@ -261,7 +261,7 @@
                     <p>Simple test example to demonstrate the use of graphics.</p>
                     <span class="go">Open demo <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M5 12h14M13 6l6 6-6 6"/></svg></span>
                 </a>
-                <a class="card" href="micropython.html?modules=hello&mip=palettes">
+                <a class="card" href="micropython.html?modules=hello&mip=palettes&wheels=palettes">
                     <div class="card-top">
                         <span class="card-icon"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect x="2" y="3" width="20" height="14" rx="2"/><path d="M8 21h8M12 17v4"/></svg></span>
                     </div>
@@ -269,7 +269,7 @@
                     <p>Test for text_font_converter.</p>
                     <span class="go">Open demo <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M5 12h14M13 6l6 6-6 6"/></svg></span>
                 </a>
-                <a class="card" href="micropython.html?modules=joystick_list_select&mip=pdwidgets">
+                <a class="card" href="micropython.html?modules=joystick_list_select&mip=pdwidgets&wheels=pdwidgets">
                     <div class="card-top">
                         <span class="card-icon"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect x="2" y="3" width="20" height="14" rx="2"/><path d="M8 21h8M12 17v4"/></svg></span>
                     </div>
@@ -293,7 +293,7 @@
                     <p>Draws the PyDevices logo using only pydisplay's own graphics primitives -- no SVG import or renderer needed.</p>
                     <span class="go">Open demo <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M5 12h14M13 6l6 6-6 6"/></svg></span>
                 </a>
-                <a class="card" href="micropython.html?modules=lv_test_timer">
+                <a class="card" href="micropython.html?modules=lv_test_timer&wheels=lvgl-cpython">
                     <div class="card-top">
                         <span class="card-icon"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect x="2" y="3" width="20" height="14" rx="2"/><path d="M8 21h8M12 17v4"/></svg></span>
                     </div>
@@ -317,7 +317,7 @@
                     <p>nano_gui_simpletest.py - Copied from:</p>
                     <span class="go">Open demo <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M5 12h14M13 6l6 6-6 6"/></svg></span>
                 </a>
-                <a class="card" href="micropython.html?manifests=noto_fonts&mip=palettes">
+                <a class="card" href="micropython.html?manifests=noto_fonts&mip=palettes&wheels=palettes">
                     <div class="card-top">
                         <span class="card-icon"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect x="2" y="3" width="20" height="14" rx="2"/><path d="M8 21h8M12 17v4"/></svg></span>
                     </div>
@@ -341,7 +341,7 @@
                     <p>The <code>pbm_create_new</code> demo running in the browser via PyScript.</p>
                     <span class="go">Open demo <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M5 12h14M13 6l6 6-6 6"/></svg></span>
                 </a>
-                <a class="card" href="micropython.html?modules=pixel_sim_demos&mip=palettes">
+                <a class="card" href="micropython.html?modules=pixel_sim_demos&mip=palettes&wheels=palettes">
                     <div class="card-top">
                         <span class="card-icon"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect x="2" y="3" width="20" height="14" rx="2"/><path d="M8 21h8M12 17v4"/></svg></span>
                     </div>
@@ -349,7 +349,7 @@
                     <p>pixel_sim_demos.py — NeoPixel simulator effects in one file.</p>
                     <span class="go">Open demo <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M5 12h14M13 6l6 6-6 6"/></svg></span>
                 </a>
-                <a class="card" href="micropython.html?manifests=proverbs&mip=palettes">
+                <a class="card" href="micropython.html?manifests=proverbs&mip=palettes&wheels=palettes">
                     <div class="card-top">
                         <span class="card-icon"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect x="2" y="3" width="20" height="14" rx="2"/><path d="M8 21h8M12 17v4"/></svg></span>
                     </div>
@@ -357,7 +357,7 @@
                     <p>Test for TrueType write_font_converter.</p>
                     <span class="go">Open demo <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M5 12h14M13 6l6 6-6 6"/></svg></span>
                 </a>
-                <a class="card" href="micropython.html?modules=rotations&mip=palettes">
+                <a class="card" href="micropython.html?modules=rotations&mip=palettes&wheels=palettes">
                     <div class="card-top">
                         <span class="card-icon"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect x="2" y="3" width="20" height="14" rx="2"/><path d="M8 21h8M12 17v4"/></svg></span>
                     </div>
@@ -365,7 +365,7 @@
                     <p>Rotates the display 0, 90, 180, and 270 degrees and displays the rotation</p>
                     <span class="go">Open demo <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M5 12h14M13 6l6 6-6 6"/></svg></span>
                 </a>
-                <a class="card" href="micropython.html?modules=scroll&mip=palettes">
+                <a class="card" href="micropython.html?modules=scroll&mip=palettes&wheels=palettes">
                     <div class="card-top">
                         <span class="card-icon"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect x="2" y="3" width="20" height="14" rx="2"/><path d="M8 21h8M12 17v4"/></svg></span>
                     </div>
@@ -373,7 +373,7 @@
                     <p>Test for hardware scrolling.</p>
                     <span class="go">Open demo <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M5 12h14M13 6l6 6-6 6"/></svg></span>
                 </a>
-                <a class="card" href="micropython.html?modules=tiny_hello&mip=palettes">
+                <a class="card" href="micropython.html?modules=tiny_hello&mip=palettes&wheels=palettes">
                     <div class="card-top">
                         <span class="card-icon"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect x="2" y="3" width="20" height="14" rx="2"/><path d="M8 21h8M12 17v4"/></svg></span>
                     </div>
@@ -381,7 +381,7 @@
                     <p>Test text_font_converter on small displays.</p>
                     <span class="go">Open demo <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M5 12h14M13 6l6 6-6 6"/></svg></span>
                 </a>
-                <a class="card" href="micropython.html?manifests=tiny_toasters&mip=palettes">
+                <a class="card" href="micropython.html?manifests=tiny_toasters&mip=palettes&wheels=palettes">
                     <div class="card-top">
                         <span class="card-icon"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect x="2" y="3" width="20" height="14" rx="2"/><path d="M8 21h8M12 17v4"/></svg></span>
                     </div>
@@ -397,7 +397,7 @@
                     <p>touch_gui_simpletest.py - Smoke test for micropython-touch on pydisplay.</p>
                     <span class="go">Open demo <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M5 12h14M13 6l6 6-6 6"/></svg></span>
                 </a>
-                <a class="card" href="micropython.html?modules=widgets_actions&mip=pdwidgets">
+                <a class="card" href="micropython.html?modules=widgets_actions&mip=pdwidgets&wheels=pdwidgets">
                     <div class="card-top">
                         <span class="card-icon"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect x="2" y="3" width="20" height="14" rx="2"/><path d="M8 21h8M12 17v4"/></svg></span>
                     </div>
@@ -405,7 +405,7 @@
                     <p>Showcase :class:`~pdwidgets.Menu` / :class:`~pdwidgets.ContextMenu`,</p>
                     <span class="go">Open demo <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M5 12h14M13 6l6 6-6 6"/></svg></span>
                 </a>
-                <a class="card" href="micropython.html?modules=widgets_demo&mip=pdwidgets">
+                <a class="card" href="micropython.html?modules=widgets_demo&mip=pdwidgets&wheels=pdwidgets">
                     <div class="card-top">
                         <span class="card-icon"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect x="2" y="3" width="20" height="14" rx="2"/><path d="M8 21h8M12 17v4"/></svg></span>
                     </div>
@@ -413,7 +413,7 @@
                     <p>The <code>widgets_demo</code> demo running in the browser via PyScript.</p>
                     <span class="go">Open demo <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M5 12h14M13 6l6 6-6 6"/></svg></span>
                 </a>
-                <a class="card" href="micropython.html?modules=widgets_device_panel&mip=pdwidgets">
+                <a class="card" href="micropython.html?modules=widgets_device_panel&mip=pdwidgets&wheels=pdwidgets">
                     <div class="card-top">
                         <span class="card-icon"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect x="2" y="3" width="20" height="14" rx="2"/><path d="M8 21h8M12 17v4"/></svg></span>
                     </div>
@@ -421,7 +421,7 @@
                     <p>A fictional "Aurora Synth" control panel built entirely from pdwidgets.</p>
                     <span class="go">Open demo <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M5 12h14M13 6l6 6-6 6"/></svg></span>
                 </a>
-                <a class="card" href="micropython.html?modules=widgets_form_kitchen&mip=pdwidgets">
+                <a class="card" href="micropython.html?modules=widgets_form_kitchen&mip=pdwidgets&wheels=pdwidgets">
                     <div class="card-top">
                         <span class="card-icon"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect x="2" y="3" width="20" height="14" rx="2"/><path d="M8 21h8M12 17v4"/></svg></span>
                     </div>
@@ -429,7 +429,7 @@
                     <p>Showcase :class:`~pdwidgets.FormRow`, :class:`~pdwidgets.Divider`,</p>
                     <span class="go">Open demo <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M5 12h14M13 6l6 6-6 6"/></svg></span>
                 </a>
-                <a class="card" href="micropython.html?modules=widgets_gauge_dash&mip=pdwidgets">
+                <a class="card" href="micropython.html?modules=widgets_gauge_dash&mip=pdwidgets&wheels=pdwidgets">
                     <div class="card-top">
                         <span class="card-icon"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect x="2" y="3" width="20" height="14" rx="2"/><path d="M8 21h8M12 17v4"/></svg></span>
                     </div>
@@ -437,7 +437,7 @@
                     <p>Showcase :class:`~pdwidgets.Gauge` / :class:`~pdwidgets.Arc`,</p>
                     <span class="go">Open demo <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M5 12h14M13 6l6 6-6 6"/></svg></span>
                 </a>
-                <a class="card" href="micropython.html?modules=widgets_media_busy&mip=pdwidgets">
+                <a class="card" href="micropython.html?modules=widgets_media_busy&mip=pdwidgets&wheels=pdwidgets">
                     <div class="card-top">
                         <span class="card-icon"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect x="2" y="3" width="20" height="14" rx="2"/><path d="M8 21h8M12 17v4"/></svg></span>
                     </div>
@@ -445,7 +445,7 @@
                     <p>Showcase :class:`~pdwidgets.Image`, :class:`~pdwidgets.Spinner`,</p>
                     <span class="go">Open demo <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M5 12h14M13 6l6 6-6 6"/></svg></span>
                 </a>
-                <a class="card" href="micropython.html?modules=widgets_nav_tabs&mip=pdwidgets">
+                <a class="card" href="micropython.html?modules=widgets_nav_tabs&mip=pdwidgets&wheels=pdwidgets">
                     <div class="card-top">
                         <span class="card-icon"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect x="2" y="3" width="20" height="14" rx="2"/><path d="M8 21h8M12 17v4"/></svg></span>
                     </div>
@@ -453,7 +453,7 @@
                     <p>Showcase :class:`~pdwidgets.AppBar`, :class:`~pdwidgets.Page`,</p>
                     <span class="go">Open demo <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M5 12h14M13 6l6 6-6 6"/></svg></span>
                 </a>
-                <a class="card" href="micropython.html?modules=widgets_percent&mip=pdwidgets">
+                <a class="card" href="micropython.html?modules=widgets_percent&mip=pdwidgets&wheels=pdwidgets">
                     <div class="card-top">
                         <span class="card-icon"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect x="2" y="3" width="20" height="14" rx="2"/><path d="M8 21h8M12 17v4"/></svg></span>
                     </div>
@@ -461,7 +461,7 @@
                     <p>The <code>widgets_percent</code> demo running in the browser via PyScript.</p>
                     <span class="go">Open demo <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M5 12h14M13 6l6 6-6 6"/></svg></span>
                 </a>
-                <a class="card" href="micropython.html?modules=widgets_pickers&mip=pdwidgets">
+                <a class="card" href="micropython.html?modules=widgets_pickers&mip=pdwidgets&wheels=pdwidgets">
                     <div class="card-top">
                         <span class="card-icon"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect x="2" y="3" width="20" height="14" rx="2"/><path d="M8 21h8M12 17v4"/></svg></span>
                     </div>
@@ -469,7 +469,7 @@
                     <p>Showcase :class:`~pdwidgets.ColorPicker` and :class:`~pdwidgets.DatePicker`.</p>
                     <span class="go">Open demo <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M5 12h14M13 6l6 6-6 6"/></svg></span>
                 </a>
-                <a class="card" href="micropython.html?modules=widgets_settings&mip=pdwidgets">
+                <a class="card" href="micropython.html?modules=widgets_settings&mip=pdwidgets&wheels=pdwidgets">
                     <div class="card-top">
                         <span class="card-icon"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect x="2" y="3" width="20" height="14" rx="2"/><path d="M8 21h8M12 17v4"/></svg></span>
                     </div>
@@ -477,7 +477,7 @@
                     <p>A settings / preferences screen that exercises pdwidgets controls together:</p>
                     <span class="go">Open demo <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M5 12h14M13 6l6 6-6 6"/></svg></span>
                 </a>
-                <a class="card" href="micropython.html?modules=widgets_sheets&mip=pdwidgets">
+                <a class="card" href="micropython.html?modules=widgets_sheets&mip=pdwidgets&wheels=pdwidgets">
                     <div class="card-top">
                         <span class="card-icon"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect x="2" y="3" width="20" height="14" rx="2"/><path d="M8 21h8M12 17v4"/></svg></span>
                     </div>
@@ -485,7 +485,7 @@
                     <p>Showcase :class:`~pdwidgets.Drawer`, :class:`~pdwidgets.BottomSheet`,</p>
                     <span class="go">Open demo <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M5 12h14M13 6l6 6-6 6"/></svg></span>
                 </a>
-                <a class="card" href="micropython.html?modules=widgets_smartwatch&mip=pdwidgets">
+                <a class="card" href="micropython.html?modules=widgets_smartwatch&mip=pdwidgets&wheels=pdwidgets">
                     <div class="card-top">
                         <span class="card-icon"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect x="2" y="3" width="20" height="14" rx="2"/><path d="M8 21h8M12 17v4"/></svg></span>
                     </div>

--- a/web/pyscript/pyodide.html
+++ b/web/pyscript/pyodide.html
@@ -76,6 +76,8 @@
             <code>?modules=<em>name</em></code> and/or
             <code>?manifests=<em>name</em></code>
             (same MIP JSON as <a href="./micropython.html">micropython.html</a>).
+            Also supports <code>?mip=</code> (TestPyPI wheels) and
+            <code>?packages=</code> (Hinch GUIs via <code>packages/*.json</code>).
             LVGL demos micropip-install the
             <code>pyemscripten_2026_0</code> wheel (local
             <code>./wheels/</code> or lv_cpython_mod Pages).
@@ -113,7 +115,8 @@
                         <li><code>?modules=</code> — comma-separated top-level module stems (no <code>.py</code>).</li>
                         <li><code>?manifests=</code> — comma-separated MIP manifest names; each installs <code>packages/&lt;name&gt;.json</code> (same files as the MicroPython gallery).</li>
                         <li>Both may appear; whichever param comes <em>first</em> in the URL supplies the import entry point.</li>
-                        <li><code>?packages=</code> is not supported — use <a href="./micropython.html">micropython.html</a> for that.</li>
+                        <li><code>?mip=</code> — <code>palettes</code> / <code>pdwidgets</code> via micropip (TestPyPI); same as <code># pyodide wheels:</code> / <code># pyscript mip:</code>.</li>
+                        <li><code>?packages=</code> — Hinch GUI names (<code>micropython-nano-gui</code>, <code>micropython-micro-gui</code>, <code>micropython-touch</code>); installs into <code>/add_ons</code> from <code>packages/*.json</code> (resolves <code>github:</code> via raw.githubusercontent.com).</li>
                         <li><code># pyodide wheels: lvgl</code> in the entry example → micropip-install
                             via <code>wheels/lvgl.json</code> (lv_cpython_mod Pages or local
                             <code>serve.py</code>); override with <code>?lvgl_wheel=</code>.</li>
@@ -146,6 +149,8 @@
     <script>
         (function () {
             var SAFE_LOADER_NAME = /^[a-zA-Z_][a-zA-Z0-9_]*$/;
+            // Package stems may include hyphens (e.g. micropython-nano-gui).
+            var SAFE_PACKAGE_NAME = /^[a-zA-Z0-9][a-zA-Z0-9_-]*$/;
 
             function parseCommaList(raw) {
                 return raw.split(',').map(function (s) {
@@ -166,6 +171,8 @@
             function parseLoaderQuery(search) {
                 var modules = [];
                 var manifests = [];
+                var packages = [];
+                var mip = [];
                 var lvglWheel = '';
                 var entryKind = null;
                 var entryName = null;
@@ -189,15 +196,19 @@
                             entryName = flist[0];
                         }
                         manifests.push.apply(manifests, flist);
+                    } else if (key === 'packages') {
+                        packages.push.apply(packages, parseCommaList(val));
+                    } else if (key === 'mip') {
+                        mip.push.apply(mip, parseCommaList(val));
                     } else if (key === 'lvgl_wheel') {
                         lvglWheel = val.trim();
-                    } else if (key === 'packages') {
-                        return { error: 'unsupported', key: key, modules: modules, manifests: manifests };
                     }
                 }
                 return {
                     modules: modules,
                     manifests: manifests,
+                    packages: packages,
+                    mip: mip,
                     lvglWheel: lvglWheel,
                     entryKind: entryKind,
                     entryName: entryName,
@@ -222,13 +233,6 @@
             }
 
             var plan = parseLoaderQuery(window.location.search);
-            if (plan.error === 'unsupported') {
-                abortLoader(
-                    '<p><code>?' + plan.key + '=</code> is not supported on <code>pyodide.html</code>. ' +
-                    'Use <a href="./micropython.html">micropython.html</a> (MicroPython) for packages, or drop that query param.</p>'
-                );
-                return;
-            }
             var badNames = [];
             plan.modules.forEach(function (name) {
                 if (!SAFE_LOADER_NAME.test(name)) badNames.push(name);
@@ -236,13 +240,18 @@
             plan.manifests.forEach(function (name) {
                 if (!SAFE_LOADER_NAME.test(name)) badNames.push(name);
             });
+            plan.packages.forEach(function (name) {
+                if (!SAFE_PACKAGE_NAME.test(name)) badNames.push(name);
+            });
+            plan.mip.forEach(function (name) {
+                if (!SAFE_PACKAGE_NAME.test(name)) badNames.push(name);
+            });
             if (badNames.length) {
                 abortLoader(
-                    '<p>Unsafe <code>?modules=</code> or <code>?manifests=</code> value(s): ' +
+                    '<p>Unsafe loader query value(s): ' +
                     badNames.map(function (n) { return JSON.stringify(n); }).join(', ') +
                     '.</p>' +
-                    '<p>Names must be simple identifiers (letters, digits, underscore; ' +
-                    'no slashes or dots).</p>'
+                    '<p>Module/manifest names must be identifiers; package/mip names may include hyphens.</p>'
                 );
                 return;
             }
@@ -250,6 +259,8 @@
             window.__pydisplayLoaderReady = true;
             window.__pydisplayModules = plan.modules.join(',');
             window.__pydisplayManifests = plan.manifests.join(',');
+            window.__pydisplayPackages = plan.packages.join(',');
+            window.__pydisplayMip = plan.mip.join(',');
             window.__pydisplayLvglWheel = plan.lvglWheel || '';
             window.__pydisplayEntryKind = plan.entryKind || '';
             window.__pydisplayEntry = plan.entryName || '';
@@ -282,6 +293,12 @@
                 }
                 if (plan.manifests.length) {
                     installParts.push(plan.manifests.length + ' manifest(s)');
+                }
+                if (plan.packages.length) {
+                    installParts.push(plan.packages.length + ' package(s)');
+                }
+                if (plan.mip.length) {
+                    installParts.push('mip: ' + plan.mip.join(', '));
                 }
                 if (lede) {
                     lede.textContent = 'Pyodide loader: ' + installParts.join(', ') +
@@ -318,7 +335,17 @@
         from pyscript.ffi import create_proxy
 
         MANIFEST_MIP_TARGET = "examples"
+        PACKAGE_MIP_TARGET = "add_ons"
         LVGL_WHEELS_DIR_PAGES = "https://pydevices.github.io/lv_cpython_mod/wheels/"
+        PH_GUI_PACKAGES = (
+            "micropython-nano-gui",
+            "micropython-micro-gui",
+            "micropython-touch",
+        )
+        MIP_TO_WHEEL = {
+            "palettes": "palettes",
+            "pdwidgets": "pdwidgets",
+        }
 
         def _log_print(*args, **kwargs):
             el = document.getElementById("log")
@@ -350,24 +377,54 @@
             path = document.location.pathname
             return path[: path.rfind("/") + 1] if "/" in path else "/"
 
+        def _page_base():
+            return document.location.origin + _site_root()
+
+        def _github_to_raw(s):
+            """Map ``github:owner/repo/path`` → raw.githubusercontent.com …/HEAD/path."""
+            rest = s[len("github:") :].lstrip("/")
+            parts = rest.split("/")
+            if len(parts) < 3:
+                raise RuntimeError("Bad github: mip URL: " + s)
+            owner, repo = parts[0], parts[1]
+            path = "/".join(parts[2:])
+            return (
+                "https://raw.githubusercontent.com/"
+                + owner
+                + "/"
+                + repo
+                + "/HEAD/"
+                + path
+            )
+
         def _abs_url(rel_or_abs, base_url=None):
             """Resolve a path relative to the pyscript page (or an explicit base URL)."""
             from urllib.parse import urljoin
 
             s = str(rel_or_abs).strip()
             if s.startswith("github:"):
-                raise RuntimeError(
-                    "github: mip URLs are not supported on pyodide.html; "
-                    "use same-origin paths (packages/*.json relative urls)."
-                )
+                return _github_to_raw(s)
             if s.startswith("http://") or s.startswith("https://"):
                 return s
             if base_url:
                 return urljoin(base_url, s)
             if s.startswith("/"):
                 return document.location.origin + s
-            page_base = document.location.origin + _site_root()
-            return urljoin(page_base, s)
+            return urljoin(_page_base(), s)
+
+        def _mip_fetch_url(src):
+            """Resolve MIP JSON file URLs the same way MicroPython mip does on Pages.
+
+            Relative ``./src/...`` paths are against the *page* base
+            (``…/web/pyscript/``), not against ``packages/<name>.json``.
+            ``github:`` URLs become raw.githubusercontent.com (CORP-friendly).
+            """
+            s = str(src).strip()
+            if s.startswith("github:"):
+                return _github_to_raw(s)
+            if s.startswith("http://") or s.startswith("https://"):
+                return s
+            return _abs_url(s)
 
         def _parse_comma(raw):
             names = []
@@ -400,8 +457,8 @@
             with open(dest, "w", encoding="utf-8") as f:
                 f.write(code)
 
-        async def _install_manifest(name):
-            """Install packages/<name>.json (same MIP files micropython.html uses)."""
+        async def _install_mip_json(name, target):
+            """Install packages/<name>.json urls into ``target`` (MIP layout)."""
             manifest_url = _abs_url("packages/" + name + ".json")
             raw = await _fetch_text(manifest_url)
             try:
@@ -411,7 +468,6 @@
             urls = data.get("urls")
             if not isinstance(urls, list) or not urls:
                 raise RuntimeError("MIP manifest packages/" + name + ".json has no urls")
-            target = MANIFEST_MIP_TARGET
             os.makedirs(target, exist_ok=True)
             for entry in urls:
                 if not (isinstance(entry, (list, tuple)) and len(entry) >= 2):
@@ -421,42 +477,92 @@
                 dest_rel, src = entry[0], entry[1]
                 dest = os.path.join(target, dest_rel)
                 _ensure_parent_dirs(dest)
-                code = await _fetch_text(_abs_url(src, base_url=manifest_url))
+                code = await _fetch_text(_mip_fetch_url(src))
                 with open(dest, "w", encoding="utf-8") as f:
                     f.write(code)
                 _log_print("Installed", dest)
+
+        async def _install_manifest(name):
+            """Install packages/<name>.json (same MIP files micropython.html uses)."""
+            await _install_mip_json(name, MANIFEST_MIP_TARGET)
+
+        async def _install_ph_package(which):
+            """Pre-seed a Hinch GUI into /add_ons (same target as fetch_ph_gui)."""
+            if which not in PH_GUI_PACKAGES:
+                raise RuntimeError(
+                    "Unsupported ?packages= value "
+                    + repr(which)
+                    + " (supported: "
+                    + ", ".join(PH_GUI_PACKAGES)
+                    + ")"
+                )
+            await _install_mip_json(which, PACKAGE_MIP_TARGET)
 
         def _prepare_vfs():
             # Match MicroPython VFS: mounts at /lib and /add_ons; lib.path expects cwd /.
             os.chdir("/")
             if "/" not in sys.path:
                 sys.path.insert(0, "/")
+            if "/add_ons" not in sys.path:
+                sys.path.insert(0, "/add_ons")
 
-        def _wheels_from_path(path):
-            """Read ``# pyodide wheels:`` from an installed example (first 10 lines)."""
+        def _header_list(path, prefix):
+            """Read a ``# prefix:`` comma list from the first 10 lines of a file."""
             try:
                 with open(path, encoding="utf-8") as f:
                     for i, line in enumerate(f):
                         if i >= 10:
                             break
                         s = line.strip()
-                        if s.startswith("# pyodide wheels:"):
+                        if s.startswith(prefix):
                             body = s.split(":", 1)[1].strip()
                             return [p.strip() for p in body.split(",") if p.strip()]
             except OSError:
                 pass
             return []
 
-        def _wheels_for_entry(entry, modules):
-            for path in (
-                "examples/" + entry + ".py",
-                entry + ".py",
-            ):
+        def _wheels_from_path(path):
+            """Read ``# pyodide wheels:`` from an installed example (first 10 lines)."""
+            return _header_list(path, "# pyodide wheels:")
+
+        def _mip_from_path(path):
+            return _header_list(path, "# pyscript mip:")
+
+        def _packages_from_path(path):
+            return _header_list(path, "# pyscript packages:")
+
+        def _entry_paths(entry, modules):
+            paths = ["examples/" + entry + ".py", entry + ".py"]
+            for name in modules:
+                paths.append(name + ".py")
+            return paths
+
+        def _wheels_for_entry(entry, modules, mip_names):
+            found = []
+            for path in _entry_paths(entry, modules):
                 found = _wheels_from_path(path)
                 if found:
-                    return found
-            for name in modules:
-                found = _wheels_from_path(name + ".py")
+                    break
+            if not found:
+                # Fall back to # pyscript mip: palettes|pdwidgets → micropip wheels
+                for path in _entry_paths(entry, modules):
+                    for name in _mip_from_path(path):
+                        wheel = MIP_TO_WHEEL.get(name.lower().replace("_", "-"))
+                        if wheel and wheel not in found:
+                            found.append(wheel)
+                    if found:
+                        break
+            for name in mip_names:
+                wheel = MIP_TO_WHEEL.get(name.lower().replace("_", "-"))
+                if wheel and wheel not in found:
+                    found.append(wheel)
+            return found
+
+        def _packages_for_entry(entry, modules, packages):
+            if packages:
+                return packages
+            for path in _entry_paths(entry, modules):
+                found = _packages_from_path(path)
                 if found:
                     return found
             return []
@@ -464,30 +570,44 @@
         def _lvgl_wheels_base():
             host = str(document.location.hostname)
             if host in ("127.0.0.1", "localhost"):
-                # serve.py links sibling lv_cpython_mod/web/wheels → ./wheels/
+                # serve.py links sibling build or mirrors Pages → ./wheels/
                 return _abs_url("wheels/")
             return LVGL_WHEELS_DIR_PAGES
 
         async def _resolve_lvgl_wheel_url(override=""):
             if override:
                 return override
-            base = _lvgl_wheels_base()
-            if not base.endswith("/"):
-                base += "/"
-            index_url = base + "lvgl.json"
-            raw = await _fetch_text(index_url)
-            try:
-                data = json.loads(raw)
-            except json.JSONDecodeError as e:
-                raise RuntimeError("Invalid " + index_url + ": " + str(e)) from e
-            name = data.get("wheel")
-            if not isinstance(name, str) or not name.endswith(".whl"):
-                raise RuntimeError(
-                    index_url + " must contain a string \"wheel\" filename ending in .whl"
-                )
-            if "/" in name or name.startswith("."):
-                raise RuntimeError("Unsafe wheel filename in " + index_url + ": " + name)
-            return base + name
+            bases = [_lvgl_wheels_base()]
+            # Local COEP pages need same-origin wheels/; if missing, try Pages
+            # (may fail under require-corp when Pages omits CORP — serve.py mirrors).
+            if bases[0].rstrip("/") != LVGL_WHEELS_DIR_PAGES.rstrip("/"):
+                bases.append(LVGL_WHEELS_DIR_PAGES)
+            last_err = None
+            for base in bases:
+                if not base.endswith("/"):
+                    base += "/"
+                index_url = base + "lvgl.json"
+                try:
+                    raw = await _fetch_text(index_url)
+                except Exception as e:
+                    last_err = e
+                    continue
+                try:
+                    data = json.loads(raw)
+                except json.JSONDecodeError as e:
+                    raise RuntimeError("Invalid " + index_url + ": " + str(e)) from e
+                name = data.get("wheel")
+                if not isinstance(name, str) or not name.endswith(".whl"):
+                    raise RuntimeError(
+                        index_url + " must contain a string \"wheel\" filename ending in .whl"
+                    )
+                if "/" in name or name.startswith("."):
+                    raise RuntimeError("Unsafe wheel filename in " + index_url + ": " + name)
+                return base + name
+            raise RuntimeError(
+                "Could not resolve LVGL wheel index (tried local wheels/ and Pages): "
+                + str(last_err)
+            )
 
         async def _ensure_micropip():
             try:
@@ -542,6 +662,8 @@
                 return
             modules = _parse_comma(_from_window("__pydisplayModules"))
             manifests = _parse_comma(_from_window("__pydisplayManifests"))
+            packages = _parse_comma(_from_window("__pydisplayPackages"))
+            mip_names = _parse_comma(_from_window("__pydisplayMip"))
             lvgl_wheel = _from_window("__pydisplayLvglWheel")
             entry_kind = _from_window("__pydisplayEntryKind")
             entry = _from_window("__pydisplayEntry")
@@ -567,7 +689,11 @@
                     _set("Fetching " + name + "…")
                     await _install_module(name)
                 import lib.path  # noqa: F401 — adds lib/add_ons/examples to path
-                wheels = _wheels_for_entry(entry, modules)
+                packages = _packages_for_entry(entry, modules, packages)
+                for which in packages:
+                    _set("Installing package " + which + "…")
+                    await _install_ph_package(which)
+                wheels = _wheels_for_entry(entry, modules, mip_names)
                 await _install_pyodide_wheels(wheels, lvgl_wheel)
                 _set("Importing " + entry + "…")
                 __import__(entry)

--- a/web/pyscript/pyodide.html
+++ b/web/pyscript/pyodide.html
@@ -76,10 +76,9 @@
             <code>?modules=<em>name</em></code> and/or
             <code>?manifests=<em>name</em></code>
             (same MIP JSON as <a href="./micropython.html">micropython.html</a>).
-            Also supports <code>?mip=</code> (TestPyPI wheels) and
-            <code>?packages=</code> (Hinch GUIs via <code>packages/*.json</code>).
-            LVGL demos micropip-install <code>lvgl-cpython</code> from TestPyPI
-            (<code>pyemscripten_2026_0</code> wasm wheel).
+            Also supports <code>?mip=</code> (MicroPython MIP),
+            <code>?packages=</code> (Hinch GUIs), and
+            <code>?wheels=</code> (micropip from TestPyPI / PyPI).
             Whichever of modules/manifests comes first supplies the import entry.
         </p>
 
@@ -114,11 +113,9 @@
                         <li><code>?modules=</code> — comma-separated top-level module stems (no <code>.py</code>).</li>
                         <li><code>?manifests=</code> — comma-separated MIP manifest names; each installs <code>packages/&lt;name&gt;.json</code> (same files as the MicroPython gallery).</li>
                         <li>Both may appear; whichever param comes <em>first</em> in the URL supplies the import entry point.</li>
-                        <li><code>?mip=</code> — <code>palettes</code> / <code>pdwidgets</code> via micropip (TestPyPI); same as <code># pyodide wheels:</code> / <code># pyscript mip:</code>.</li>
+                        <li><code>?mip=</code> — MicroPython MIP names (ignored here; used by <code>micropython.html</code>).</li>
                         <li><code>?packages=</code> — Hinch GUI names (<code>micropython-nano-gui</code>, <code>micropython-micro-gui</code>, <code>micropython-touch</code>); installs into <code>/add_ons</code> from <code>packages/*.json</code> (resolves <code>github:</code> via raw.githubusercontent.com).</li>
-                        <li><code># pyodide wheels: lvgl</code> (or <code>lvgl-cpython</code>) →
-                            micropip-install from TestPyPI; override with a wheel URL via
-                            <code>?lvgl_wheel=</code>.</li>
+                        <li><code>?wheels=</code> — comma-separated PyPI / TestPyPI project names (or direct <code>.whl</code> URLs) installed via micropip. Gallery cards emit this from <code># pyodide wheels:</code>.</li>
                         <li>Click <strong>Run</strong> to install, then import the entry.</li>
                     </ul>
                 </div>
@@ -172,7 +169,7 @@
                 var manifests = [];
                 var packages = [];
                 var mip = [];
-                var lvglWheel = '';
+                var wheels = [];
                 var entryKind = null;
                 var entryName = null;
                 var raw = search.startsWith('?') ? search.slice(1) : search;
@@ -199,8 +196,8 @@
                         packages.push.apply(packages, parseCommaList(val));
                     } else if (key === 'mip') {
                         mip.push.apply(mip, parseCommaList(val));
-                    } else if (key === 'lvgl_wheel') {
-                        lvglWheel = val.trim();
+                    } else if (key === 'wheels') {
+                        wheels.push.apply(wheels, parseCommaList(val));
                     }
                 }
                 return {
@@ -208,7 +205,7 @@
                     manifests: manifests,
                     packages: packages,
                     mip: mip,
-                    lvglWheel: lvglWheel,
+                    wheels: wheels,
                     entryKind: entryKind,
                     entryName: entryName,
                 };
@@ -245,12 +242,20 @@
             plan.mip.forEach(function (name) {
                 if (!SAFE_PACKAGE_NAME.test(name)) badNames.push(name);
             });
+            plan.wheels.forEach(function (name) {
+                // Direct .whl URLs are allowed; otherwise same rules as package names.
+                if (/^https?:\/\//i.test(name)) {
+                    if (!/\.whl(\?|#|$)/i.test(name)) badNames.push(name);
+                } else if (!SAFE_PACKAGE_NAME.test(name)) {
+                    badNames.push(name);
+                }
+            });
             if (badNames.length) {
                 abortLoader(
                     '<p>Unsafe loader query value(s): ' +
                     badNames.map(function (n) { return JSON.stringify(n); }).join(', ') +
                     '.</p>' +
-                    '<p>Module/manifest names must be identifiers; package/mip names may include hyphens.</p>'
+                    '<p>Module/manifest names must be identifiers; package/mip/wheels names may include hyphens; wheel URLs must end in <code>.whl</code>.</p>'
                 );
                 return;
             }
@@ -260,7 +265,7 @@
             window.__pydisplayManifests = plan.manifests.join(',');
             window.__pydisplayPackages = plan.packages.join(',');
             window.__pydisplayMip = plan.mip.join(',');
-            window.__pydisplayLvglWheel = plan.lvglWheel || '';
+            window.__pydisplayWheels = plan.wheels.join(',');
             window.__pydisplayEntryKind = plan.entryKind || '';
             window.__pydisplayEntry = plan.entryName || '';
 
@@ -299,6 +304,9 @@
                 if (plan.mip.length) {
                     installParts.push('mip: ' + plan.mip.join(', '));
                 }
+                if (plan.wheels.length) {
+                    installParts.push('wheels: ' + plan.wheels.join(', '));
+                }
                 if (lede) {
                     lede.textContent = 'Pyodide loader: ' + installParts.join(', ') +
                         '. Entry: import ' + entry + '.';
@@ -335,16 +343,17 @@
 
         MANIFEST_MIP_TARGET = "examples"
         PACKAGE_MIP_TARGET = "add_ons"
-        TESTPYPI_SIMPLE = "https://test.pypi.org/simple/"
+        # Prefer TestPyPI (PyDevices publishes here) then PyPI so third-party
+        # pure/wasm wheels resolve too. micropip tries each index in order.
+        WHEEL_INDEX_URLS = [
+            "https://test.pypi.org/simple/",
+            "https://pypi.org/simple/",
+        ]
         PH_GUI_PACKAGES = (
             "micropython-nano-gui",
             "micropython-micro-gui",
             "micropython-touch",
         )
-        MIP_TO_WHEEL = {
-            "palettes": "palettes",
-            "pdwidgets": "pdwidgets",
-        }
 
         def _log_print(*args, **kwargs):
             el = document.getElementById("log")
@@ -520,13 +529,6 @@
                 pass
             return []
 
-        def _wheels_from_path(path):
-            """Read ``# pyodide wheels:`` from an installed example (first 10 lines)."""
-            return _header_list(path, "# pyodide wheels:")
-
-        def _mip_from_path(path):
-            return _header_list(path, "# pyscript mip:")
-
         def _packages_from_path(path):
             return _header_list(path, "# pyscript packages:")
 
@@ -535,27 +537,6 @@
             for name in modules:
                 paths.append(name + ".py")
             return paths
-
-        def _wheels_for_entry(entry, modules, mip_names):
-            found = []
-            for path in _entry_paths(entry, modules):
-                found = _wheels_from_path(path)
-                if found:
-                    break
-            if not found:
-                # Fall back to # pyscript mip: palettes|pdwidgets → micropip wheels
-                for path in _entry_paths(entry, modules):
-                    for name in _mip_from_path(path):
-                        wheel = MIP_TO_WHEEL.get(name.lower().replace("_", "-"))
-                        if wheel and wheel not in found:
-                            found.append(wheel)
-                    if found:
-                        break
-            for name in mip_names:
-                wheel = MIP_TO_WHEEL.get(name.lower().replace("_", "-"))
-                if wheel and wheel not in found:
-                    found.append(wheel)
-            return found
 
         def _packages_for_entry(entry, modules, packages):
             if packages:
@@ -581,43 +562,22 @@
 
             return micropip
 
-        async def _install_pyodide_wheels(wheels, lvgl_wheel_override=""):
+        async def _install_pyodide_wheels(wheels):
+            """micropip-install each ``?wheels=`` entry (project name or .whl URL)."""
             if not wheels:
                 return
             micropip = await _ensure_micropip()
             for which in wheels:
-                key = which.lower().replace("_", "-")
-                if key in ("lvgl", "lvgl-cpython", "lvglcpython"):
-                    _set("Installing lvgl-cpython…")
-                    if lvgl_wheel_override:
-                        _log_print("micropip.install", lvgl_wheel_override)
-                        await micropip.install(lvgl_wheel_override)
-                    else:
-                        _log_print("micropip.install lvgl-cpython from TestPyPI")
-                        await micropip.install(
-                            "lvgl-cpython",
-                            index_urls=TESTPYPI_SIMPLE,
-                        )
-                elif key in ("pdwidgets",):
-                    _set("Installing pdwidgets…")
-                    _log_print("micropip.install pdwidgets from TestPyPI")
-                    await micropip.install(
-                        "pdwidgets",
-                        index_urls=TESTPYPI_SIMPLE,
-                    )
-                elif key in ("palettes",):
-                    _set("Installing palettes…")
-                    _log_print("micropip.install palettes from TestPyPI")
-                    await micropip.install(
-                        "palettes",
-                        index_urls=TESTPYPI_SIMPLE,
-                    )
+                spec = str(which).strip()
+                if not spec:
+                    continue
+                _set("Installing " + spec + "…")
+                if spec.startswith("http://") or spec.startswith("https://"):
+                    _log_print("micropip.install", spec)
+                    await micropip.install(spec)
                 else:
-                    raise RuntimeError(
-                        "Unknown # pyodide wheels: entry "
-                        + repr(which)
-                        + " (supported: lvgl, pdwidgets, palettes)"
-                    )
+                    _log_print("micropip.install", spec, "indexes=", WHEEL_INDEX_URLS)
+                    await micropip.install(spec, index_urls=WHEEL_INDEX_URLS)
 
         async def _start(*_):
             global _started
@@ -626,8 +586,7 @@
             modules = _parse_comma(_from_window("__pydisplayModules"))
             manifests = _parse_comma(_from_window("__pydisplayManifests"))
             packages = _parse_comma(_from_window("__pydisplayPackages"))
-            mip_names = _parse_comma(_from_window("__pydisplayMip"))
-            lvgl_wheel = _from_window("__pydisplayLvglWheel")
+            wheels = _parse_comma(_from_window("__pydisplayWheels"))
             entry_kind = _from_window("__pydisplayEntryKind")
             entry = _from_window("__pydisplayEntry")
             if not entry and modules:
@@ -656,8 +615,7 @@
                 for which in packages:
                     _set("Installing package " + which + "…")
                     await _install_ph_package(which)
-                wheels = _wheels_for_entry(entry, modules, mip_names)
-                await _install_pyodide_wheels(wheels, lvgl_wheel)
+                await _install_pyodide_wheels(wheels)
                 _set("Importing " + entry + "…")
                 __import__(entry)
                 _set("")

--- a/web/pyscript/pyodide.html
+++ b/web/pyscript/pyodide.html
@@ -78,9 +78,8 @@
             (same MIP JSON as <a href="./micropython.html">micropython.html</a>).
             Also supports <code>?mip=</code> (TestPyPI wheels) and
             <code>?packages=</code> (Hinch GUIs via <code>packages/*.json</code>).
-            LVGL demos micropip-install the
-            <code>pyemscripten_2026_0</code> wheel (local
-            <code>./wheels/</code> or lv_cpython_mod Pages).
+            LVGL demos micropip-install <code>lvgl-cpython</code> from TestPyPI
+            (<code>pyemscripten_2026_0</code> wasm wheel).
             Whichever of modules/manifests comes first supplies the import entry.
         </p>
 
@@ -117,9 +116,9 @@
                         <li>Both may appear; whichever param comes <em>first</em> in the URL supplies the import entry point.</li>
                         <li><code>?mip=</code> — <code>palettes</code> / <code>pdwidgets</code> via micropip (TestPyPI); same as <code># pyodide wheels:</code> / <code># pyscript mip:</code>.</li>
                         <li><code>?packages=</code> — Hinch GUI names (<code>micropython-nano-gui</code>, <code>micropython-micro-gui</code>, <code>micropython-touch</code>); installs into <code>/add_ons</code> from <code>packages/*.json</code> (resolves <code>github:</code> via raw.githubusercontent.com).</li>
-                        <li><code># pyodide wheels: lvgl</code> in the entry example → micropip-install
-                            via <code>wheels/lvgl.json</code> (lv_cpython_mod Pages or local
-                            <code>serve.py</code>); override with <code>?lvgl_wheel=</code>.</li>
+                        <li><code># pyodide wheels: lvgl</code> (or <code>lvgl-cpython</code>) →
+                            micropip-install from TestPyPI; override with a wheel URL via
+                            <code>?lvgl_wheel=</code>.</li>
                         <li>Click <strong>Run</strong> to install, then import the entry.</li>
                     </ul>
                 </div>
@@ -336,7 +335,7 @@
 
         MANIFEST_MIP_TARGET = "examples"
         PACKAGE_MIP_TARGET = "add_ons"
-        LVGL_WHEELS_DIR_PAGES = "https://pydevices.github.io/lv_cpython_mod/wheels/"
+        TESTPYPI_SIMPLE = "https://test.pypi.org/simple/"
         PH_GUI_PACKAGES = (
             "micropython-nano-gui",
             "micropython-micro-gui",
@@ -567,48 +566,6 @@
                     return found
             return []
 
-        def _lvgl_wheels_base():
-            host = str(document.location.hostname)
-            if host in ("127.0.0.1", "localhost"):
-                # serve.py links sibling build or mirrors Pages → ./wheels/
-                return _abs_url("wheels/")
-            return LVGL_WHEELS_DIR_PAGES
-
-        async def _resolve_lvgl_wheel_url(override=""):
-            if override:
-                return override
-            bases = [_lvgl_wheels_base()]
-            # Local COEP pages need same-origin wheels/; if missing, try Pages
-            # (may fail under require-corp when Pages omits CORP — serve.py mirrors).
-            if bases[0].rstrip("/") != LVGL_WHEELS_DIR_PAGES.rstrip("/"):
-                bases.append(LVGL_WHEELS_DIR_PAGES)
-            last_err = None
-            for base in bases:
-                if not base.endswith("/"):
-                    base += "/"
-                index_url = base + "lvgl.json"
-                try:
-                    raw = await _fetch_text(index_url)
-                except Exception as e:
-                    last_err = e
-                    continue
-                try:
-                    data = json.loads(raw)
-                except json.JSONDecodeError as e:
-                    raise RuntimeError("Invalid " + index_url + ": " + str(e)) from e
-                name = data.get("wheel")
-                if not isinstance(name, str) or not name.endswith(".whl"):
-                    raise RuntimeError(
-                        index_url + " must contain a string \"wheel\" filename ending in .whl"
-                    )
-                if "/" in name or name.startswith("."):
-                    raise RuntimeError("Unsafe wheel filename in " + index_url + ": " + name)
-                return base + name
-            raise RuntimeError(
-                "Could not resolve LVGL wheel index (tried local wheels/ and Pages): "
-                + str(last_err)
-            )
-
         async def _ensure_micropip():
             try:
                 import micropip
@@ -631,23 +588,29 @@
             for which in wheels:
                 key = which.lower().replace("_", "-")
                 if key in ("lvgl", "lvgl-cpython", "lvglcpython"):
-                    url = await _resolve_lvgl_wheel_url(lvgl_wheel_override)
-                    _set("Installing lvgl…")
-                    _log_print("micropip.install", url)
-                    await micropip.install(url)
+                    _set("Installing lvgl-cpython…")
+                    if lvgl_wheel_override:
+                        _log_print("micropip.install", lvgl_wheel_override)
+                        await micropip.install(lvgl_wheel_override)
+                    else:
+                        _log_print("micropip.install lvgl-cpython from TestPyPI")
+                        await micropip.install(
+                            "lvgl-cpython",
+                            index_urls=TESTPYPI_SIMPLE,
+                        )
                 elif key in ("pdwidgets",):
                     _set("Installing pdwidgets…")
                     _log_print("micropip.install pdwidgets from TestPyPI")
                     await micropip.install(
                         "pdwidgets",
-                        index_urls="https://test.pypi.org/simple/",
+                        index_urls=TESTPYPI_SIMPLE,
                     )
                 elif key in ("palettes",):
                     _set("Installing palettes…")
                     _log_print("micropip.install palettes from TestPyPI")
                     await micropip.install(
                         "palettes",
-                        index_urls="https://test.pypi.org/simple/",
+                        index_urls=TESTPYPI_SIMPLE,
                     )
                 else:
                     raise RuntimeError(


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Closes the 17 remaining PyScript gallery canvas failures after v0.0.18.

### Fixes

1. **Manifest 404s** (`alien`, `chango`, `noto_fonts`, `proverbs`, `tiny_toasters`) — `pyodide.html` now resolves MIP relative `./src/...` URLs against the page base (same as MicroPython mip), not against `packages/<name>.json`.
2. **Missing `palettes`** — honor `?mip=` / `# pyscript mip:` as TestPyPI micropip wheels; add `# pyodide wheels: palettes` headers for parity.
3. **`wheels/lvgl.json`** — `serve.py` mirrors the published lv_cpython_mod Pages wheel into same-origin `web/pyscript/wheels/` (needed under COEP); pyodide also falls back to Pages if local is missing.
4. **Hinch GUIs** (`micro`/`nano`/`touch` simpletests) — `?packages=` is supported on pyodide; installs `packages/micropython-*.json` into `/add_ons`, resolving `github:` via raw.githubusercontent.com.
5. **`console_advanced_demo`** — guard when `os.dupterm` is absent (browser MicroPython).

### Test plan

```bash
.venv/bin/python tools/serve.py   # mirrors LVGL wheels on first start
.venv/bin/python tools/ps_gallery_canvas_test.py \
  --only alien boxlines calc_lvgl chango color_test console_advanced_demo \
         fonts hello lv_test_timer micro_gui_simpletest nano_gui_simpletest \
         noto_fonts proverbs scroll tiny_hello tiny_toasters touch_gui_simpletest \
  --case-timeout 15 --soak 3.5 --ready-timeout 8
```

Full matrix re-run in agent session after this PR.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-6c799e6a-a7f9-4d72-82a1-e6c42ee2bc95"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-6c799e6a-a7f9-4d72-82a1-e6c42ee2bc95"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

