### PR TITLE
Fix gallery loader stall from stale PWA shell cache

### DIFF
--- a/scripts/install_gen_manifests.py
+++ b/scripts/install_gen_manifests.py
@@ -206,6 +206,9 @@ for entry in sorted(os.listdir(examples_root)):
         json.dump({"urls": urls, "version": package_ver}, f, indent=2)
     example_package_names.append(entry)
 
+# Gallery loaders use `import ps_loader` (top-level); also mount at VFS root.
+master_toml.append(pyscript_toml_file_entry("src/add_ons/ps_loader.py", "/"))
+
 # web/pyscript/packages → ../../packages (same layout as web/pyscript/src).
 pyscript_packages_link = os.path.join(output_dir, "web", "pyscript", "packages")
 packages_abs = os.path.join(output_dir, packages_dir.rstrip("/"))

--- a/web/pyscript/loader-ready.js
+++ b/web/pyscript/loader-ready.js
@@ -1,0 +1,70 @@
+/*! pydisplay gallery loaders — hide the loading row when PyScript is ready or failed */
+(function () {
+  var runtime = document.body && document.body.getAttribute('data-loader-runtime');
+  if (runtime !== 'mpy' && runtime !== 'py') {
+    return;
+  }
+
+  var btn = document.getElementById('run-btn');
+  var spin = document.querySelector('#loading .spinner');
+  var status = document.getElementById('status');
+  var readyEvent = runtime === 'mpy' ? 'mpy:ready' : 'py:ready';
+  var doneEvent = runtime === 'mpy' ? 'mpy:done' : 'py:done';
+  var polls = 0;
+  var maxPolls = 800; // ~120s at 150ms — slow WASM / first visit
+  var timer = null;
+
+  function hideSpinner() {
+    if (spin) {
+      spin.style.display = 'none';
+    }
+  }
+
+  function runtimeFailed() {
+    hideSpinner();
+    if (!btn || !btn.disabled) {
+      return;
+    }
+    if (status && /Loading/i.test(status.textContent)) {
+      status.textContent = 'Runtime failed — see console output below.';
+    }
+  }
+
+  function runtimeReady() {
+    hideSpinner();
+  }
+
+  function stopPolling() {
+    if (timer !== null) {
+      clearInterval(timer);
+      timer = null;
+    }
+  }
+
+  addEventListener(readyEvent, function () {
+    if (status && /Loading/i.test(status.textContent)) {
+      status.textContent =
+        runtime === 'mpy' ? 'Starting MicroPython…' : 'Starting Python…';
+    }
+  });
+
+  addEventListener(doneEvent, function () {
+    stopPolling();
+    if (btn && !btn.disabled) {
+      runtimeReady();
+    } else {
+      runtimeFailed();
+    }
+  });
+
+  timer = setInterval(function () {
+    polls += 1;
+    if (btn && !btn.disabled) {
+      stopPolling();
+      runtimeReady();
+    } else if (polls >= maxPolls) {
+      stopPolling();
+      runtimeFailed();
+    }
+  }, 150);
+})();

--- a/web/pyscript/micropython.html
+++ b/web/pyscript/micropython.html
@@ -21,7 +21,7 @@
     <script type="module" src="./vendor/core.js"></script>
     <script src="https://pydevices.github.io/assets/js/theme-toggle.js" defer></script>
 </head>
-<body>
+<body data-loader-runtime="mpy">
     <header class="site-header">
         <div class="wrap">
             <a class="brand" href="https://pydevices.github.io/">
@@ -401,18 +401,7 @@
             print("MicroPython runtime ready. Click Run to start the demo.")
     </script>
 
