### PR TITLE
Fix __future__ MIP error: lib.path before mip, defer ps_loader to Run

### DIFF
--- a/src/add_ons/ps_loader.py
+++ b/src/add_ons/ps_loader.py
@@ -4,9 +4,9 @@
 """PyScript gallery loader install plans (MicroPython WASM + Pyodide).
 
 Consolidates loader install logic for ``micropython.html``, ``pyodide.html``,
-``run.html``, and ``run-pyodide.html``. MicroPython WASM uses firmware ``mip``.
-Pyodide uses ``add_ons/mip.py`` for MIP manifests/modules and ``micropip`` for
-wheels.
+``run.html``, and ``run-pyodide.html``. Gallery pages call ``_ps_loader()`` on
+Run only (``import lib.path`` then ``import ps_loader``). MicroPython WASM uses
+firmware ``mip`` after ``lib.path``; Pyodide uses ``add_ons/mip.py``.
 """
 
 import sys
@@ -103,23 +103,43 @@ def _install_index_deps_micropython(mip_mod, names, status):
         mip_mod.install(pkg_url, index=MIP_LIB_INDEX)
 
 
-def install_micropython(modules, manifests, index_deps, status=None):
-    """Sync install plan for MicroPython WASM (firmware ``mip``)."""
-    import mip
-
-    _install_manifests_and_modules(mip, modules, manifests, status)
-    import lib.path  # noqa: F401
-    _install_index_deps_micropython(mip, index_deps, status)
-
-
-def prepare_vfs():
+def _ensure_cwd():
     import os
 
-    os.chdir("/")
-    if "/" not in sys.path:
-        sys.path.insert(0, "/")
-    if "/add_ons" not in sys.path:
-        sys.path.insert(0, "/add_ons")
+    try:
+        os.chdir("/")
+    except OSError:
+        pass
+
+
+def _import_firmware_mip():
+    """Firmware ``mip`` on MicroPython WASM (not ``add_ons/mip.py``).
+
+    ``lib.path`` must run first so ``add_ons`` is appended, not prepended.
+    """
+    import lib.path  # noqa: F401
+
+    import mip
+
+    return mip
+
+
+def _import_portable_mip():
+    """Portable ``add_ons/mip.py`` for Pyodide (no firmware ``mip``)."""
+    _ensure_cwd()
+    import lib.path  # noqa: F401
+
+    import mip
+
+    return mip
+
+
+def install_micropython(modules, manifests, index_deps, status=None):
+    """Sync install plan for MicroPython WASM (firmware ``mip``)."""
+    _ensure_cwd()
+    mip = _import_firmware_mip()
+    _install_manifests_and_modules(mip, modules, manifests, status)
+    _install_index_deps_micropython(mip, index_deps, status)
 
 
 async def _ensure_micropip(status):
@@ -159,8 +179,7 @@ async def _install_wheels_pyodide(names, status):
 
 async def install_pyodide(modules, manifests, wheel_deps, status=None):
     """Async install plan for Pyodide (``mip`` manifests/modules + micropip wheels)."""
-    prepare_vfs()
-    import mip
+    mip = _import_portable_mip()
 
     _install_manifests_and_modules(
         mip,
@@ -169,5 +188,4 @@ async def install_pyodide(modules, manifests, wheel_deps, status=None):
         status,
         url_base=_page_base(),
     )
-    import lib.path  # noqa: F401
     await _install_wheels_pyodide(wheel_deps, status)

--- a/web/pyscript/micropython.html
+++ b/web/pyscript/micropython.html
@@ -323,10 +323,12 @@
         import builtins
         from js import document
         from pyscript.ffi import create_proxy
-        import sys
-        if "/add_ons" not in sys.path:
-            sys.path.insert(0, "/add_ons")
-        import ps_loader
+
+        def _ps_loader():
+            import lib.path  # noqa: F401
+            import ps_loader
+
+            return ps_loader
 
         def _log_print(*args, **kwargs):
             el = document.getElementById("log")
@@ -352,9 +354,10 @@
             return str(val or default).strip()
 
         def _loader_plan():
-            modules = ps_loader.parse_names(_from_window("__pydisplayModules"))
-            manifests = ps_loader.parse_names(_from_window("__pydisplayManifests"))
-            deps = ps_loader.parse_names(_from_window("__pydisplayDeps"))
+            pl = _ps_loader()
+            modules = pl.parse_names(_from_window("__pydisplayModules"))
+            manifests = pl.parse_names(_from_window("__pydisplayManifests"))
+            deps = pl.parse_names(_from_window("__pydisplayDeps"))
             entry_kind = _from_window("__pydisplayEntryKind")
             entry = _from_window("__pydisplayEntry")
             if not entry and modules:
@@ -382,7 +385,8 @@
             _btn.textContent = "Running…"
             try:
                 _set("Installing…")
-                ps_loader.install_micropython(modules, manifests, deps, status=_set)
+                pl = _ps_loader()
+                pl.install_micropython(modules, manifests, deps, status=_set)
                 _set("Importing " + entry + "…")
                 __import__(entry)
                 _set("")

--- a/web/pyscript/pyodide.html
+++ b/web/pyscript/pyodide.html
@@ -311,10 +311,12 @@
         import builtins
         from js import document
         from pyscript.ffi import create_proxy
-        import sys
-        if "/add_ons" not in sys.path:
-            sys.path.insert(0, "/add_ons")
-        import ps_loader
+
+        def _ps_loader():
+            import lib.path  # noqa: F401
+            import ps_loader
+
+            return ps_loader
 
         def _log_print(*args, **kwargs):
             el = document.getElementById("log")
