### PR TITLE
Fix gallery loader stall: sys.path before ps_loader import

### DIFF
--- a/web/pyscript/micropython.html
+++ b/web/pyscript/micropython.html
@@ -323,6 +323,9 @@
         import builtins
         from js import document
         from pyscript.ffi import create_proxy
+        import sys
+        if "/add_ons" not in sys.path:
+            sys.path.insert(0, "/add_ons")
         import ps_loader
 
         def _log_print(*args, **kwargs):

--- a/web/pyscript/pyodide.html
+++ b/web/pyscript/pyodide.html
@@ -311,6 +311,9 @@
         import builtins
         from js import document
         from pyscript.ffi import create_proxy
+        import sys
+        if "/add_ons" not in sys.path:
+            sys.path.insert(0, "/add_ons")
         import ps_loader
 
         def _log_print(*args, **kwargs):

--- a/web/pyscript/run-pyodide.html
+++ b/web/pyscript/run-pyodide.html
@@ -78,6 +78,9 @@
 <script type="py" config="./pyodide.toml" output="log">
 import builtins
 from js import document
+import sys
+if "/add_ons" not in sys.path:
+    sys.path.insert(0, "/add_ons")
 import ps_loader
 
 def _log_print(*args, **kwargs):

--- a/web/pyscript/run.html
+++ b/web/pyscript/run.html
@@ -72,6 +72,9 @@
 <script type="mpy" config="./micropython.toml" output="log">
 import builtins
 from js import document
+import sys
+if "/add_ons" not in sys.path:
+    sys.path.insert(0, "/add_ons")
 import ps_loader
 
 def _log_print(*args, **kwargs):


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

All gallery loader pages (`micropython.html`, `pyodide.html`, and the thin `run*.html` wrappers) stall on **"Loading MicroPython/Python runtime…"** with Run disabled.

Playwright/CDP on production shows:

```
ImportError: no module named 'ps_loader'
```

## Cause

PR #89 moved install logic into `ps_loader.py` and added `import ps_loader` at page load. The module is mounted at `/add_ons/ps_loader.py` in the PyScript VFS, but `/add_ons` is not on `sys.path` until `install_*` runs (or `embed.html`'s bootstrap).

## Fix

Prepend `/add_ons` to `sys.path` before importing `ps_loader` (same pattern as `embed.html` and `ps_loader.prepare_vfs()`).

Verified locally with `tools/ps_debug.py` on both runtimes.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-a0f1acde-d64b-40f0-b004-d438b02884a0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-a0f1acde-d64b-40f0-b004-d438b02884a0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