-    <script>
-        (function () {
-            const _btn = document.getElementById('run-btn');
-            const _spin = document.querySelector('#loading .spinner');
-            const _t = setInterval(() => {
-                if (_btn && !_btn.disabled) {
-                    if (_spin) _spin.style.display = 'none';
-                    clearInterval(_t);
-                }
-            }, 150);
-        })();
-    </script>
+    <script src="./loader-ready.js"></script>
 
     <script>
         (function () {

--- a/web/pyscript/micropython.toml
+++ b/web/pyscript/micropython.toml
@@ -96,3 +96,4 @@ interpreter = "./vendor/micropython/micropython.mjs"
 "./src/lib/multimer/_backends/threading.py" = "/lib/multimer/_backends/"
 "./src/lib/multimer/_backends/win32.py" = "/lib/multimer/_backends/"
 
+"./src/add_ons/ps_loader.py" = "/"

--- a/web/pyscript/pyodide.html
+++ b/web/pyscript/pyodide.html
@@ -21,7 +21,7 @@
     <script type="module" src="./vendor/core.js"></script>
     <script src="https://pydevices.github.io/assets/js/theme-toggle.js" defer></script>
 </head>
-<body>
+<body data-loader-runtime="py">
     <header class="site-header">
         <div class="wrap">
             <a class="brand" href="https://pydevices.github.io/">
@@ -384,18 +384,7 @@
             print("Python runtime ready. Click Run to start the demo.")
     </script>
 
-    <script>
-        (function () {
-            const _btn = document.getElementById('run-btn');
-            const _spin = document.querySelector('#loading .spinner');
-            const _t = setInterval(() => {
-                if (_btn && !_btn.disabled) {
-                    if (_spin) _spin.style.display = 'none';
-                    clearInterval(_t);
-                }
-            }, 150);
-        })();
-    </script>
+    <script src="./loader-ready.js"></script>
 
     <script>
         (function () {

--- a/web/pyscript/pyodide.toml
+++ b/web/pyscript/pyodide.toml
@@ -96,3 +96,4 @@ interpreter = "./vendor/pyodide/pyodide.mjs"
 "./src/lib/multimer/_backends/threading.py" = "/lib/multimer/_backends/"
 "./src/lib/multimer/_backends/win32.py" = "/lib/multimer/_backends/"
 
+"./src/add_ons/ps_loader.py" = "/"

--- a/web/pyscript/sw.js
+++ b/web/pyscript/sw.js
@@ -16,9 +16,18 @@ const STATIC_ASSETS = [
   './demo.css',
   './pwa.css',
   './pwa.js',
+  './loader-ready.js',
   './mini-coi-fd.js',
   './micropython.toml',
   './pyodide.toml',
+];
+
+// Loader HTML changes often; fetch network-first so fixes are not masked by cache.
+const NETWORK_FIRST_ASSETS = [
+  './micropython.html',
+  './pyodide.html',
+  './run.html',
+  './run-pyodide.html',
 ];
 
 const RUNTIME_ORIGINS = [
@@ -51,6 +60,13 @@ function isStaticAssetPath(pathname) {
   });
 }
 
+function isNetworkFirstPath(pathname) {
+  return NETWORK_FIRST_ASSETS.some((asset) => {
+    const name = asset.replace(/^\.\//, '');
+    return pathname.endsWith('/' + name) || pathname.endsWith(name);
+  });
+}
+
 function shouldCache(url, request) {
   if (request.method !== 'GET') {
     return false;
@@ -62,6 +78,22 @@ function shouldCache(url, request) {
     return true;
   }
   return isRuntimeOrigin(url.hostname);
+}
+
+function networkFirstStaleWhileRevalidate(request) {
+  return fetch(request)
+    .then((networkResponse) => {
+      if (
+        networkResponse &&
+        networkResponse.status === 200 &&
+        networkResponse.type !== 'error'
+      ) {
+        const responseToCache = networkResponse.clone();
+        caches.open(CACHE_NAME).then((cache) => cache.put(request, responseToCache));
+      }
+      return networkResponse;
+    })
+    .catch(() => caches.match(request));
 }
 
 function cacheFirstStaleWhileRevalidate(request) {
@@ -132,7 +164,10 @@ self.addEventListener('fetch', (event) => {
   }
 
   event.respondWith(
-    cacheFirstStaleWhileRevalidate(request).then((response) => {
+    (url.origin === self.location.origin && isNetworkFirstPath(url.pathname)
+      ? networkFirstStaleWhileRevalidate(request)
+      : cacheFirstStaleWhileRevalidate(request)
+    ).then((response) => {
       if (!response) {
         return fetch(request).then((networkResponse) => withCoiHeaders(networkResponse));
       }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

Gallery loaders stall on **"Loading MicroPython runtime…"** with Run disabled — reported on `?modules=testris` and broadly after the `ps_loader` refactor.

Root causes:
1. **PWA cache-first** served stale `micropython.html` / `pyodide.html` (missing `/add_ons` `sys.path` bootstrap from PR #91) until a manual reload.
2. Loading UI only polled `run-btn.disabled` and never reacted to PyScript `done`/failure events.

## Fix

- **Service worker:** network-first for loader HTML (`micropython.html`, `pyodide.html`, `run*.html`); cache as offline fallback.
- **`loader-ready.js`:** `mpy:ready` / `py:ready` status updates; hide spinner on `mpy:done` / `py:done`; show **Runtime failed** if Run is still disabled after ~120s.
- **VFS:** also mount `ps_loader.py` at `/` in `micropython.toml` / `pyodide.toml` so `import ps_loader` works even without the HTML bootstrap.

Deploy will stamp a new `CACHE_NAME` (sw.js + shell change).
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-a0f1acde-d64b-40f0-b004-d438b02884a0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-a0f1acde-d64b-40f0-b004-d438b02884a0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