@@ -346,9 +348,10 @@
             global _started
             if _started or _loader_disabled():
                 return
-            modules = ps_loader.parse_names(_from_window("__pydisplayModules"))
-            manifests = ps_loader.parse_names(_from_window("__pydisplayManifests"))
-            deps = ps_loader.parse_names(_from_window("__pydisplayDeps"))
+            pl = _ps_loader()
+            modules = pl.parse_names(_from_window("__pydisplayModules"))
+            manifests = pl.parse_names(_from_window("__pydisplayManifests"))
+            deps = pl.parse_names(_from_window("__pydisplayDeps"))
             entry_kind = _from_window("__pydisplayEntryKind")
             entry = _from_window("__pydisplayEntry")
             if not entry and modules:
@@ -365,7 +368,7 @@
             _btn.disabled = True
             _btn.textContent = "Running…"
             try:
-                await ps_loader.install_pyodide(modules, manifests, deps, status=_set)
+                await pl.install_pyodide(modules, manifests, deps, status=_set)
                 _set("Importing " + entry + "…")
                 __import__(entry)
                 _set("")

--- a/web/pyscript/run-pyodide.html
+++ b/web/pyscript/run-pyodide.html
@@ -78,10 +78,12 @@
 <script type="py" config="./pyodide.toml" output="log">
 import builtins
 from js import document
-import sys
-if "/add_ons" not in sys.path:
-    sys.path.insert(0, "/add_ons")
-import ps_loader
+
+def _ps_loader():
+    import lib.path  # noqa: F401
+    import ps_loader
+
+    return ps_loader
 
 def _log_print(*args, **kwargs):
     el = document.getElementById("log")
@@ -100,9 +102,10 @@ def _from_window(name, default=""):
 async def _run():
     if _from_window("__pydisplayLoaderDisabled"):
         return
-    modules = ps_loader.parse_names(_from_window("__pydisplayModules"))
-    manifests = ps_loader.parse_names(_from_window("__pydisplayManifests"))
-    wheels = ps_loader.parse_names(_from_window("__pydisplayWheels"))
+    pl = _ps_loader()
+    modules = pl.parse_names(_from_window("__pydisplayModules"))
+    manifests = pl.parse_names(_from_window("__pydisplayManifests"))
+    wheels = pl.parse_names(_from_window("__pydisplayWheels"))
     entry = _from_window("__pydisplayEntry")
     if not entry and modules:
         entry = modules[0]
@@ -111,7 +114,7 @@ async def _run():
     if not entry:
         print("Missing ?modules= and/or ?manifests= in the URL.")
         return
-    await ps_loader.install_pyodide(modules, manifests, wheels)
+    await pl.install_pyodide(modules, manifests, wheels)
     __import__(entry)
 
 await _run()

--- a/web/pyscript/run.html
+++ b/web/pyscript/run.html
@@ -72,10 +72,12 @@
 <script type="mpy" config="./micropython.toml" output="log">
 import builtins
 from js import document
-import sys
-if "/add_ons" not in sys.path:
-    sys.path.insert(0, "/add_ons")
-import ps_loader
+
+def _ps_loader():
+    import lib.path  # noqa: F401
+    import ps_loader
+
+    return ps_loader
 
 def _log_print(*args, **kwargs):
     el = document.getElementById("log")
@@ -94,9 +96,10 @@ def _from_window(name, default=""):
 def _run():
     if _from_window("__pydisplayLoaderDisabled"):
         return
-    modules = ps_loader.parse_names(_from_window("__pydisplayModules"))
-    manifests = ps_loader.parse_names(_from_window("__pydisplayManifests"))
-    mip_pkgs = ps_loader.parse_names(_from_window("__pydisplayMip"))
+    pl = _ps_loader()
+    modules = pl.parse_names(_from_window("__pydisplayModules"))
+    manifests = pl.parse_names(_from_window("__pydisplayManifests"))
+    mip_pkgs = pl.parse_names(_from_window("__pydisplayMip"))
     entry = _from_window("__pydisplayEntry")
     if not entry and modules:
         entry = modules[0]
@@ -105,7 +108,7 @@ def _run():
     if not entry:
         print("Missing ?modules= and/or ?manifests= in the URL.")
         return
-    ps_loader.install_micropython(modules, manifests, mip_pkgs)
+    pl.install_micropython(modules, manifests, mip_pkgs)
     __import__(entry)
 
 _run()


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

`?deps=pdwidgets` on MicroPython gallery failed with:

```
Run failed: no module named '__future__'
```

PR #91 prepended `/add_ons` to `sys.path` so `import ps_loader` worked at page load. That made `add_ons/mip.py` shadow **firmware** `mip` on Run; portable `mip.py` uses `from __future__ import annotations`, which MP WASM lacks.

## Approach

- **No `sys.path` hacks in HTML** — `lib.path` remains the source of truth.
- **`_ps_loader()`** in all four loader pages: called on **Run** only (`import lib.path` then `import ps_loader`). Avoids Pyodide page-load `ModuleNotFoundError` and keeps `add_ons` appended (not prepended).
- **`ps_loader.install_micropython`**: `lib.path` **before** `import mip` so firmware `mip` wins.
- **`ps_loader.install_pyodide`**: `lib.path` before portable `mip`; removed `prepare_vfs()` path prepends.

## Files

- `src/add_ons/ps_loader.py`
- `web/pyscript/micropython.html`, `pyodide.html`, `run.html`, `run-pyodide.html`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-a0f1acde-d64b-40f0-b004-d438b02884a0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-a0f1acde-d64b-40f0-b004-d438b02884a0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

