### PR TITLE
Document pip name pydisplay-graphics (not graphics-py)

### DIFF
--- a/.cursor/testpypi-naming-convention.md
+++ b/.cursor/testpypi-naming-convention.md
@@ -5,7 +5,7 @@ PyDevices publishes **CPython wheels to TestPyPI only** (not production PyPI). E
 | Role | Example | Used by |
 |------|---------|---------|
 | **MIP / micropython-lib** | `graphics` | `mip.install("graphics", index=…)`, manifest `package("graphics")` |
-| **pip / TestPyPI project** | `graphics-py` | `pip install … graphics-py`, hatch `[project].name` |
+| **pip / TestPyPI project** | `pydisplay-graphics` | `pip install … pydisplay-graphics`, hatch `[project].name` |
 | **Python import** | `graphics` | `import graphics` in application code |
 
 MIP names stay short. pip project names must **not collide with [pypi.org](https://pypi.org)** — TestPyPI rejects sdists when the normalized name is already registered there (wheels may still upload; treat collisions as errors).
@@ -29,9 +29,16 @@ When the MIP name is **taken on pypi.org**, prefix with `pydisplay-`:
 
 | MIP name | pip / TestPyPI | Import | Why |
 |----------|----------------|--------|-----|
-| `graphics` | **`graphics-py`** | `graphics` | [pypi.org/project/graphics](https://pypi.org/project/graphics) exists |
+| `graphics` | **`pydisplay-graphics`** | `graphics` | [pypi.org/project/graphics](https://pypi.org/project/graphics) exists |
 
-Mapping lives in `pypi_publish_name()` in [`scripts/publish_sync_packages.sh`](../scripts/publish_sync_packages.sh). MIP and source trees keep the short name `graphics/`.
+Mapping lives in the owning repo’s publish script (graphics: `PYPI_NAME` in
+[`publish_micropython_lib.sh`](https://github.com/PyDevices/graphics/blob/main/scripts/publish_micropython_lib.sh)).
+MIP and source trees keep the short name `graphics/`.
+
+**PEP 503:** pip normalizes `-`, `_`, and `.` to `-`. Never use a `*-py`
+suffix when a `*.py` project exists on pypi.org — `graphics-py` collides with
+[graphics.py](https://pypi.org/project/graphics.py/) (Zelle), so a two-index
+install can pull the wrong package. Do not revive `graphics-py`.
 
 ### 3. Native CPython extensions (separate repos): suffix disambiguation
 
@@ -44,7 +51,7 @@ Use a **repo-specific suffix** so pip names are unique and intent is obvious:
 
 Do **not** publish as bare `lvgl` — [pypi.org/project/lvgl](https://pypi.org/project/lvgl) exists.
 
-`graphics-cmod` and `graphics-py` (both from [PyDevices/graphics](https://github.com/PyDevices/graphics)) provide `import graphics`; prefer **`graphics-cmod`** on desktop/Android when the native wheel matches the platform, and **`graphics-py`** for pure-Python-only or cross-check installs.
+`graphics-cmod` and `pydisplay-graphics` (both from [PyDevices/graphics](https://github.com/PyDevices/graphics)) provide `import graphics`; prefer **`graphics-cmod`** on desktop/Android when the native wheel matches the platform, and **`pydisplay-graphics`** for pure-Python-only or cross-check installs.
 
 ### 4. displaysys is one package
 
@@ -82,7 +89,7 @@ After a version is on TestPyPI, **do not rename** the project (TestPyPI rejects 
 | `displaysys` | `displaysys` | `displaysys`, `board_config` | free |
 | `eventsys` | `eventsys` | `eventsys` | free |
 | `multimer` | `multimer` | `multimer` | free |
-| `graphics` | **`graphics-py`** | `graphics` | **taken** → mapped |
+| `graphics` | **`pydisplay-graphics`** | `graphics` | **taken** → mapped |
 
 ### Sibling repos (own workflows)
 

--- a/.cursor/testpypi-publish-audit.md
+++ b/.cursor/testpypi-publish-audit.md
@@ -28,7 +28,7 @@ Audited **2026-07-08** from local clones under `~/github/cmods` and `~/github/py
 | `displaysys` | `displaysys-0.0.7-py2.py3-none-any.whl` | universal; full tree + `board_config.py` |
 | `eventsys` | `eventsys-0.0.7-py2.py3-none-any.whl` | universal |
 | `multimer` | `multimer-0.0.7-py2.py3-none-any.whl` | universal |
-| `graphics-py` | `pydisplay_graphics-0.0.7-py2.py3-none-any.whl` | universal (PyPI name mapped from `graphics`) |
+| `pydisplay-graphics` | `pydisplay_graphics-0.0.7-py2.py3-none-any.whl` | universal (PyPI name mapped from `graphics`) |
 
 **Layout:** `displaysys` is the full package (all modules under `src/lib/displaysys/` plus `board_config.py`). Per-backend `displaysys-*` packages are **not** published. Published packages do not include `examples/` trees.
 
@@ -84,7 +84,7 @@ Both use the same shape: matrix `ubuntu-latest` + `windows-latest`, plus a dedic
 | Category | Status |
 |----------|--------|
 | **Native CPython extensions** (`lvgl-cpython`, `graphics-cmod`) | **Met** — CI builds linux + windows + android wheels |
-| **Pure pydisplay libs** (`displaysys`, `eventsys`, `multimer`, `graphics-py`) | **Met by design** — universal wheels; manifest `require()` graph in § Pip dependency graph |
+| **Pure pydisplay libs** (`displaysys`, `eventsys`, `multimer`, `pydisplay-graphics`) | **Met by design** — universal wheels; manifest `require()` graph in § Pip dependency graph |
 | **usdl2** | **Met for CPython shim** — universal wheel; MP cmod is separate |
 | **displayif** | **N/A** — firmware-only user C module, not a pip/MIP package |
 | **displaysys-* backends** | **Removed** — use full `displaysys` only |

--- a/docs/platforms/circuitpython.md
+++ b/docs/platforms/circuitpython.md
@@ -108,7 +108,7 @@ frozen asyncio still uses `adafruit_ticks` internally unless the build is custom
 
 CircuitPython lacks MicroPython-compatible `framebuf`. Use the `framebuf` module
 from [PyDevices/graphics](https://github.com/PyDevices/graphics)
-(`lib/graphics/framebuf.py`, MIP `graphics` / TestPyPI `graphics-py`).
+(`lib/graphics/framebuf.py`, MIP `graphics` / TestPyPI `pydisplay-graphics`).
 
 ## Installers
 

--- a/docs/publishing-micropython-lib.md
+++ b/docs/publishing-micropython-lib.md
@@ -57,7 +57,7 @@ Tags must match `v*.*.*` (e.g. `v0.0.5`, not `0.0.5`).
 Pushing the tag starts [**Publish micropython-lib**](https://github.com/PyDevices/pydisplay/actions/workflows/publish-micropython-lib.yml), which:
 
 1. Syncs `src/lib/*` into [micropython-lib](https://github.com/PyDevices/micropython-lib) (`PyDevices` branch) at version `X.Y.Z`
-2. Uploads CPython wheels to TestPyPI (`displaysys`, `eventsys`, `multimer`, …). Pure-Python `graphics` publishes from [PyDevices/graphics](https://github.com/PyDevices/graphics) as `graphics-py`.
+2. Uploads CPython wheels to TestPyPI (`displaysys`, `eventsys`, `multimer`, …). Pure-Python `graphics` publishes from [PyDevices/graphics](https://github.com/PyDevices/graphics) as `pydisplay-graphics`.
 3. Rebuilds the [MIP index](https://PyDevices.github.io/micropython-lib/mip/PyDevices) on micropython-lib `gh-pages`
 
 Typical runtime: **~10–20 minutes**.
@@ -192,7 +192,7 @@ Or `mpremote mip install --index "https://PyDevices.github.io/micropython-lib/mi
 
 ### TestPyPI
 
-PyDevices CPython wheels are published to [TestPyPI](https://test.pypi.org) only (not production PyPI). Browse package names there (`displaysys`, `eventsys`, `multimer`, `graphics-py`, …).
+PyDevices CPython wheels are published to [TestPyPI](https://test.pypi.org) only (not production PyPI). Browse package names there (`displaysys`, `eventsys`, `multimer`, `pydisplay-graphics`, …).
 
 **Naming:** MIP package names (e.g. `graphics`) may differ from the pip/TestPyPI project name when the MIP name is already taken on pypi.org. The mapping lives in `pypi_publish_name()` in [`publish_sync_packages.sh`](https://github.com/PyDevices/pydisplay/blob/main/scripts/publish_sync_packages.sh).
 
@@ -268,7 +268,7 @@ Script options: `./scripts/publish_sync_packages.sh --help`
 |--------|------------|
 | Version already exists | Push a **new tag** with a higher semver — TestPyPI rejects duplicate versions |
 | Upload fails mid-run | Partial uploads may succeed; fix the error, bump the tag, push again |
-| `graphics` packaging | Pure-Python `graphics` / `graphics-py` is published from [PyDevices/graphics](https://github.com/PyDevices/graphics), not this repo. |
+| `graphics` packaging | Pure-Python `graphics` / `pydisplay-graphics` is published from [PyDevices/graphics](https://github.com/PyDevices/graphics), not this repo. |
 | Slow | Normal — each lib package gets hatch build + twine upload |
 | Not for devices | Boards use the **MIP index**, not TestPyPI |
 

--- a/scripts/publish_sync_packages.sh
+++ b/scripts/publish_sync_packages.sh
@@ -150,7 +150,7 @@ should_skip_name() {
 }
 
 # MIP package names may differ from PyPI project names when needed.
-# graphics publishes from PyDevices/graphics (graphics-py), not this repo.
+# graphics publishes from PyDevices/graphics (pydisplay-graphics), not this repo.
 # Convention: .cursor/testpypi-naming-convention.md
 pypi_publish_name() {
     echo "$1"

--- a/src/lib/displaysys/README.md
+++ b/src/lib/displaysys/README.md
@@ -47,7 +47,7 @@ Desktop input backends use [eventsys](https://test.pypi.org/project/eventsys/) a
 - [Documentation — Displays](https://pydisplay.readthedocs.io/en/latest/concepts/displays/)
 - [Source](https://github.com/PyDevices/pydisplay)
 - [Issues](https://github.com/PyDevices/pydisplay/issues)
-- Related: [eventsys](https://test.pypi.org/project/eventsys/), [multimer](https://test.pypi.org/project/multimer/), [graphics-py](https://test.pypi.org/project/graphics-py/), [usdl2](https://test.pypi.org/project/usdl2/), [usdl2-py](https://test.pypi.org/project/usdl2-py/)
+- Related: [eventsys](https://test.pypi.org/project/eventsys/), [multimer](https://test.pypi.org/project/multimer/), [pydisplay-graphics](https://test.pypi.org/project/pydisplay-graphics/), [usdl2](https://test.pypi.org/project/usdl2/), [usdl2-py](https://test.pypi.org/project/usdl2-py/)
 
 ## License
 

--- a/tools/README.md
+++ b/tools/README.md
@@ -106,7 +106,7 @@ Installs `displaysys`, `usdl2`, `graphics-cmod`, and `lvgl-cpython` (no version 
 
 | Script | Purpose |
 |--------|---------|
-| [`test_testpypi_standalone.sh`](test_testpypi_standalone.sh) | Per-package TestPyPI venv import smoke (`multimer`, `displaysys`, `eventsys`, `graphics-py`; `--desktop` adds backend stacks) |
+| [`test_testpypi_standalone.sh`](test_testpypi_standalone.sh) | Per-package TestPyPI venv import smoke (`multimer`, `displaysys`, `eventsys`, `pydisplay-graphics`; `--desktop` adds backend stacks) |
 
 ```bash
 ./tools/test_testpypi_standalone.sh

--- a/tools/test_testpypi_standalone.sh
+++ b/tools/test_testpypi_standalone.sh
@@ -91,7 +91,7 @@ r.start_timer()
 print('eventsys', type(r).__name__)
 "
 
-test_package graphics-py "import graphics; print('graphics', graphics.implementation())"
+test_package pydisplay-graphics "import graphics; print('graphics', graphics.implementation())"
 
 if [[ "$DESKTOP" -eq 1 ]]; then
     # usdl2 / pygame-ce are runtime deps, not pip requires of the displaysys wheel.


### PR DESCRIPTION
## Summary

Align docs and TestPyPI smoke tooling with **`pydisplay-graphics`**. Naming convention notes that `graphics-py` must not be revived (PEP 503 collision with `graphics.py`).

## Related

- PyDevices/graphics rename PR
- PyDevices/pdwidgets dependency update