### PR TITLE
Add scalable Roku ECP remote example (roku_engine + roku_remote)

### DIFF
--- a/packages/examples.json
+++ b/packages/examples.json
@@ -169,6 +169,14 @@
       "github:PyDevices/pydisplay/src/examples/pydisplay_demo.py"
     ],
     [
+      "roku_engine.py",
+      "github:PyDevices/pydisplay/src/examples/roku_engine.py"
+    ],
+    [
+      "roku_remote.py",
+      "github:PyDevices/pydisplay/src/examples/roku_remote.py"
+    ],
+    [
       "rotations.py",
       "github:PyDevices/pydisplay/src/examples/rotations.py"
     ],

--- a/src/examples/roku_engine.py
+++ b/src/examples/roku_engine.py
@@ -1,0 +1,771 @@
+# gallery: skip
+# SPDX-FileCopyrightText: 2026 Brad Barnett
+#
+# SPDX-License-Identifier: MIT
+"""
+`roku_engine`
+====================================================
+
+Roku External Control Protocol (ECP) client — no display, event, or UI imports.
+
+Talks HTTP on port 8060 and discovers devices via SSDP (``ST: roku:ecp``).
+Shared by the ``roku_remote`` graphics front end; designed so other UIs can
+reuse the same engine later.
+
+Requires the Roku setting **Control by mobile apps → Enabled**. WiFi must
+already be associated on microcontroller targets; unix MicroPython uses the
+host network.
+
+Usage::
+
+    from roku_engine import RokuEngine
+
+    eng = RokuEngine()
+    devices = eng.discover(timeout=3)
+    if devices:
+        eng.set_host(devices[0]["host"])
+    eng.connect()
+    eng.press("Home")
+    apps = eng.query_apps()
+"""
+
+import socket
+import sys
+
+try:
+    import time
+except ImportError:  # pragma: no cover
+    time = None
+
+# Default host: empty → discover / set manually. Edit for a fixed target.
+ROKU_HOST = ""
+ROKU_PORT = 8060
+
+SSDP_ADDR = "239.255.255.250"
+SSDP_PORT = 1900
+SSDP_ST = "roku:ecp"
+
+# Documented ECP keypress names (remote + TV extras).
+ECP_KEYS = (
+    "Home",
+    "Rev",
+    "Fwd",
+    "Play",
+    "Select",
+    "Left",
+    "Right",
+    "Down",
+    "Up",
+    "Back",
+    "InstantReplay",
+    "Info",
+    "Backspace",
+    "Search",
+    "Enter",
+    "FindRemote",
+    "VolumeDown",
+    "VolumeMute",
+    "VolumeUp",
+    "PowerOff",
+    "PowerOn",
+    "ChannelUp",
+    "ChannelDown",
+    "InputTuner",
+    "InputHDMI1",
+    "InputHDMI2",
+    "InputHDMI3",
+    "InputHDMI4",
+    "InputAV1",
+)
+
+ECP_KEY_SET = frozenset(ECP_KEYS)
+
+
+def _quote_lit(ch):
+    """URL-encode one character for Lit_ keypresses (ASCII-safe on MP)."""
+    o = ord(ch)
+    if ch == " ":
+        return "%20"
+    if 0x21 <= o <= 0x7E and ch not in "/%?#&=+":
+        return ch
+    # UTF-8 percent-encode
+    try:
+        raw = ch.encode("utf-8")
+    except (AttributeError, UnicodeEncodeError):
+        raw = bytes([o & 0xFF])
+    return "".join("%%%02X" % b for b in raw)
+
+
+def _xml_tag(text, tag):
+    """Return first inner text of <tag>...</tag>, or ''."""
+    if not text:
+        return ""
+    if isinstance(text, bytes):
+        try:
+            text = text.decode("utf-8")
+        except UnicodeError:
+            text = str(text)
+    open_tag = "<" + tag
+    i = text.find(open_tag)
+    if i < 0:
+        # case-insensitive fallback
+        lower = text.lower()
+        i = lower.find(open_tag.lower())
+        if i < 0:
+            return ""
+    gt = text.find(">", i)
+    if gt < 0:
+        return ""
+    # self-closing
+    if text[gt - 1] == "/":
+        return ""
+    close = "</" + tag + ">"
+    j = text.find(close, gt + 1)
+    if j < 0:
+        close = "</" + tag.lower() + ">"
+        j = text.lower().find(close, gt + 1)
+        if j < 0:
+            return ""
+        # recover original slice end using length
+        return text[gt + 1 : gt + 1 + (j - (gt + 1))].strip()
+    return text[gt + 1 : j].strip()
+
+
+def _xml_attrs(open_tag_src):
+    """Parse key=\"value\" attributes from an opening tag string."""
+    attrs = {}
+    if not open_tag_src:
+        return attrs
+    i = 0
+    s = open_tag_src
+    while i < len(s):
+        # find name=
+        while i < len(s) and s[i] in " \t\r\n/<>":
+            i += 1
+        if i >= len(s) or s[i] == ">":
+            break
+        j = i
+        while j < len(s) and s[j] not in "=\t\r\n />":
+            j += 1
+        name = s[i:j]
+        while j < len(s) and s[j] in " \t":
+            j += 1
+        if j >= len(s) or s[j] != "=":
+            i = j
+            continue
+        j += 1
+        while j < len(s) and s[j] in " \t":
+            j += 1
+        if j >= len(s):
+            break
+        quote = s[j]
+        if quote in "\"'":
+            j += 1
+            k = s.find(quote, j)
+            if k < 0:
+                break
+            attrs[name] = s[j:k]
+            i = k + 1
+        else:
+            k = j
+            while k < len(s) and s[k] not in " \t>/":
+                k += 1
+            attrs[name] = s[j:k]
+            i = k
+    return attrs
+
+
+def _parse_apps(xml_text):
+    """Parse /query/apps XML into list of {id, name, type, version}."""
+    if isinstance(xml_text, bytes):
+        try:
+            xml_text = xml_text.decode("utf-8")
+        except UnicodeError:
+            xml_text = str(xml_text)
+    apps = []
+    lower = xml_text.lower()
+    pos = 0
+    while True:
+        i = lower.find("<app", pos)
+        if i < 0:
+            break
+        # Avoid matching the wrapper <apps> tag.
+        after = i + 4
+        if after < len(lower) and lower[after] not in " \t\r\n/>":
+            pos = after
+            continue
+        gt = xml_text.find(">", i)
+        if gt < 0:
+            break
+        open_src = xml_text[i : gt + 1]
+        if open_src.rstrip().endswith("/>"):
+            pos = gt + 1
+            continue
+        close_i = lower.find("</app>", gt)
+        if close_i < 0:
+            break
+        name = xml_text[gt + 1 : close_i].strip()
+        attrs = _xml_attrs(open_src)
+        apps.append(
+            {
+                "id": attrs.get("id", ""),
+                "name": name,
+                "type": attrs.get("type", ""),
+                "version": attrs.get("version", ""),
+            }
+        )
+        pos = close_i + 6
+    return apps
+
+
+def _parse_ssdp_headers(data):
+    if isinstance(data, bytes):
+        try:
+            text = data.decode("utf-8")
+        except UnicodeError:
+            text = data.decode("latin-1")
+    else:
+        text = data
+    headers = {}
+    for line in text.split("\r\n"):
+        if ":" not in line:
+            continue
+        key, val = line.split(":", 1)
+        headers[key.strip().lower()] = val.strip()
+    return headers
+
+
+def _host_from_location(location):
+    """Extract host from http://host:8060/ LOCATION header."""
+    if not location:
+        return ""
+    loc = location.strip()
+    if "://" in loc:
+        loc = loc.split("://", 1)[1]
+    loc = loc.split("/", 1)[0]
+    if loc.startswith("["):
+        # ipv6 [addr]:port
+        end = loc.find("]")
+        if end > 0:
+            return loc[1:end]
+    if ":" in loc:
+        # host:port — last split for ipv4
+        parts = loc.rsplit(":", 1)
+        try:
+            int(parts[1])
+            return parts[0]
+        except (ValueError, IndexError):
+            return loc
+    return loc
+
+
+def http_request(method, url, timeout=5.0, data=None):
+    """
+    Portable HTTP GET/POST → (status_code, body_bytes).
+
+    Tries urllib, then urequests/requests. Raises RuntimeError if no client.
+    """
+    method = method.upper()
+    body = data if data is not None else b""
+    if isinstance(body, str):
+        body = body.encode("utf-8")
+
+    try:
+        from urllib.request import Request, urlopen
+        from urllib.error import HTTPError, URLError
+
+        req = Request(url, data=body if method != "GET" else None, method=method)
+        if method != "GET":
+            req.add_header("Content-Length", str(len(body)))
+        try:
+            with urlopen(req, timeout=timeout) as resp:
+                return int(getattr(resp, "status", 200) or 200), resp.read()
+        except HTTPError as e:
+            raw = b""
+            try:
+                raw = e.read()
+            except Exception:
+                pass
+            return int(getattr(e, "code", 0) or 0), raw
+        except URLError as e:
+            raise RuntimeError(str(getattr(e, "reason", e))) from e
+    except ImportError:
+        pass
+
+    # MicroPython Request may not support method=; fall through
+    except TypeError:
+        try:
+            from urllib.request import Request, urlopen
+            from urllib.error import HTTPError, URLError
+
+            req = Request(url, data=body if method != "GET" else None)
+            if method != "GET":
+                req.get_method = lambda: method  # type: ignore[attr-defined]
+            try:
+                with urlopen(req, timeout=timeout) as resp:
+                    return int(getattr(resp, "status", 200) or 200), resp.read()
+            except HTTPError as e:
+                raw = b""
+                try:
+                    raw = e.read()
+                except Exception:
+                    pass
+                return int(getattr(e, "code", 0) or 0), raw
+            except URLError as e:
+                raise RuntimeError(str(getattr(e, "reason", e))) from e
+        except ImportError:
+            pass
+
+    for mod_name in ("urequests", "requests"):
+        try:
+            mod = __import__(mod_name)
+        except ImportError:
+            continue
+        fn = getattr(mod, method.lower(), None)
+        if fn is None and method == "GET":
+            fn = getattr(mod, "get", None)
+        if fn is None and method == "POST":
+            fn = getattr(mod, "post", None)
+        if fn is None:
+            continue
+        try:
+            if method == "GET":
+                resp = fn(url, timeout=timeout)
+            else:
+                resp = fn(url, data=body, timeout=timeout)
+        except TypeError:
+            # older urequests without timeout
+            if method == "GET":
+                resp = fn(url)
+            else:
+                resp = fn(url, data=body)
+        try:
+            if hasattr(resp, "content"):
+                raw = resp.content
+            elif hasattr(resp, "text"):
+                text = resp.text
+                raw = text.encode("utf-8") if isinstance(text, str) else text
+            elif callable(getattr(resp, "read", None)):
+                raw = resp.read()
+            else:
+                raw = bytes(resp) if resp is not None else b""
+            if isinstance(raw, str):
+                raw = raw.encode("utf-8")
+            status = getattr(resp, "status_code", getattr(resp, "status", 200))
+            return int(status or 200), raw or b""
+        finally:
+            close = getattr(resp, "close", None)
+            if callable(close):
+                close()
+
+    raise RuntimeError("no HTTP client (need urllib, urequests, or requests)")
+
+
+def discover_rokus(timeout=3.0, retries=2):
+    """
+    SSDP M-SEARCH for Roku ECP devices.
+
+    Returns a list of dicts: ``{host, location, usn, st}``.
+    """
+    message = (
+        "M-SEARCH * HTTP/1.1\r\n"
+        "HOST: %s:%d\r\n"
+        'MAN: "ssdp:discover"\r\n'
+        "ST: %s\r\n"
+        "MX: 2\r\n"
+        "\r\n"
+    ) % (SSDP_ADDR, SSDP_PORT, SSDP_ST)
+
+    found = {}
+    deadline = None
+    if time is not None:
+        deadline = time.time() + float(timeout)
+
+    for _ in range(max(1, int(retries))):
+        sock = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
+        try:
+            try:
+                sock.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+            except (OSError, AttributeError):
+                pass
+            try:
+                # IPPROTO_IP=0, IP_MULTICAST_TTL=33 on many stacks
+                sock.setsockopt(0, 33, 2)
+            except (OSError, AttributeError):
+                pass
+            try:
+                sock.settimeout(0.4)
+            except OSError:
+                pass
+
+            payload = message.encode() if isinstance(message, str) else message
+            try:
+                sock.sendto(payload, (SSDP_ADDR, SSDP_PORT))
+            except OSError as e:
+                sock.close()
+                raise RuntimeError("SSDP send failed: " + str(e)) from e
+
+            while True:
+                if deadline is not None and time.time() >= deadline:
+                    break
+                try:
+                    data, _addr = sock.recvfrom(2048)
+                except OSError:
+                    if deadline is None:
+                        break
+                    # keep waiting until overall timeout
+                    if time is not None and time.time() >= deadline:
+                        break
+                    continue
+                headers = _parse_ssdp_headers(data)
+                st = headers.get("st", "")
+                location = headers.get("location", "")
+                if "roku" not in st.lower() and "roku" not in location.lower():
+                    # still accept LOCATION pointing at :8060
+                    if ":8060" not in location:
+                        continue
+                host = _host_from_location(location)
+                if not host:
+                    continue
+                found[host] = {
+                    "host": host,
+                    "location": location,
+                    "usn": headers.get("usn", ""),
+                    "st": st or SSDP_ST,
+                }
+                if deadline is None:
+                    # single-response mode when no time module
+                    break
+        finally:
+            try:
+                sock.close()
+            except OSError:
+                pass
+
+    return list(found.values())
+
+
+class RokuEngine:
+    """Stateful ECP client for one Roku target."""
+
+    def __init__(self, host=None, port=ROKU_PORT, timeout=5.0):
+        self.host = host if host is not None else ROKU_HOST
+        self.port = int(port)
+        self.timeout = float(timeout)
+        self.last_error = ""
+        self.connected = False
+        self.device_info = {}
+        self.apps = []
+        self.active_app = {}
+        self.media_player = ""
+        self.discovered = []
+        # Optional inject for tests: callable(method, url, timeout, data) -> (status, body)
+        self._http = None
+
+    def set_host(self, host, port=None):
+        self.host = (host or "").strip()
+        if port is not None:
+            self.port = int(port)
+        self.connected = False
+        self.last_error = ""
+
+    @property
+    def base_url(self):
+        return "http://%s:%d" % (self.host, self.port)
+
+    @property
+    def status(self):
+        if self.last_error:
+            return "err: " + self.last_error
+        if not self.host:
+            return "no host"
+        if not self.connected:
+            return "offline " + self.host
+        name = self.device_info.get("user-device-name") or self.device_info.get(
+            "model-name", ""
+        )
+        app = self.active_app.get("name", "")
+        bits = [self.host]
+        if name:
+            bits.append(name)
+        if app:
+            bits.append(app)
+        return " | ".join(bits)
+
+    def _request(self, method, path, data=b""):
+        if not self.host:
+            self.last_error = "no host"
+            return 0, b""
+        url = self.base_url + path
+        try:
+            if self._http is not None:
+                status, body = self._http(method, url, self.timeout, data)
+            else:
+                status, body = http_request(method, url, timeout=self.timeout, data=data)
+        except Exception as e:
+            self.last_error = str(e)
+            self.connected = False
+            return 0, b""
+        if status and status >= 400:
+            self.last_error = "HTTP %d %s" % (status, path)
+        else:
+            self.last_error = ""
+        return status, body
+
+    def discover(self, timeout=3.0, retries=2):
+        try:
+            self.discovered = discover_rokus(timeout=timeout, retries=retries)
+            self.last_error = "" if self.discovered else "no Roku found"
+        except Exception as e:
+            self.discovered = []
+            self.last_error = str(e)
+        return self.discovered
+
+    def connect(self, discover_if_empty=True):
+        """Ping device-info. If host empty and discover_if_empty, SSDP first."""
+        if not self.host and discover_if_empty:
+            devices = self.discover()
+            if devices:
+                self.set_host(devices[0]["host"])
+        if not self.host:
+            self.last_error = "no host"
+            self.connected = False
+            return False
+        info = self.query_device_info()
+        self.connected = bool(info)
+        if self.connected:
+            try:
+                self.query_active_app()
+            except Exception:
+                pass
+        return self.connected
+
+    def press(self, key):
+        if key not in ECP_KEY_SET and not str(key).startswith("Lit_"):
+            self.last_error = "unknown key: " + str(key)
+            return False
+        status, _ = self._request("POST", "/keypress/" + key, b"")
+        return 200 <= status < 300 or status == 200
+
+    def keydown(self, key):
+        status, _ = self._request("POST", "/keydown/" + key, b"")
+        return 200 <= status < 300
+
+    def keyup(self, key):
+        status, _ = self._request("POST", "/keyup/" + key, b"")
+        return 200 <= status < 300
+
+    def type_text(self, text):
+        ok = True
+        for ch in text:
+            lit = "Lit_" + _quote_lit(ch)
+            if not self.press(lit):
+                ok = False
+        return ok
+
+    def launch(self, app_id, query=""):
+        path = "/launch/" + str(app_id)
+        if query:
+            path += ("&" if "?" in query else "?") + query.lstrip("?&")
+        status, _ = self._request("POST", path, b"")
+        return 200 <= status < 300
+
+    def install(self, app_id):
+        status, _ = self._request("POST", "/install/" + str(app_id), b"")
+        return 200 <= status < 300
+
+    def input_params(self, params):
+        """POST /input?k=v&... custom events to the current app."""
+        if isinstance(params, dict):
+            parts = []
+            for k, v in params.items():
+                parts.append("%s=%s" % (k, v))
+            qs = "&".join(parts)
+        else:
+            qs = str(params).lstrip("?")
+        status, _ = self._request("POST", "/input?" + qs, b"")
+        return 200 <= status < 300
+
+    def query_device_info(self):
+        status, body = self._request("GET", "/query/device-info")
+        if not body or status >= 400:
+            self.device_info = {}
+            return {}
+        text = body.decode("utf-8") if isinstance(body, bytes) else body
+        info = {}
+        for tag in (
+            "udn",
+            "serial-number",
+            "device-id",
+            "vendor-name",
+            "model-name",
+            "model-number",
+            "model-region",
+            "is-tv",
+            "is-stick",
+            "user-device-name",
+            "software-version",
+            "software-build",
+            "power-mode",
+            "network-type",
+            "network-name",
+            "supports-find-remote",
+            "supports-audio-volume-control",
+            "supports-tv-power-control",
+            "supports-ethernet",
+            "wifi-mac",
+            "ethernet-mac",
+        ):
+            val = _xml_tag(text, tag)
+            if val:
+                info[tag] = val
+        self.device_info = info
+        return info
+
+    def query_apps(self):
+        status, body = self._request("GET", "/query/apps")
+        if not body or status >= 400:
+            self.apps = []
+            return []
+        self.apps = _parse_apps(body)
+        return self.apps
+
+    def query_active_app(self):
+        status, body = self._request("GET", "/query/active-app")
+        if not body or status >= 400:
+            self.active_app = {}
+            return {}
+        text = body.decode("utf-8") if isinstance(body, bytes) else body
+        # <app id="12">Netflix</app> or screensaver sibling
+        apps = _parse_apps(text)
+        if apps:
+            self.active_app = apps[0]
+        else:
+            name = _xml_tag(text, "app")
+            self.active_app = {"id": "", "name": name} if name else {}
+        return self.active_app
+
+    def query_media_player(self):
+        status, body = self._request("GET", "/query/media-player")
+        if not body or status >= 400:
+            self.media_player = ""
+            return ""
+        text = body.decode("utf-8") if isinstance(body, bytes) else body
+        self.media_player = text.strip()
+        return self.media_player
+
+    def query_tv_channels(self):
+        status, body = self._request("GET", "/query/tv-channels")
+        if not body or status >= 400:
+            return ""
+        return body.decode("utf-8") if isinstance(body, bytes) else body
+
+    def query_tv_active_channel(self):
+        status, body = self._request("GET", "/query/tv-active-channel")
+        if not body or status >= 400:
+            return ""
+        return body.decode("utf-8") if isinstance(body, bytes) else body
+
+    def query_icon(self, app_id):
+        """Return raw icon bytes (PNG/JPEG) or b''."""
+        status, body = self._request("GET", "/query/icon/" + str(app_id))
+        if not body or status >= 400:
+            return b""
+        return body
+
+    # --- Developer-mode helpers (engine API; light UI dump) ---
+
+    def query_raw(self, path):
+        """GET an arbitrary ECP path; return decoded text or ''."""
+        if not path.startswith("/"):
+            path = "/" + path
+        status, body = self._request("GET", path)
+        if not body:
+            return ""
+        if isinstance(body, bytes):
+            try:
+                return body.decode("utf-8")
+            except UnicodeError:
+                return repr(body[:80])
+        return body
+
+    def query_chanperf(self, duration_seconds=None):
+        path = "/query/chanperf"
+        if duration_seconds is not None:
+            path += "?duration-seconds=" + str(duration_seconds)
+        return self.query_raw(path)
+
+    def query_sgnodes(self, which="all"):
+        return self.query_raw("/query/sgnodes/" + which)
+
+    def query_registry(self, channel_id="dev"):
+        return self.query_raw("/query/registry/" + str(channel_id))
+
+    def query_graphics_frame_rate(self):
+        return self.query_raw("/query/graphics-frame-rate")
+
+    def query_app_state(self, app_id):
+        return self.query_raw("/query/app-state/" + str(app_id))
+
+    def query_app_object_counts(self, app_id):
+        return self.query_raw("/query/app-object-counts/" + str(app_id))
+
+    def exit_app(self, force=False):
+        path = "/exit-app"
+        if force:
+            path += "/true"
+        status, _ = self._request("POST", path, b"")
+        return 200 <= status < 300
+
+    def fwbeacons_track(self, channel_id=None):
+        path = "/fwbeacons/track"
+        if channel_id:
+            path += "/" + str(channel_id)
+        status, _ = self._request("POST", path, b"")
+        return 200 <= status < 300
+
+    def fwbeacons_untrack(self):
+        status, _ = self._request("POST", "/fwbeacons/untrack", b"")
+        return 200 <= status < 300
+
+    def query_fwbeacons(self):
+        return self.query_raw("/query/fwbeacons")
+
+    def sgrendezvous_track(self, channel_id=None):
+        path = "/query/sgrendezvous/track"
+        if channel_id:
+            path += "/" + str(channel_id)
+        status, _ = self._request("POST", path, b"")
+        return 200 <= status < 300
+
+    def sgrendezvous_untrack(self):
+        status, _ = self._request("POST", "/query/sgrendezvous/untrack", b"")
+        return 200 <= status < 300
+
+    def query_sgrendezvous(self):
+        return self.query_raw("/query/sgrendezvous")
+
+    def query_r2d2_bitmaps(self):
+        return self.query_raw("/query/r2d2-bitmaps")
+
+    def is_tv(self):
+        return str(self.device_info.get("is-tv", "")).lower() in ("true", "1")
+
+    def supports_volume(self):
+        return str(self.device_info.get("supports-audio-volume-control", "")).lower() in (
+            "true",
+            "1",
+        ) or self.is_tv()
+
+
+# MicroPython-friendly: avoid dataclass / typing
+if __name__ == "__main__":
+    eng = RokuEngine()
+    print("discover:", eng.discover())
+    if eng.discovered:
+        eng.set_host(eng.discovered[0]["host"])
+        print("connect:", eng.connect())
+        print("status:", eng.status)
+        print("apps:", len(eng.query_apps()))
+    else:
+        print("last_error:", eng.last_error, file=sys.stderr)

