### PR TITLE
Fix Pyodide ``import lib.path`` with VFS root on sys.path

### DIFF
--- a/src/add_ons/ps_loader.py
+++ b/src/add_ons/ps_loader.py
@@ -9,15 +9,12 @@ Run only (``import lib.path`` then ``import ps_loader``). MicroPython WASM uses
 firmware ``mip`` after ``lib.path``; Pyodide uses ``add_ons/mip.py``.
 """
 
-import sys
-
 MIP_LIB_INDEX = "https://PyDevices.github.io/micropython-lib/mip/PyDevices"
 MANIFEST_MIP_TARGET = "examples"
 WHEEL_INDEX_URLS = (
     "https://test.pypi.org/simple/",
     "https://pypi.org/simple/",
 )
-_MPY_LIB_CHANNEL_DEFAULT = "6"
 
 
 def parse_names(raw):
@@ -57,24 +54,6 @@ def module_url(name):
     if _use_same_origin():
         return _page_base() + "src/examples/" + name + ".py"
     return "github:PyDevices/pydisplay/src/examples/" + name + ".py"
-
-
-def mip_lib_channel():
-    mpy_byte = getattr(sys.implementation, "_mpy", 0) & 0xFF
-    if mpy_byte:
-        return str(mpy_byte)
-    return _MPY_LIB_CHANNEL_DEFAULT
-
-
-def _index_package_url(name, channel):
-    return (
-        MIP_LIB_INDEX.rstrip("/")
-        + "/package/"
-        + channel
-        + "/"
-        + name
-        + "/latest.json"
-    )
 
 
 def _install_manifests_and_modules(mip_mod, modules, manifests, status=None, url_base=None):

--- a/src/add_ons/ps_loader.py
+++ b/src/add_ons/ps_loader.py
@@ -94,13 +94,11 @@ def _install_manifests_and_modules(mip_mod, modules, manifests, status=None, url
 def _install_index_deps_micropython(mip_mod, names, status):
     if not names:
         return
-    channel = mip_lib_channel()
     for which in names:
         if status:
             status("Installing " + which + "…")
-        pkg_url = _index_package_url(which, channel)
-        print("MIP install:", which, "channel=", channel)
-        mip_mod.install(pkg_url, index=MIP_LIB_INDEX)
+        print("MIP install:", which, "index=", MIP_LIB_INDEX)
+        mip_mod.install(which, index=MIP_LIB_INDEX)
 
 
 def _ensure_cwd():

--- a/web/pyscript/micropython.html
+++ b/web/pyscript/micropython.html
@@ -321,24 +321,19 @@
 
     <script type="mpy" config="./micropython.toml" output="log">
         import builtins
+        import os
+        import sys
         from js import document
         from pyscript.ffi import create_proxy
 
-        def _ps_loader():
-            # Keep the same VFS bootstrap as pyodide.html so ``import lib.path`` is first.
-            import os
-            import sys
-
-            try:
-                os.chdir("/")
-            except OSError:
-                pass
-            if "/" not in sys.path:
-                sys.path.insert(0, "/")
-            import lib.path  # noqa: F401
-            import ps_loader
-
-            return ps_loader
+        try:
+            os.chdir("/")
+        except OSError:
+            pass
+        if "/" not in sys.path:
+            sys.path.insert(0, "/")
+        import lib.path  # noqa: F401
+        import ps_loader
 
         def _log_print(*args, **kwargs):
             el = document.getElementById("log")
@@ -364,10 +359,9 @@
             return str(val or default).strip()
 
         def _loader_plan():
-            pl = _ps_loader()
-            modules = pl.parse_names(_from_window("__pydisplayModules"))
-            manifests = pl.parse_names(_from_window("__pydisplayManifests"))
-            deps = pl.parse_names(_from_window("__pydisplayDeps"))
+            modules = ps_loader.parse_names(_from_window("__pydisplayModules"))
+            manifests = ps_loader.parse_names(_from_window("__pydisplayManifests"))
+            deps = ps_loader.parse_names(_from_window("__pydisplayDeps"))
             entry_kind = _from_window("__pydisplayEntryKind")
             entry = _from_window("__pydisplayEntry")
             if not entry and modules:
@@ -395,8 +389,7 @@
             _btn.textContent = "Running…"
             try:
                 _set("Installing…")
-                pl = _ps_loader()
-                pl.install_micropython(modules, manifests, deps, status=_set)
+                ps_loader.install_micropython(modules, manifests, deps, status=_set)
                 _set("Importing " + entry + "…")
                 __import__(entry)
                 _set("")

--- a/web/pyscript/micropython.html
+++ b/web/pyscript/micropython.html
@@ -325,6 +325,16 @@
         from pyscript.ffi import create_proxy
 
         def _ps_loader():
+            # Keep the same VFS bootstrap as pyodide.html so ``import lib.path`` is first.
+            import os
+            import sys
+
+            try:
+                os.chdir("/")
+            except OSError:
+                pass
+            if "/" not in sys.path:
+                sys.path.insert(0, "/")
             import lib.path  # noqa: F401
             import ps_loader
 

--- a/web/pyscript/pyodide.html
+++ b/web/pyscript/pyodide.html
@@ -313,6 +313,17 @@
         from pyscript.ffi import create_proxy
 
         def _ps_loader():
+            # Pyodide needs cwd / and / on sys.path so ``import lib.path`` resolves
+            # the VFS mount at /lib/path.py (same bootstrap as pre-ps_loader loaders).
+            import os
+            import sys
+
+            try:
+                os.chdir("/")
+            except OSError:
+                pass
+            if "/" not in sys.path:
+                sys.path.insert(0, "/")
             import lib.path  # noqa: F401
             import ps_loader
 

--- a/web/pyscript/pyodide.html
+++ b/web/pyscript/pyodide.html
@@ -309,25 +309,19 @@
 
     <script type="py" config="./pyodide.toml" output="log">
         import builtins
+        import os
+        import sys
         from js import document
         from pyscript.ffi import create_proxy
 
-        def _ps_loader():
-            # Pyodide needs cwd / and / on sys.path so ``import lib.path`` resolves
-            # the VFS mount at /lib/path.py (same bootstrap as pre-ps_loader loaders).
-            import os
-            import sys
-
-            try:
-                os.chdir("/")
-            except OSError:
-                pass
-            if "/" not in sys.path:
-                sys.path.insert(0, "/")
-            import lib.path  # noqa: F401
-            import ps_loader
-
-            return ps_loader
+        try:
+            os.chdir("/")
+        except OSError:
+            pass
+        if "/" not in sys.path:
+            sys.path.insert(0, "/")
+        import lib.path  # noqa: F401
+        import ps_loader
 
         def _log_print(*args, **kwargs):
             el = document.getElementById("log")
@@ -359,10 +353,9 @@
             global _started
             if _started or _loader_disabled():
                 return
-            pl = _ps_loader()
-            modules = pl.parse_names(_from_window("__pydisplayModules"))
-            manifests = pl.parse_names(_from_window("__pydisplayManifests"))
-            deps = pl.parse_names(_from_window("__pydisplayDeps"))
+            modules = ps_loader.parse_names(_from_window("__pydisplayModules"))
+            manifests = ps_loader.parse_names(_from_window("__pydisplayManifests"))
+            deps = ps_loader.parse_names(_from_window("__pydisplayDeps"))
             entry_kind = _from_window("__pydisplayEntryKind")
             entry = _from_window("__pydisplayEntry")
             if not entry and modules:
@@ -379,7 +372,7 @@
             _btn.disabled = True
             _btn.textContent = "Running…"
             try:
-                await pl.install_pyodide(modules, manifests, deps, status=_set)
+                await ps_loader.install_pyodide(modules, manifests, deps, status=_set)
                 _set("Importing " + entry + "…")
                 __import__(entry)
                 _set("")

--- a/web/pyscript/run-pyodide.html
+++ b/web/pyscript/run-pyodide.html
@@ -77,24 +77,18 @@
 </script>
 <script type="py" config="./pyodide.toml" output="log">
 import builtins
+import os
+import sys
 from js import document
 
-def _ps_loader():
-    # Pyodide needs cwd / and / on sys.path so ``import lib.path`` resolves
-    # the VFS mount at /lib/path.py (same bootstrap as pre-ps_loader loaders).
-    import os
-    import sys
-
-    try:
-        os.chdir("/")
-    except OSError:
-        pass
-    if "/" not in sys.path:
-        sys.path.insert(0, "/")
-    import lib.path  # noqa: F401
-    import ps_loader
-
-    return ps_loader
+try:
+    os.chdir("/")
+except OSError:
+    pass
+if "/" not in sys.path:
+    sys.path.insert(0, "/")
+import lib.path  # noqa: F401
+import ps_loader
 
 def _log_print(*args, **kwargs):
     el = document.getElementById("log")
@@ -113,10 +107,9 @@ def _from_window(name, default=""):
 async def _run():
     if _from_window("__pydisplayLoaderDisabled"):
         return
-    pl = _ps_loader()
-    modules = pl.parse_names(_from_window("__pydisplayModules"))
-    manifests = pl.parse_names(_from_window("__pydisplayManifests"))
-    wheels = pl.parse_names(_from_window("__pydisplayWheels"))
+    modules = ps_loader.parse_names(_from_window("__pydisplayModules"))
+    manifests = ps_loader.parse_names(_from_window("__pydisplayManifests"))
+    wheels = ps_loader.parse_names(_from_window("__pydisplayWheels"))
     entry = _from_window("__pydisplayEntry")
     if not entry and modules:
         entry = modules[0]
@@ -125,7 +118,7 @@ async def _run():
     if not entry:
         print("Missing ?modules= and/or ?manifests= in the URL.")
         return
-    await pl.install_pyodide(modules, manifests, wheels)
+    await ps_loader.install_pyodide(modules, manifests, wheels)
     __import__(entry)
 
 await _run()

--- a/web/pyscript/run-pyodide.html
+++ b/web/pyscript/run-pyodide.html
@@ -80,6 +80,17 @@ import builtins
 from js import document
 
 def _ps_loader():
+    # Pyodide needs cwd / and / on sys.path so ``import lib.path`` resolves
+    # the VFS mount at /lib/path.py (same bootstrap as pre-ps_loader loaders).
+    import os
+    import sys
+
+    try:
+        os.chdir("/")
+    except OSError:
+        pass
+    if "/" not in sys.path:
+        sys.path.insert(0, "/")
     import lib.path  # noqa: F401
     import ps_loader
 

--- a/web/pyscript/run.html
+++ b/web/pyscript/run.html
@@ -74,6 +74,16 @@ import builtins
 from js import document
 
 def _ps_loader():
+    # Keep the same VFS bootstrap as pyodide.html so ``import lib.path`` is first.
+    import os
+    import sys
+
+    try:
+        os.chdir("/")
+    except OSError:
+        pass
+    if "/" not in sys.path:
+        sys.path.insert(0, "/")
     import lib.path  # noqa: F401
     import ps_loader
 

--- a/web/pyscript/run.html
+++ b/web/pyscript/run.html
@@ -71,23 +71,18 @@
 </script>
 <script type="mpy" config="./micropython.toml" output="log">
 import builtins
+import os
+import sys
 from js import document
 
-def _ps_loader():
-    # Keep the same VFS bootstrap as pyodide.html so ``import lib.path`` is first.
-    import os
-    import sys
-
-    try:
-        os.chdir("/")
-    except OSError:
-        pass
-    if "/" not in sys.path:
-        sys.path.insert(0, "/")
-    import lib.path  # noqa: F401
-    import ps_loader
-
-    return ps_loader
+try:
+    os.chdir("/")
+except OSError:
+    pass
+if "/" not in sys.path:
+    sys.path.insert(0, "/")
+import lib.path  # noqa: F401
+import ps_loader
 
 def _log_print(*args, **kwargs):
     el = document.getElementById("log")
@@ -106,10 +101,9 @@ def _from_window(name, default=""):
 def _run():
     if _from_window("__pydisplayLoaderDisabled"):
         return
-    pl = _ps_loader()
-    modules = pl.parse_names(_from_window("__pydisplayModules"))
-    manifests = pl.parse_names(_from_window("__pydisplayManifests"))
-    mip_pkgs = pl.parse_names(_from_window("__pydisplayMip"))
+    modules = ps_loader.parse_names(_from_window("__pydisplayModules"))
+    manifests = ps_loader.parse_names(_from_window("__pydisplayManifests"))
+    mip_pkgs = ps_loader.parse_names(_from_window("__pydisplayMip"))
     entry = _from_window("__pydisplayEntry")
     if not entry and modules:
         entry = modules[0]
@@ -118,7 +112,7 @@ def _run():
     if not entry:
         print("Missing ?modules= and/or ?manifests= in the URL.")
         return
-    pl.install_micropython(modules, manifests, mip_pkgs)
+    ps_loader.install_micropython(modules, manifests, mip_pkgs)
     __import__(entry)
 
 _run()


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Pyodide gallery Run failed with `ModuleNotFoundError: No module named 'lib'` because `import lib.path` ran without `/` on `sys.path`. MicroPython accepts that idiom on the flat VFS; CPython/Pyodide needs `/` so `/lib/path.py` resolves as a namespace package.

Also: MicroPython `?deps=` now uses native firmware `mip.install(name, index=…)` again (no `package/{channel}/…` URL workaround). That lets WASM mip follow `sys.implementation._mpy` and install source `.py` when bytecode isn’t selected — avoiding the large consolidated `.mpy` OOM on `pdwidgets`.

## Changes

- Four gallery loaders: VFS bootstrap + top-level `import lib.path` / `import ps_loader`
- `ps_loader._install_index_deps_micropython`: `mip.install(which, index=MIP_LIB_INDEX)`

## Test plan

- [x] Pyodide `calc_widgets&deps=pdwidgets` — Run succeeds
- [x] MicroPython `calc_widgets,calc_engine&deps=pdwidgets` after native mip — installs `.py`, no OOM, demo starts
- [ ] Deployed Pages after merge

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-a0f1acde-d64b-40f0-b004-d438b02884a0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-a0f1acde-d64b-40f0-b004-d438b02884a0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

