### PR TITLE
Add pre-commit hooks for manifest and gallery refresh

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -12,3 +12,17 @@ repos:
     rev: 0.9.1
     hooks:
       - id: nbstripout
+  - repo: local
+    hooks:
+      - id: install-refresh-manifests
+        name: refresh install manifests (packages/*.json)
+        entry: ./scripts/install_refresh_manifests.sh
+        language: system
+        pass_filenames: false
+        files: ^(src/|scripts/install_gen_manifests\.py|scripts/personal_examples\.py)
+      - id: gallery-generator
+        name: refresh PyScript gallery (index.html)
+        entry: python3 scripts/gallery_generator.py
+        language: system
+        pass_filenames: false
+        files: ^(src/examples/.*\.py$|scripts/gallery_generator\.py|scripts/url_maker\.py)

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -14,17 +14,27 @@ python3 -m venv .venv-docs
 .venv-docs/bin/mkdocs serve    # http://127.0.0.1:8000
 ```
 
-After editing files under `src/`:
+After editing files under `src/` (or install pre-commit hooks — see below):
 
 ```bash
 ./scripts/install_refresh_manifests.sh    # refresh packages/*.json and web/pyscript/micropython.toml
 ```
 
+Optional — run codegen on commit (CI still audits if you skip this):
+
+```bash
+.venv/bin/pip install -r requirements-dev.txt
+.venv/bin/pre-commit install
+```
+
+Hooks refresh install manifests when `src/` changes and the PyScript gallery when
+`src/examples/` (or gallery scripts) change.
+
 ## Pull request workflow
 
 1. Fork [PyDevices/pydisplay](https://github.com/PyDevices/pydisplay)
 2. Create a feature branch
-3. Make changes; run `./scripts/install_refresh_manifests.sh --audit` if you touched `src/`
+3. Make changes; run `./scripts/install_refresh_manifests.sh --audit` if you touched `src/` (or use pre-commit)
 4. For docs: see [Building docs](building-docs.md) — `mkdocs serve` and verify pages build
 5. Open a PR against `main` with a clear description
 
@@ -40,7 +50,10 @@ After editing files under `src/`:
 
 ## Code style
 
-Python is linted with Ruff — see `pyproject.toml`. Pre-commit hooks may run on commit.
+Python is linted with Ruff — see `pyproject.toml`. With `pre-commit install`, hooks
+run Ruff, strip notebook outputs, refresh install manifests, and refresh the PyScript
+gallery (narrow paths). CI keeps `--audit` / `--check` gates for contributors who do
+not use pre-commit.
 
 Public API docstrings: [Docstring conventions](contributing/docstrings.md).
 

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -18,6 +18,7 @@ ipyevents>=2.0
 nbstripout>=0.9
 
 # Lint / format (see pyproject.toml; pre-commit hooks use ruff-pre-commit)
+pre-commit>=4.0
 ruff>=0.15.17
 
 # Display / image inspection


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds two local pre-commit hooks so generated artifacts stay in sync before push. CI `--audit` / `--check` gates are unchanged.

## Hooks

| Hook | Runs when | Action |
|------|-----------|--------|
| `install-refresh-manifests` | `src/`, `scripts/install_gen_manifests.py`, `scripts/personal_examples.py` | `./scripts/install_refresh_manifests.sh` |
| `gallery-generator` | `src/examples/*.py`, `scripts/gallery_generator.py`, `scripts/url_maker.py` | `python3 scripts/gallery_generator.py` |

## Setup

```bash
.venv/bin/pip install -r requirements-dev.txt
.venv/bin/pre-commit install
```

If a hook updates files, stage them and commit again (standard pre-commit codegen behavior).

## Docs

- `requirements-dev.txt`: add `pre-commit`
- `docs/contributing.md`: install instructions and hook scope
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-a0f1acde-d64b-40f0-b004-d438b02884a0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-a0f1acde-d64b-40f0-b004-d438b02884a0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