--- a/src/examples/roku_remote.py
+++ b/src/examples/roku_remote.py
@@ -1,0 +1,818 @@
+# modules: roku_engine
+# SPDX-FileCopyrightText: 2026 Brad Barnett
+#
+# SPDX-License-Identifier: MIT
+"""
+roku_remote
+====================================================
+Museum-quality portrait Roku remote drawn with ``graphics.FrameBuffer``.
+
+Shares :class:`roku_engine.RokuEngine` for ECP over the LAN (SSDP discover +
+HTTP keypress / apps / queries). Uses only the four core pydisplay packages
+(``graphics``, ``displaysys`` via ``board_config``, ``eventsys``, ``multimer``).
+
+Geometry scales from a 320x480 reference up through tall phone portraits.
+Compact layouts show classic remote chrome; expanded layouts add side volume,
+channel / input shortcuts, theme picker, discover + IP entry, and an apps rail.
+
+Edit ``ROKU_HOST`` below, or leave empty and use **Find** / Discover on device.
+Requires Roku **Control by mobile apps → Enabled**. Join WiFi before running
+on a microcontroller.
+"""
+
+import sys
+
+_EXAMPLES = __file__.replace("\\", "/").rsplit("/", 1)[0]
+if _EXAMPLES not in sys.path:
+    sys.path.insert(0, _EXAMPLES)
+
+from board_config import display_drv, runtime
+from eventsys.keys import Keys
+from graphics import RGB565, Area, FrameBuffer
+from multimer import Timer
+from roku_engine import ROKU_HOST as _DEFAULT_HOST
+from roku_engine import RokuEngine
+
+# Override here, or leave "" and use Discover / IP pad.
+ROKU_HOST = _DEFAULT_HOST
+
+
+def _c565(r, g, b):
+    return ((r & 0xF8) << 8) | ((g & 0xFC) << 3) | (b >> 3)
+
+
+def _channels(c):
+    return (c >> 8) & 0xF8, (c >> 3) & 0xFC, (c << 3) & 0xF8
+
+
+def _lerp(c1, c2, t):
+    r1, g1, b1 = _channels(c1)
+    r2, g2, b2 = _channels(c2)
+    r = int(r1 + (r2 - r1) * t)
+    g = int(g1 + (g2 - g1) * t)
+    b = int(b1 + (b2 - b1) * t)
+    return _c565(r, g, b)
+
+
+def _shade(c, factor):
+    """factor < 1 darkens, > 1 lightens (clamped)."""
+    r, g, b = _channels(c)
+    r = max(0, min(255, int(r * factor)))
+    g = max(0, min(255, int(g * factor)))
+    b = max(0, min(255, int(b * factor)))
+    return _c565(r, g, b)
+
+
+# Named themes: professional chassis + key roles (no external palettes package).
+_THEMES = {
+    "midnight": {
+        "chassis": _c565(0x12, 0x14, 0x1A),
+        "chassis2": _c565(0x1A, 0x1E, 0x28),
+        "bezel": _c565(0x0A, 0x0C, 0x10),
+        "status_bg": _c565(0x1C, 0x22, 0x2E),
+        "key": _c565(0x3A, 0x40, 0x4E),
+        "key_alt": _c565(0x2E, 0x34, 0x40),
+        "accent": _c565(0x7C, 0x5C, 0xFC),
+        "accent2": _c565(0x5A, 0x3E, 0xD0),
+        "power": _c565(0xE0, 0x5A, 0x4A),
+        "transport": _c565(0x3A, 0x5A, 0x72),
+        "text": _c565(0xF2, 0xF4, 0xF8),
+        "muted": _c565(0x9A, 0xA0, 0xB0),
+        "ok_text": _c565(0xFF, 0xFF, 0xFF),
+        "press": _c565(0xE8, 0xEC, 0xF4),
+        "press_text": _c565(0x18, 0x1A, 0x22),
+    },
+    "graphite": {
+        "chassis": _c565(0x1A, 0x1A, 0x1C),
+        "chassis2": _c565(0x28, 0x28, 0x2C),
+        "bezel": _c565(0x0E, 0x0E, 0x10),
+        "status_bg": _c565(0x24, 0x24, 0x28),
+        "key": _c565(0x48, 0x48, 0x50),
+        "key_alt": _c565(0x38, 0x38, 0x40),
+        "accent": _c565(0x5A, 0xC8, 0xFA),
+        "accent2": _c565(0x2E, 0x8A, 0xC0),
+        "power": _c565(0xFF, 0x6B, 0x5A),
+        "transport": _c565(0x50, 0x58, 0x68),
+        "text": _c565(0xF5, 0xF5, 0xF7),
+        "muted": _c565(0xA0, 0xA0, 0xA8),
+        "ok_text": _c565(0x10, 0x12, 0x16),
+        "press": _c565(0xFF, 0xFF, 0xFF),
+        "press_text": _c565(0x20, 0x20, 0x24),
+    },
+    "ocean": {
+        "chassis": _c565(0x0E, 0x1A, 0x22),
+        "chassis2": _c565(0x14, 0x28, 0x34),
+        "bezel": _c565(0x08, 0x12, 0x18),
+        "status_bg": _c565(0x16, 0x2E, 0x3A),
+        "key": _c565(0x2A, 0x4A, 0x58),
+        "key_alt": _c565(0x22, 0x3C, 0x48),
+        "accent": _c565(0x2E, 0xD2, 0xC0),
+        "accent2": _c565(0x1A, 0xA0, 0x92),
+        "power": _c565(0xF0, 0x70, 0x60),
+        "transport": _c565(0x2A, 0x5A, 0x6E),
+        "text": _c565(0xE8, 0xF4, 0xF8),
+        "muted": _c565(0x8A, 0xB0, 0xBC),
+        "ok_text": _c565(0x0A, 0x18, 0x1C),
+        "press": _c565(0xD0, 0xF8, 0xF0),
+        "press_text": _c565(0x0E, 0x1A, 0x22),
+    },
+    "ember": {
+        "chassis": _c565(0x1A, 0x12, 0x10),
+        "chassis2": _c565(0x28, 0x1A, 0x14),
+        "bezel": _c565(0x10, 0x0A, 0x08),
+        "status_bg": _c565(0x2A, 0x1C, 0x16),
+        "key": _c565(0x4A, 0x36, 0x2C),
+        "key_alt": _c565(0x3A, 0x2A, 0x22),
+        "accent": _c565(0xFF, 0x9A, 0x3C),
+        "accent2": _c565(0xD0, 0x6A, 0x20),
+        "power": _c565(0xE0, 0x40, 0x40),
+        "transport": _c565(0x5A, 0x40, 0x30),
+        "text": _c565(0xFF, 0xF0, 0xE4),
+        "muted": _c565(0xC0, 0xA0, 0x88),
+        "ok_text": _c565(0x1A, 0x10, 0x0C),
+        "press": _c565(0xFF, 0xE0, 0xC0),
+        "press_text": _c565(0x2A, 0x16, 0x10),
+    },
+}
+_THEME_NAMES = ("midnight", "graphite", "ocean", "ember")
+
+
+class _Btn:
+    __slots__ = ("id", "label", "area", "role", "ecp", "meta")
+
+    def __init__(self, bid, label, x, y, w, h, role="key", ecp=None, meta=None):
+        self.id = bid
+        self.label = label
+        self.area = Area(x, y, w, h)
+        self.role = role
+        self.ecp = ecp
+        self.meta = meta
+
+
+class _Remote:
+    FONT_W = 8
+    FONT_H = 16
+
+    def __init__(self):
+        self.width = display_drv.width
+        self.height = display_drv.height
+        self.bpp = display_drv.color_depth // 8
+        self.unit = min(self.width, self.height)
+        self.expanded = self.height >= 640 or (self.height >= 560 and self.unit >= 360)
+
+        self.pad = max(3, self.unit // 64)
+        self.radius = max(5, self.unit // 36)
+        self.font_scale = max(1, self.unit // 280)
+        self.title_scale = self.font_scale + (1 if self.unit >= 400 else 0)
+
+        self.theme_name = "midnight"
+        self.theme = _THEMES[self.theme_name]
+        self.engine = RokuEngine(host=ROKU_HOST)
+        self.ip_buf = self.engine.host or ""
+        self.page = "remote"  # remote | apps | more | ip
+        self.app_offset = 0
+        self.discover_list = []
+        self._status_line = "ready"
+        self._dev_dump = ""
+
+        # Layout regions
+        self.status_h = max(28, self.FONT_H * self.font_scale + 2 * self.pad)
+        self.margin_x = self.pad if not self.expanded else max(self.pad, self.width // 10)
+        self.side_w = 0 if not self.expanded else max(36, self.width // 9)
+
+        self.buttons = []
+        self._by_id = {}
+        self._pressed_id = None
+        self._release_timer = Timer(-1)
+        self._status_timer = Timer(-1)
+
+        max_w = self.width
+        max_h = max(48, self.height // 8)
+        self.btn_ba = bytearray(max_w * max_h * self.bpp)
+        self.btn_fb = FrameBuffer(self.btn_ba, max_w, max_h, RGB565)
+
+        self._build_layout()
+        self._draw_all()
+
+        runtime.on(runtime.events.MOUSEBUTTONDOWN, self._on_mouse)
+        runtime.on(runtime.events.KEYDOWN, self._on_key)
+
+        # Best-effort connect (may fail offline — UI still usable).
+        try:
+            if self.engine.host:
+                self.engine.connect(discover_if_empty=False)
+                self._status_line = self.engine.status
+                self._refresh_status()
+        except Exception as e:
+            self._status_line = str(e)
+            self._refresh_status()
+
+    # ----- layout ---------------------------------------------------------
+
+    def _build_layout(self):
+        self.buttons = []
+        self._by_id = {}
+        y = self.pad
+        # Status band is drawn separately; reserve space.
+        y += self.status_h + self.pad
+
+        content_x = self.margin_x
+        content_w = self.width - 2 * self.margin_x
+        if self.expanded:
+            content_x = self.margin_x + self.side_w + self.pad
+            content_w = self.width - content_x - self.margin_x - self.side_w - self.pad
+
+        if self.page == "ip":
+            self._layout_ip(content_x, y, content_w)
+            return
+        if self.page == "apps":
+            self._layout_apps(content_x, y, content_w)
+            return
+        if self.page == "more":
+            self._layout_more(content_x, y, content_w)
+            return
+
+        self._layout_remote(content_x, y, content_w)
+        if self.expanded:
+            self._layout_side_volume()
+            self._layout_side_channel()
+
+    def _add(self, bid, label, x, y, w, h, role="key", ecp=None, meta=None):
+        b = _Btn(bid, label, int(x), int(y), int(w), int(h), role=role, ecp=ecp, meta=meta)
+        self.buttons.append(b)
+        self._by_id[bid] = b
+        return b
+
+    def _layout_remote(self, x0, y0, w):
+        # Top utility row: Back | Home | Power (or Find on compact)
+        row_h = max(36, self.height // 14)
+        gap = self.pad
+        n = 3
+        bw = (w - gap * (n - 1)) // n
+        labels = (("back", "BACK", "Back"), ("home", "HOME", "Home"), ("power", "PWR", "PowerOff"))
+        for i, (bid, lab, ecp) in enumerate(labels):
+            role = "accent" if bid == "home" else ("power" if bid == "power" else "key")
+            self._add(bid, lab, x0 + i * (bw + gap), y0, bw, row_h, role=role, ecp=ecp)
+        y = y0 + row_h + gap * 2
+
+        # D-pad block (square-ish)
+        dpad = min(w, max(140, self.height // 3))
+        if dpad > w:
+            dpad = w
+        dx = x0 + (w - dpad) // 2
+        cell = dpad // 3
+        # Up
+        self._add("up", "^", dx + cell, y, cell, cell, role="dpad", ecp="Up")
+        # Left / OK / Right
+        self._add("left", "<", dx, y + cell, cell, cell, role="dpad", ecp="Left")
+        self._add("ok", "OK", dx + cell, y + cell, cell, cell, role="accent", ecp="Select")
+        self._add("right", ">", dx + 2 * cell, y + cell, cell, cell, role="dpad", ecp="Right")
+        # Down
+        self._add("down", "v", dx + cell, y + 2 * cell, cell, cell, role="dpad", ecp="Down")
+        y += dpad + gap * 2
+
+        # Replay / Info / Options(*) / Search
+        n = 4
+        bw = (w - gap * (n - 1)) // n
+        # Classic remote: Instant Replay, Info (*), Search (voice), Enter
+        mid = (
+            ("replay", "REPLAY", "InstantReplay", "key"),
+            ("info", "*", "Info", "key"),
+            ("search", "SRCH", "Search", "key"),
+            ("enter_row", "ENTER", "Enter", "key_alt"),
+        )
+        for i, (bid, lab, ecp, role) in enumerate(mid):
+            self._add(bid, lab, x0 + i * (bw + gap), y, bw, row_h, role=role, ecp=ecp)
+        y += row_h + gap * 2
+
+        # Transport: Rev / Play / Fwd
+        n = 3
+        bw = (w - gap * (n - 1)) // n
+        for i, (bid, lab, ecp) in enumerate(
+            (("rev", "<<", "Rev"), ("play", "PLAY", "Play"), ("fwd", ">>", "Fwd"))
+        ):
+            self._add(bid, lab, x0 + i * (bw + gap), y, bw, row_h, role="transport", ecp=ecp)
+        y += row_h + gap * 2
+
+        # Bottom chrome: theme / apps / more / discover(+ip)
+        if self.expanded:
+            labs = (
+                ("theme", "THEME", None, "ui"),
+                ("apps_pg", "APPS", None, "ui"),
+                ("more_pg", "MORE", None, "ui"),
+                ("find", "SCAN", None, "ui"),
+            )
+        else:
+            labs = (
+                ("theme", "THM", None, "ui"),
+                ("apps_pg", "APP", None, "ui"),
+                ("more_pg", "…", None, "ui"),
+                ("find", "SCAN", None, "ui"),
+            )
+        n = len(labs)
+        bw = (w - gap * (n - 1)) // n
+        bh = max(32, row_h - 4)
+        for i, (bid, lab, ecp, role) in enumerate(labs):
+            self._add(bid, lab, x0 + i * (bw + gap), y, bw, bh, role=role, ecp=ecp)
+
+        # Expanded: input shortcuts under bottom row if room
+        y2 = y + bh + gap
+        if self.expanded and y2 + row_h < self.height - self.pad:
+            inputs = (
+                ("tuner", "TV", "InputTuner"),
+                ("hdmi1", "H1", "InputHDMI1"),
+                ("hdmi2", "H2", "InputHDMI2"),
+                ("hdmi3", "H3", "InputHDMI3"),
+                ("av", "AV", "InputAV1"),
+            )
+            n = len(inputs)
+            bw = (w - gap * (n - 1)) // n
+            for i, (bid, lab, ecp) in enumerate(inputs):
+                self._add(bid, lab, x0 + i * (bw + gap), y2, bw, row_h - 4, role="key_alt", ecp=ecp)
+
+    def _layout_side_volume(self):
+        x = self.margin_x
+        top = self.pad + self.status_h + self.pad
+        bottom = self.height - self.pad
+        h = bottom - top
+        # Volume rocker: Up / Mute / Down stacked
+        seg = h // 3
+        self._add("vol_up", "+", x, top, self.side_w, seg - self.pad, role="transport", ecp="VolumeUp")
+        self._add(
+            "vol_mute",
+            "M",
+            x,
+            top + seg,
+            self.side_w,
+            seg - self.pad,
+            role="key_alt",
+            ecp="VolumeMute",
+        )
+        self._add(
+            "vol_dn",
+            "-",
+            x,
+            top + 2 * seg,
+            self.side_w,
+            seg - self.pad,
+            role="transport",
+            ecp="VolumeDown",
+        )
+
+    def _layout_side_channel(self):
+        x = self.width - self.margin_x - self.side_w
+        top = self.pad + self.status_h + self.pad
+        bottom = self.height - self.pad
+        h = bottom - top
+        seg = h // 3
+        self._add("ch_up", "CH+", x, top, self.side_w, seg - self.pad, role="key", ecp="ChannelUp")
+        self._add(
+            "enter",
+            "ENT",
+            x,
+            top + seg,
+            self.side_w,
+            seg - self.pad,
+            role="key_alt",
+            ecp="Enter",
+        )
+        self._add(
+            "ch_dn",
+            "CH-",
+            x,
+            top + 2 * seg,
+            self.side_w,
+            seg - self.pad,
+            role="key",
+            ecp="ChannelDown",
+        )
+
+    def _layout_apps(self, x0, y0, w):
+        row_h = max(36, self.height // 14)
+        gap = self.pad
+        self._add("back_pg", "REMOTE", x0, y0, w // 3 - gap, row_h, role="ui")
+        self._add("apps_refresh", "REFRESH", x0 + w // 3, y0, w // 3 - gap, row_h, role="ui")
+        self._add("apps_next", "NEXT", x0 + 2 * w // 3, y0, w // 3, row_h, role="ui")
+        y = y0 + row_h + gap
+        # App list slots
+        slot_h = max(32, self.FONT_H * self.font_scale + 2 * self.pad)
+        apps = self.engine.apps or []
+        max_slots = max(1, (self.height - y - self.pad) // (slot_h + gap))
+        slice_apps = apps[self.app_offset : self.app_offset + max_slots]
+        if not slice_apps:
+            self._add("apps_empty", "(no apps — REFRESH)", x0, y, w, slot_h, role="key_alt")
+            return
+        for i, app in enumerate(slice_apps):
+            name = app.get("name") or app.get("id") or "?"
+            if len(name) > 18:
+                name = name[:17] + "."
+            self._add(
+                "app_%d" % i,
+                name,
+                x0,
+                y + i * (slot_h + gap),
+                w,
+                slot_h,
+                role="accent" if i == 0 else "key",
+                meta=app,
+            )
+
+    def _layout_more(self, x0, y0, w):
+        row_h = max(34, self.height // 16)
+        gap = self.pad
+        self._add("back_pg", "REMOTE", x0, y0, w // 2 - gap, row_h, role="ui")
+        self._add("ip_pg", "IP", x0 + w // 2, y0, w // 2, row_h, role="ui")
+        y = y0 + row_h + gap
+        actions = (
+            ("find_remote", "FIND REMOTE", "FindRemote"),
+            ("bs", "BACKSPACE", "Backspace"),
+            ("enter_k", "ENTER", "Enter"),
+            ("replay2", "REPLAY", "InstantReplay"),
+            ("dev_info", "DEV INFO", None),
+            ("media", "MEDIA", None),
+            ("tv_ch", "TV CH", None),
+            ("chanperf", "PERF", None),
+        )
+        cols = 2
+        bw = (w - gap) // cols
+        for i, (bid, lab, ecp) in enumerate(actions):
+            col = i % cols
+            row = i // cols
+            role = "ui" if ecp is None else "key"
+            self._add(
+                bid,
+                lab,
+                x0 + col * (bw + gap),
+                y + row * (row_h + gap),
+                bw,
+                row_h,
+                role=role,
+                ecp=ecp,
+            )
+
+    def _layout_ip(self, x0, y0, w):
+        row_h = max(34, self.height // 14)
+        gap = self.pad
+        self._add("back_pg", "BACK", x0, y0, w // 3 - gap, row_h, role="ui")
+        self._add("ip_clear", "CLR", x0 + w // 3, y0, w // 3 - gap, row_h, role="ui")
+        self._add("ip_ok", "SET", x0 + 2 * w // 3, y0, w // 3, row_h, role="accent")
+        y = y0 + row_h + gap
+        # Display current IP buffer as a fake label button
+        shown = self.ip_buf if self.ip_buf else "(empty)"
+        self._add("ip_disp", shown, x0, y, w, row_h, role="key_alt")
+        y += row_h + gap
+        keys = "123456789.0<"
+        cols = 3
+        bw = (w - gap * (cols - 1)) // cols
+        bh = row_h
+        for i, ch in enumerate(keys):
+            col = i % cols
+            row = i // cols
+            lab = "BS" if ch == "<" else ch
+            self._add(
+                "ipk_%d" % i,
+                lab,
+                x0 + col * (bw + gap),
+                y + row * (bh + gap),
+                bw,
+                bh,
+                role="key",
+                meta=ch,
+            )
+        y2 = y + 4 * (bh + gap)
+        if y2 + row_h < self.height - self.pad:
+            self._add("find", "DISCOVER", x0, y2, w, row_h, role="accent")
+
+    # ----- drawing --------------------------------------------------------
+
+    def _role_colors(self, role, pressed=False):
+        t = self.theme
+        if pressed:
+            return t["press_text"], t["press"], _shade(t["press"], 0.85), _shade(t["press"], 1.08)
+        if role == "accent":
+            face = t["accent"]
+            return t["ok_text"], face, t["accent2"], _shade(face, 1.15)
+        if role == "power":
+            face = t["power"]
+            return t["text"], face, _shade(face, 0.75), _shade(face, 1.12)
+        if role == "transport":
+            face = t["transport"]
+            return t["text"], face, _shade(face, 0.8), _shade(face, 1.12)
+        if role == "dpad":
+            face = t["key"]
+            return t["text"], face, _shade(face, 0.78), _shade(face, 1.14)
+        if role == "ui":
+            face = t["key_alt"]
+            return t["muted"], face, _shade(face, 0.8), _shade(face, 1.1)
+        if role == "key_alt":
+            face = t["key_alt"]
+            return t["text"], face, _shade(face, 0.8), _shade(face, 1.1)
+        face = t["key"]
+        return t["text"], face, _shade(face, 0.78), _shade(face, 1.12)
+
+    def _draw_chassis(self):
+        t = self.theme
+        # Vertical gradient background
+        h = self.height
+        for j in range(h):
+            c = _lerp(t["chassis"], t["chassis2"], j / (h - 1) if h > 1 else 0)
+            display_drv.fill_rect(0, j, self.width, 1, c)
+        # Inset bezel
+        m = max(2, self.pad // 2)
+        display_drv.rect(m, m, self.width - 2 * m, self.height - 2 * m, t["bezel"])
+
+    def _draw_button(self, btn, pressed=False):
+        x, y, w, h = btn.area.x, btn.area.y, btn.area.w, btn.area.h
+        if w <= 0 or h <= 0:
+            return
+        # Cap buffer use
+        if w * h * self.bpp > len(self.btn_ba):
+            # draw simplified fill without offscreen if too large
+            fg, face, lo, hi = self._role_colors(btn.role, pressed)
+            display_drv.fill_rect(x, y, w, h, face)
+            return
+
+        fg, face, lo, hi = self._role_colors(btn.role, pressed)
+        self.btn_fb = FrameBuffer(self.btn_ba, w, h, RGB565)
+        self.btn_fb.fill(self.theme["chassis"])
+        r = min(self.radius, w // 3, h // 3)
+
+        # 3D: top-lit gradient round rect
+        for j in range(h):
+            if j < r:
+                d = r - j
+            elif j >= h - r:
+                d = r - (h - 1 - j)
+            else:
+                d = 0
+            if d:
+                # approximate circular inset
+                inset = 0
+                rr = r * r
+                dd = d * d
+                # integer sqrt-ish: try
+                s = 0
+                while (s + 1) * (s + 1) <= rr - dd:
+                    s += 1
+                inset = r - s
+            else:
+                inset = 0
+            t = j / (h - 1) if h > 1 else 0
+            # pressed → invert lighting
+            if pressed:
+                c = _lerp(lo, hi, t)
+            else:
+                c = _lerp(hi, lo, t)
+            ww = w - 2 * inset
+            if ww > 0:
+                self.btn_fb.fill_rect(inset, j, ww, 1, c)
+
+        # Soft rim
+        self.btn_fb.round_rect(0, 0, w, h, r, _shade(face, 0.55), False)
+
+        text = btn.label
+        scale = self.font_scale
+        while scale > 1 and len(text) * self.FONT_W * scale > w - 4:
+            scale -= 1
+        tw = len(text) * self.FONT_W * scale
+        th = self.FONT_H * scale
+        tx = max(0, (w - tw) // 2)
+        ty = max(0, (h - th) // 2)
+        if scale != 1:
+            self.btn_fb.text16(text, tx, ty, fg, scale)
+        else:
+            self.btn_fb.text16(text, tx, ty, fg)
+        display_drv.blit_rect(self.btn_ba[: w * h * self.bpp], x, y, w, h)
+
+    def _draw_status(self):
+        t = self.theme
+        y = self.pad
+        x = self.pad
+        w = self.width - 2 * self.pad
+        h = self.status_h
+        display_drv.fill_rect(x, y, w, h, t["status_bg"])
+        display_drv.rect(x, y, w, h, t["bezel"])
+        line = self._status_line or self.engine.status
+        if self.page == "ip":
+            line = "IP " + (self.ip_buf or "…")
+        elif self.page == "more" and self._dev_dump:
+            line = self._dev_dump[: max(8, w // (self.FONT_W * self.font_scale))]
+        scale = self.font_scale
+        max_chars = max(4, (w - 2 * self.pad) // (self.FONT_W * scale))
+        if len(line) > max_chars:
+            line = line[: max_chars - 1] + "."
+        # Use scratch for text band
+        if w * h * self.bpp <= len(self.btn_ba):
+            self.btn_fb = FrameBuffer(self.btn_ba, w, h, RGB565)
+            self.btn_fb.fill(t["status_bg"])
+            ty = max(0, (h - self.FONT_H * scale) // 2)
+            if scale != 1:
+                self.btn_fb.text16(line, self.pad, ty, t["muted"], scale)
+            else:
+                self.btn_fb.text16(line, self.pad, ty, t["muted"])
+            display_drv.blit_rect(self.btn_ba[: w * h * self.bpp], x, y, w, h)
+        else:
+            display_drv.fill_rect(x, y, w, h, t["status_bg"])
+
+    def _draw_all(self):
+        self._draw_chassis()
+        self._draw_status()
+        for btn in self.buttons:
+            self._draw_button(btn, pressed=False)
+        display_drv.show()
+
+    def _refresh_status(self):
+        self._status_line = self.engine.status
+        self._draw_status()
+        display_drv.show()
+
+    # ----- interaction ----------------------------------------------------
+
+    def _hit(self, pos):
+        for btn in self.buttons:
+            if btn.area.contains(pos):
+                return btn
+        return None
+
+    def _flash(self, btn):
+        self._pressed_id = btn.id
+        self._draw_button(btn, pressed=True)
+        display_drv.show()
+        self._release_timer.init(mode=Timer.ONE_SHOT, period=120, callback=self._release)
+
+    def _release(self, _=None):
+        bid = self._pressed_id
+        self._pressed_id = None
+        if bid and bid in self._by_id:
+            self._draw_button(self._by_id[bid], pressed=False)
+            display_drv.show()
+
+    def _on_mouse(self, e):
+        btn = self._hit(e.pos)
+        if btn is None:
+            return
+        self._activate(btn)
+
+    def _on_key(self, e):
+        key = e.key
+        mapping = {
+            Keys.K_UP: "Up",
+            Keys.K_DOWN: "Down",
+            Keys.K_LEFT: "Left",
+            Keys.K_RIGHT: "Right",
+            Keys.K_RETURN: "Select",
+            Keys.K_KP_ENTER: "Select",
+            Keys.K_ESCAPE: "Back",
+            Keys.K_BACKSPACE: "Backspace",
+            Keys.K_h: "Home",
+            Keys.K_i: "Info",
+            Keys.K_SPACE: "Play",
+        }
+        ecp = mapping.get(key)
+        if ecp:
+            self.engine.press(ecp)
+            self._status_line = self.engine.status
+            self._refresh_status()
+
+    def _set_page(self, page):
+        self.page = page
+        self._build_layout()
+        self._draw_all()
+
+    def _activate(self, btn):
+        self._flash(btn)
+        bid = btn.id
+
+        if bid == "theme":
+            i = _THEME_NAMES.index(self.theme_name)
+            self.theme_name = _THEME_NAMES[(i + 1) % len(_THEME_NAMES)]
+            self.theme = _THEMES[self.theme_name]
+            self._status_line = "theme: " + self.theme_name
+            self._draw_all()
+            return
+
+        if bid == "apps_pg":
+            self._set_page("apps")
+            return
+        if bid == "more_pg":
+            self._set_page("more")
+            return
+        if bid == "ip_pg":
+            self.ip_buf = self.engine.host or self.ip_buf
+            self._set_page("ip")
+            return
+        if bid == "back_pg":
+            self._set_page("remote")
+            return
+
+        if bid == "find":
+            self._status_line = "scanning…"
+            self._refresh_status()
+            devices = self.engine.discover(timeout=2.5)
+            self.discover_list = devices
+            if devices:
+                self.engine.set_host(devices[0]["host"])
+                self.ip_buf = self.engine.host
+                self.engine.connect(discover_if_empty=False)
+                self._status_line = "found %d · %s" % (len(devices), self.engine.status)
+            else:
+                self._status_line = self.engine.last_error or "no Roku found"
+            if self.page == "ip":
+                self._build_layout()
+                self._draw_all()
+            else:
+                self._refresh_status()
+            return
+
+        if bid == "apps_refresh":
+            self.engine.query_apps()
+            self.app_offset = 0
+            self._status_line = "%d apps" % len(self.engine.apps)
+            self._build_layout()
+            self._draw_all()
+            return
+
+        if bid == "apps_next":
+            n = len(self.engine.apps)
+            if n:
+                self.app_offset = (self.app_offset + 4) % n
+            self._build_layout()
+            self._draw_all()
+            return
+
+        if bid.startswith("app_") and btn.meta:
+            app = btn.meta
+            ok = self.engine.launch(app.get("id", ""))
+            self._status_line = ("launched " if ok else "fail ") + (app.get("name") or "")
+            try:
+                self.engine.query_active_app()
+            except Exception:
+                pass
+            self._refresh_status()
+            return
+
+        if bid == "ip_clear":
+            self.ip_buf = ""
+            self._build_layout()
+            self._draw_all()
+            return
+
+        if bid == "ip_ok":
+            self.engine.set_host(self.ip_buf)
+            self.engine.connect(discover_if_empty=False)
+            self._status_line = self.engine.status
+            self._set_page("remote")
+            return
+
+        if bid.startswith("ipk_") and btn.meta is not None:
+            ch = btn.meta
+            if ch == "<":
+                self.ip_buf = self.ip_buf[:-1]
+            else:
+                if len(self.ip_buf) < 15:
+                    self.ip_buf += ch
+            self._build_layout()
+            self._draw_all()
+            return
+
+        if bid == "dev_info":
+            info = self.engine.query_device_info()
+            self._dev_dump = info.get("model-name", "") + " " + info.get("power-mode", "")
+            self._status_line = self._dev_dump or self.engine.last_error or "no info"
+            self._refresh_status()
+            return
+
+        if bid == "media":
+            raw = self.engine.query_media_player()
+            self._dev_dump = (raw.replace("\n", " ")[:48]) if raw else "no media"
+            self._status_line = self._dev_dump
+            self._refresh_status()
+            return
+
+        if bid == "tv_ch":
+            raw = self.engine.query_tv_active_channel() or self.engine.query_tv_channels()
+            self._dev_dump = (raw.replace("\n", " ")[:48]) if raw else "n/a"
+            self._status_line = self._dev_dump
+            self._refresh_status()
+            return
+
+        if bid == "chanperf":
+            raw = self.engine.query_chanperf()
+            self._dev_dump = (raw.replace("\n", " ")[:48]) if raw else self.engine.last_error
+            self._status_line = self._dev_dump or "perf n/a"
+            self._refresh_status()
+            return
+
+        if btn.ecp:
+            self.engine.press(btn.ecp)
+            if btn.ecp in ("Home", "Select", "Launch"):
+                try:
+                    self.engine.query_active_app()
+                except Exception:
+                    pass
+            self._status_line = self.engine.status
+            self._refresh_status()
+
+
+remote = _Remote()
+runtime.run_forever()

--- a/web/pyscript/index.html
+++ b/web/pyscript/index.html
@@ -470,6 +470,17 @@
                     <div class="card-top">
                         <span class="card-icon"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect x="2" y="3" width="20" height="14" rx="2"/><path d="M8 21h8M12 17v4"/></svg></span>
                     </div>
+                    <h3>Roku Remote</h3>
+                    <p>Museum-quality portrait Roku remote drawn with ``graphics.FrameBuffer``.</p>
+                    <div class="card-runtimes">
+                        <a class="go" href="micropython.html?modules=roku_remote,roku_engine">MicroPython <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M5 12h14M13 6l6 6-6 6"/></svg></a>
+                        <a class="go" href="pyodide.html?modules=roku_remote,roku_engine">Pyodide <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M5 12h14M13 6l6 6-6 6"/></svg></a>
+                    </div>
+                </article>
+                <article class="card">
+                    <div class="card-top">
+                        <span class="card-icon"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect x="2" y="3" width="20" height="14" rx="2"/><path d="M8 21h8M12 17v4"/></svg></span>
+                    </div>
                     <h3>Rotations</h3>
                     <p>Rotates the display 0, 90, 180, and 270 degrees and displays the rotation</p>
                     <div class="card-runtimes">


### PR DESCRIPTION
## Summary

Adds a two-file pydisplay example that controls a Roku over the LAN via the External Control Protocol:

- **`src/examples/roku_engine.py`** — pure ECP client (`# gallery: skip`): portable HTTP GET/POST, SSDP `roku:ecp` discovery, all documented keypress keys, apps/launch/install, device/media/TV queries, and developer-mode query wrappers. No UI imports.
- **`src/examples/roku_remote.py`** — museum-quality portrait remote (`# modules: roku_engine`): scales from 320×480 classic chrome to tall-phone layouts with side volume/channel, theme switcher (midnight/graphite/ocean/ember), Discover + IP pad, apps rail, and a More sheet for extras. 3D bevelled buttons via offscreen `FrameBuffer`. Core packages only (`graphics` / `displaysys` / `eventsys` / `multimer`).

## Usage

1. Enable Roku **Control by mobile apps**.
2. Set `ROKU_HOST` or leave empty and tap **SCAN** / Discover.
3. Run with a portrait `board_config` (e.g. pgdisplay 320×480 or taller).

## Testing

- CPython + MicroPython unix: mocked HTTP covers connect/press/launch/apps/XML parse and all 29 ECP keys.
- MicroPython unix: fake `board_config` smoke-tested expanded (volume sides) and compact layouts, theme/apps/IP pages.