### PR TITLE
Document full RTD API surface for core packages

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -71,3 +71,4 @@ htmlcov/
 .ipynb_checkpoints
 docs/_build/
 /site
+.cache/

--- a/docs/concepts/drawing-and-fonts.md
+++ b/docs/concepts/drawing-and-fonts.md
@@ -1,6 +1,6 @@
 # Drawing and fonts
 
-**Start here for the `pygraphics` library:** [graphics](pygraphics.md) — quick start, FrameBuffer vs Draw, Area bounds, fonts, and loaders.
+**Start here for the `pygraphics` library:** [graphics](graphics.md) — quick start, FrameBuffer vs Draw, Area bounds, fonts, and loaders.
 
 This page covers how `pygraphics` fits into the wider pydisplay stack.
 
@@ -8,7 +8,7 @@ This page covers how `pygraphics` fits into the wider pydisplay stack.
 
 | Need | Use |
 |------|-----|
-| Buffer + shapes + Area bounds | [`pygraphics`](pygraphics.md) — `FrameBuffer` or `Draw` |
+| Buffer + shapes + Area bounds | [`pygraphics`](graphics.md) — `FrameBuffer` or `Draw` |
 | Basic pixels on a display | `framebuf` API on display or buffer |
 | Peter Hinch scrollable buffer | `add_ons/displaybuf.DisplayBuffer` |
 | CPython without importing add-ons | `pygraphics` (bundles pure-Python framebuf) |
@@ -25,15 +25,15 @@ Use `Draw(canvas)` when you prefer a separate drawer object over subclassing.
 
 | Mechanism | Source | Notes |
 |-----------|--------|-------|
-| `pygraphics.text8` / `text14` / `text16` | Embedded romfont in `pygraphics` (`_font_8x*.py`) | Default; transparent; per-pixel on canvas — [patterns](pygraphics.md#choosing-a-font-rendering-pattern) |
-| `pygraphics.Font(path, height)` | Romfont [`.bin` on disk](pygraphics.md#loading-romfont-bin-files-from-the-filesystem) | Optional; use with any pattern below |
+| `pygraphics.text8` / `text14` / `text16` | Embedded romfont in `pygraphics` (`_font_8x*.py`) | Default; transparent; per-pixel on canvas — [patterns](graphics.md#choosing-a-font-rendering-pattern) |
+| `pygraphics.Font(path, height)` | Romfont [`.bin` on disk](graphics.md#loading-romfont-bin-files-from-the-filesystem) | Optional; use with any pattern below |
 | `pygraphics.Font(height=8)` | Embedded romfont for that height | Same bytes as `text8` / `text14` / `text16` |
 | String FB + `blit_rect` | [`font_simpletest.py`](../examples/font_simpletest.py) (`string_blit` phase) | Opaque bg; low RAM; one blit per string — good desktop + tight MCU RAM |
 | `Font.text(display_drv, …)` | [`font_simpletest.py`](../examples/font_simpletest.py) (`per_pixel` phase) | Transparent; lowest RAM; slowest on SPI |
 | `DisplayBuffer` + `show(dirty)` | [`font_simpletest.py`](../examples/font_simpletest.py) (`displaybuf` phase) | Transparent; full-screen RAM; fastest repeated text on MCU |
 | `tft_text.text()` | @russhughes text_font_converter | Width 8 or 16, height multiples of 8 |
 | `tft_write.write()` | @russhughes write_font_converter | Proportional fonts |
-| `framebuf.text()` | Damien `font_petme128_8x8` | MP framebuf API only; not romfont — see [Fonts in graphics](pygraphics.md#not-the-same-as-framebuftext) |
+| `framebuf.text()` | Damien `font_petme128_8x8` | MP framebuf API only; not romfont — see [Fonts in graphics](graphics.md#not-the-same-as-framebuftext) |
 
 Peter Hinch's **Writer** (MicroPython-Touch) may be used on MicroPython but does not return Area objects.
 

--- a/docs/concepts/graphics-files.md
+++ b/docs/concepts/graphics-files.md
@@ -4,7 +4,7 @@ Two layers: **pygraphics package loaders** (eager, full image in RAM) and **pydi
 
 ## pygraphics package loaders
 
-Built into [`pygraphics`](pygraphics.md):
+Built into [`pygraphics`](graphics.md):
 
 | Function | Format |
 |----------|--------|

--- a/docs/contributing/docstrings.md
+++ b/docs/contributing/docstrings.md
@@ -38,10 +38,11 @@ See also: https://pydisplay.readthedocs.io/en/latest/concepts/displays/
 
 ## pydisplay-specific notes
 
-- **`Area` returns:** Many `pygraphics` methods return an `Area` (`x`, `y`, `w`, `h`) for partial refresh.
+- **`Area` returns:** Drawing helpers that return dirty regions use `pygraphics.Area` (`x`, `y`, `w`, `h`).
 - **Runtime:** Document poll/subscribe patterns; link to [Events concept](../concepts/events.md).
-- **Delegates:** `Draw` and `FrameBuffer` shape methods delegate to `pygraphics._shapes` — signatures must match.
 - **Private API:** Names starting with `_` are excluded from mkdocstrings output; minimal or no docstrings are fine.
+  Document public methods that live on private implementation bases when they surface via inheritance
+  (e.g. `multimer.Timer` ← `_TimerCore.init` / `deinit` with `inherited_members: true`).
 
 ## Verification
 
@@ -57,8 +58,8 @@ Griffe warnings mean a docstring parameter does not appear in the signature — 
 
 | Tier | Modules |
 |------|---------|
-| P0 | `displaysys`, `eventsys`, `pygraphics.FrameBuffer`, `pygraphics._shapes` |
-| P1 | `pygraphics.Draw`, `displaybuf`, `eventsys` helpers |
-| P2 | ✅ `pdwidgets` — done: Google-style docstrings on all public classes/methods (lifecycle `Display.tick`/`render`/event registration + every widget) |
+| P0 | `displaysys`, `eventsys`, `multimer` |
+| P1 | `displaybuf`, `display_driver`, `console`, other `add_ons` |
+| P2 | Sibling packages document their own APIs: [pygraphics](https://pygraphics.readthedocs.io), [pdwidgets](https://pdwidgets.readthedocs.io), [palettes](https://palettes.readthedocs.io) |
 
 See [Contributing](../contributing.md) for the PR workflow.

--- a/docs/examples/index.md
+++ b/docs/examples/index.md
@@ -106,7 +106,7 @@ board_config.runtime.run_forever()
 
 ### Notes
 
-- `font_simpletest.py` — cycles `string_blit` → `per_pixel` → `displaybuf` in one run (see [Font rendering patterns](../concepts/pygraphics.md#choosing-a-font-rendering-pattern)).
+- `font_simpletest.py` — cycles `string_blit` → `per_pixel` → `displaybuf` in one run (see [Font rendering patterns](../concepts/graphics.md#choosing-a-font-rendering-pattern)).
 - `nano_gui_simpletest.py` / `micro_gui_simpletest.py` / `touch_gui_simpletest.py` need the matching Peter Hinch `gui/` in `add_ons/` (via `fetch_ph_gui` / mip).
 **Legend:** Platforms = CPython · MCU · PyScript · Wokwi · Packages = core · add_ons · LVGL
 

--- a/docs/reference/overviews/graphics.md
+++ b/docs/reference/overviews/graphics.md
@@ -2,7 +2,7 @@ graphics extends `framebuf` with extra drawing helpers (rounded rectangles, grad
 
 ## Narrative docs
 
-- [graphics concept](../../concepts/pygraphics.md) — quick start, font rendering patterns, loaders
+- [graphics concept](../../concepts/graphics.md) — quick start, font rendering patterns, loaders
 - [Drawing and fonts](../../concepts/drawing-and-fonts.md) — pydisplay drawing stack
 - [Graphics files](../../concepts/graphics-files.md) — loaders and BMP565
 
@@ -12,7 +12,7 @@ graphics extends `framebuf` with extra drawing helpers (rounded rectangles, grad
 - `pygraphics.Draw` — draws on any framebuf-compatible canvas
 - `pygraphics.Area` — dirty rectangle with union/clip helpers
 - Module functions — `circle`, `rect`, `text8`, … (same primitives as FrameBuffer)
-- `pygraphics.Font` — romfont renderer; built-in embedded fonts or optional `.bin` path ([Fonts](../../concepts/pygraphics.md#fonts))
+- `pygraphics.Font` — romfont renderer; built-in embedded fonts or optional `.bin` path ([Fonts](../../concepts/graphics.md#fonts))
 - `load_image`, `save_image` — auto-detect load / format-aware save
 - `bmp_to_framebuffer`, `pbm_to_framebuffer`, `pgm_to_framebuffer` — image loaders
 - `BMP565` — sliceable/streaming RGB565 BMP asset

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -99,7 +99,7 @@ nav:
     - Runtime: concepts/runtime.md
     - multimer: concepts/multimer.md
     - Drawing and fonts: concepts/drawing-and-fonts.md
-    - Graphics: concepts/pygraphics.md
+    - Graphics: concepts/graphics.md
     - Graphics files: concepts/graphics-files.md
     - Config files: concepts/config-files.md
   - Portability & platforms:
@@ -137,7 +137,7 @@ nav:
   - Package overviews:
     - displaysys: reference/overviews/displaysys.md
     - eventsys: reference/overviews/eventsys.md
-    - graphics: reference/overviews/pygraphics.md
+    - graphics: reference/overviews/graphics.md
     - multimer: reference/overviews/multimer.md
   - Core modules: reference/
   - Add-ons API: reference/add_ons/

--- a/scripts/mkdocs_gen_ref_pages.py
+++ b/scripts/mkdocs_gen_ref_pages.py
@@ -10,12 +10,13 @@ nav = mkdocs_gen_files.Nav()
 root = Path(__file__).parent.parent
 
 # (source tree, output prefix under reference/, nav prefix, extra sys.path entries)
+# pygraphics lives in the sibling PyDevices/pygraphics repo — not under src/lib.
 SOURCE_TREES = (
     (
         root / "src/lib",
         Path("reference"),
         (),
-        ("", "displaysys", "eventsys", "pygraphics", "multimer"),
+        ("", "displaysys", "eventsys", "multimer"),
     ),
     (
         root / "src/add_ons",
@@ -30,13 +31,18 @@ SKIP_DIR_NAMES = {"__pycache__", "fonts"}
 ADD_ONS_SKIP_DIR_NAMES = {"gui"}
 
 
-def _should_skip(path: Path, parts: tuple[str, ...]) -> bool:
+def _should_skip(parts: tuple[str, ...]) -> bool:
+    """Skip private modules/packages and non-documentable names."""
+    if not parts:
+        return True
     if any(part in SKIP_DIR_NAMES for part in parts):
         return True
     if any(part.endswith(".bak") for part in parts):
         return True
-    name = parts[-1]
-    return name == "__main__" or name.startswith("_")
+    # Any underscore path segment is private (e.g. multimer/_backends/…).
+    if any(part.startswith("_") for part in parts):
+        return True
+    return parts[-1] == "__main__"
 
 
 for src, ref_prefix, nav_prefix, path_entries in SOURCE_TREES:
@@ -62,7 +68,8 @@ for src, ref_prefix, nav_prefix, path_entries in SOURCE_TREES:
             parts = parts[:-1]
             doc_path = doc_path.with_name("index.md")
             full_doc_path = full_doc_path.with_name("index.md")
-        elif _should_skip(path, parts):
+
+        if _should_skip(parts):
             continue
 
         nav[nav_prefix + parts] = full_doc_path.relative_to("reference").as_posix()

--- a/src/add_ons/console.py
+++ b/src/add_ons/console.py
@@ -85,6 +85,25 @@ class Console(io.IOBase):
         timer_period=1000,  # Timer period for status bar
         readobj=None,  # Object to read from, such as a keyboard queue
     ):
+        """Create a scrolling text console on ``display_drv``.
+
+        Args:
+            display_drv: Display with ``vscrdef`` / ``vscsad`` / ``fill_rect`` /
+                ``blit_rect`` (or a custom ``char_writer``).
+            char_writer: Optional ``(char, x, y, fg, bg)`` glyph writer.
+            title: Title-bar text.
+            left: Left status-bar text (or callable returning text).
+            middle: Middle status-bar text (or callable).
+            right: Right status-bar text (or callable).
+            cwidth: Character cell width in pixels.
+            lheight: Line / cell height in pixels.
+            bgcolor: Background color.
+            fgcolor: Foreground color.
+            tfa: Top fixed area height (default ``lheight``).
+            bfa: Bottom fixed area height (default ``lheight``).
+            timer_period: Milliseconds between status-bar refreshes.
+            readobj: Optional object with ``read`` / ``readinto`` for dupterm.
+        """
         self.display_drv = display_drv
         self._cwidth = cwidth
         self._lheight = lheight
@@ -134,6 +153,7 @@ class Console(io.IOBase):
         self.show()
 
     def show(self):
+        """Lay out title/status bars, enable vertical scroll, and clear the text area."""
         self.width = self.display_drv.width
         self.height = self.display_drv.height
         self._vsa = self.height - self._tfa - self._bfa  # Vertical scroll area
@@ -155,6 +175,7 @@ class Console(io.IOBase):
         self.cls()
 
     def cls(self):
+        """Clear the scrollable text area and reset the cursor."""
         self.x = 0
         self.y = 0
         self.y_end = 0
@@ -163,12 +184,21 @@ class Console(io.IOBase):
         self.display_drv.fill_rect(0, self._tfa, self.width, self._vsa, self.bgcolor)
 
     def hide(self):
+        """Stop the status timer and blank the whole display."""
         if self._timer:
             self._timer.deinit()
         self.display_drv.vscsad(0)
         self.display_drv.fill_rect(0, 0, self.width, self.height, 0)
 
     def label(self, pos, param, fg=0, bg=-1):
+        """Set a title or status-bar label.
+
+        Args:
+            pos: :attr:`TITLE`, :attr:`LEFT`, :attr:`MIDDLE`, or :attr:`RIGHT`.
+            param: String text, or a zero-arg callable returning text.
+            fg: Foreground color for the label.
+            bg: Background color for the label band.
+        """
         self._labels[pos] = (param, fg, bg)
         if isinstance(param, str):
             self._write_label(pos, param, fg, bg)
@@ -236,6 +266,15 @@ class Console(io.IOBase):
             return b""
 
     def readinto(self, buf, nbytes=0):
+        """Read bytes into ``buf`` (dupterm / ``io.IOBase`` interface).
+
+        Args:
+            buf: Destination bytearray / memoryview.
+            nbytes: Max bytes to read; ``0`` means ``len(buf)``.
+
+        Returns:
+            int: Number of bytes written into ``buf``.
+        """
         if self._readobj is not None and hasattr(self._readobj, "readinto"):
             return self._readobj.readinto(buf, nbytes)
         data = self.read(nbytes or len(buf))
@@ -246,6 +285,16 @@ class Console(io.IOBase):
         return n
 
     def write(self, buf, fg=None, bg=None):
+        """Write bytes or text to the console (supports a few ANSI escapes).
+
+        Args:
+            buf: ``bytes``, ``bytearray``, or ``str``.
+            fg: Optional foreground color override.
+            bg: Optional background color override.
+
+        Returns:
+            int: Number of bytes consumed from ``buf``.
+        """
         fg = self.fgcolor if fg is None else fg
         bg = self.bgcolor if bg is None else bg
         if isinstance(buf, str):

--- a/src/add_ons/display_driver.py
+++ b/src/add_ons/display_driver.py
@@ -73,6 +73,14 @@ def _asyncio_loop_running():
 
 
 class event_loop:
+    """LVGL task loop driven by ``eventsys.Runtime.on_tick``.
+
+    One instance may be active at a time. Sync mode runs ``lv.task_handler``
+    from the shared timer; async mode signals an asyncio refresh task.
+    Prefer ``import display_driver`` (module ``main()``) over constructing this
+    by hand unless you need custom ``freq`` / ``asynchronous`` settings.
+    """
+
     _current_instance = None
 
     def __init__(
@@ -84,6 +92,22 @@ class event_loop:
         exception_sink=None,
         period_ms=None,
     ):
+        """Create and register the LVGL event loop.
+
+        Args:
+            freq: Desired Hz when ``period_ms`` is omitted (period = ``1000 // freq``).
+            max_scheduled: Kept for lv_utils API parity (unused).
+            refresh_cb: Optional zero-arg callable after each successful
+                ``lv.task_handler()``.
+            asynchronous: When True, drive LVGL via an asyncio refresh task.
+            exception_sink: Callable receiving exceptions from task handling;
+                defaults to :meth:`default_exception_sink`.
+            period_ms: Explicit tick period in milliseconds (overrides ``freq``).
+
+        Raises:
+            RuntimeError: Another loop is already running, ``runtime`` is
+                missing, or async mode is requested without asyncio.
+        """
         if self.is_running():
             raise RuntimeError("Event loop is already running!")
 
@@ -150,6 +174,7 @@ class event_loop:
         self._timer_sub = runtime.on_tick(self.timer_cb, period=self.delay, async_=True)
 
     def deinit(self):
+        """Stop the tick subscription / async task and clear the singleton."""
         if getattr(self, "_timer_sub", None) is not None:
             self._timer_sub.deinit()
             self._timer_sub = None
@@ -160,10 +185,12 @@ class event_loop:
         event_loop._current_instance = None
 
     def disable(self):
+        """Pause LVGL task handling (re-entrant; pair with :meth:`enable`)."""
         # Pause LVGL task handling (e.g. while building the UI). Re-entrant.
         self._pause += 1
 
     def enable(self):
+        """Resume LVGL task handling after :meth:`disable`; arms the sync timer."""
         if self._pause > 0:
             self._pause -= 1
         if self._pause == 0:
@@ -171,13 +198,16 @@ class event_loop:
 
     @staticmethod
     def is_running():
+        """True when an :class:`event_loop` instance is currently registered."""
         return event_loop._current_instance is not None
 
     @staticmethod
     def current_instance():
+        """Return the active :class:`event_loop`, or ``None``."""
         return event_loop._current_instance
 
     def task_handler(self, _=None):
+        """Run ``lv.task_handler()`` once when not paused and not nested."""
         if self._in_task or self._pause > 0:
             return
         self._in_task = True
@@ -193,9 +223,11 @@ class event_loop:
             self._in_task = False
 
     def tick(self):
+        """Manually invoke the timer callback once (same path as the shared timer)."""
         self.timer_cb(None)
 
     def run(self):
+        """Blocking forever-tick loop (macOS only; prefer ``runtime.run_forever()``)."""
         if sys.platform == "darwin":
             while True:
                 self.tick()
@@ -214,6 +246,11 @@ class event_loop:
         self._next_ok_ms = ticks_add(ticks_ms(), self.delay)
 
     def timer_cb(self, t):
+        """Shared-timer callback: advance LVGL time and run/signal task handling.
+
+        Args:
+            t: Timer instance (ignored; may be ``None`` from :meth:`tick`).
+        """
         # Called from the runtime's shared timer (on the main thread).
         # In async mode the AsyncTimer fires from inside the running asyncio
         # loop, so we can safely arm (create the refresh task) on the first
@@ -244,6 +281,7 @@ class event_loop:
             self._arm_gate()
 
     async def async_refresh(self):
+        """Asyncio task body: wait for refresh signals and run ``lv.task_handler``."""
         while True:
             await self.refresh_event.wait()
             if lv._nesting.value == 0:
@@ -258,10 +296,16 @@ class event_loop:
                 self._arm_gate()
 
     def default_exception_sink(self, e):
+        """Print ``e`` with traceback to stderr (default :attr:`exception_sink`)."""
         sys.print_exception(e)
 
 
 def main():
+    """Initialize LVGL, wire :class:`DisplayDriver`, and enable the event loop.
+
+    Called automatically on ``import display_driver`` when ``board_config``
+    provides ``display_drv`` / ``runtime``.
+    """
     global _driver_ref, _host_pump_sub
     gc.collect()
     if not lv.is_initialized():
@@ -578,6 +622,17 @@ def _keypad_cb(event, indev, data):
 
 
 def create_devices(devs, lv_display, virtual_devices=None):
+    """Register eventsys devices as LVGL indevs (pointer / encoder / keypad).
+
+    Args:
+        devs: Iterable of eventsys devices from ``runtime.devices``.
+        lv_display: LVGL display object to attach indevs to.
+        virtual_devices: Optional list mutated when expanding :class:`HostEventsDevice`
+            into virtual pointer/keypad devices.
+
+    Returns:
+        list: Accumulated virtual devices (for host expansion).
+    """
     if virtual_devices is None:
         virtual_devices = []
     for device in devs:
@@ -618,6 +673,13 @@ def create_devices(devs, lv_display, virtual_devices=None):
 
 
 class DisplayDriver:
+    """Bridge a displaysys driver to an LVGL display + input devices.
+
+    Creates the LVGL display, chooses DIRECT (shared framebuffer) or PARTIAL
+    render mode, installs flush callbacks, and wires eventsys devices via
+    :func:`create_devices`.
+    """
+
     def __init__(
         self,
         display_drv,
@@ -625,6 +687,14 @@ class DisplayDriver:
         color_format=lv.COLOR_FORMAT.RGB565,
         blocking=True,
     ):
+        """Create LVGL display buffers and register input devices.
+
+        Args:
+            display_drv: displaysys driver (BusDisplay, SDLDisplay, FBDisplay, …).
+            devs: Iterable of eventsys devices to register as LVGL indevs.
+            color_format: LVGL color format (default RGB565).
+            blocking: When False, register a bus flush-ready callback for async blit.
+        """
         if devs is None:
             devs = []
         gc.collect()

--- a/src/add_ons/displaybuf.py
+++ b/src/add_ons/displaybuf.py
@@ -27,8 +27,9 @@ Usage:
 import gc
 import sys
 
-from displaysys import alloc_buffer, color332, color565, color565_swapped
 import pygraphics
+
+from displaysys import alloc_buffer, color332, color565, color565_swapped
 
 _has_viper_tools = False
 if sys.implementation.name == "micropython":
@@ -161,6 +162,7 @@ class DisplayBuffer(pygraphics.FrameBuffer):
 
     @property
     def color_palette(self):
+        """Registered RGB888 palette used with GS4_HMSB / Nano-GUI color helpers."""
         return self._color_palette
 
     @color_palette.setter
@@ -267,17 +269,35 @@ class DisplayBuffer(pygraphics.FrameBuffer):
 
 
 class BoolPalette(pygraphics.FrameBuffer):
-    # This is a 2-value color palette for rendering monochrome glyphs to color
-    # FrameBuffer instances. Supports destinations with up to 16 bit color.
+    """Two-entry palette for blitting monochrome glyphs into a color framebuffer.
+
+    Supports destinations with up to 16-bit color. Used as
+    ``DisplayBuffer.palette`` with ``ssd.blit(glyph, x, y, key=-1, palette=…)``.
+    """
 
     # Copyright (c) Peter Hinch 2021
     # Released under the MIT license see LICENSE
     def __init__(self, format):
+        """Allocate a 2x1 framebuffer in ``format`` for fg/bg colors.
+
+        Args:
+            format: A ``pygraphics`` framebuf format constant (e.g. ``RGB565``).
+        """
         buf = bytearray(4)  # OK for <= 16 bit color
         super().__init__(buf, 2, 1, format)
 
-    def fg(self, color):  # Set foreground color
+    def fg(self, color):
+        """Set the foreground (glyph-on) color.
+
+        Args:
+            color: Destination pixel value in the palette's format.
+        """
         self.pixel(1, 0, color)
 
     def bg(self, color):
+        """Set the background (glyph-off) color.
+
+        Args:
+            color: Destination pixel value in the palette's format.
+        """
         self.pixel(0, 0, color)

--- a/src/lib/displaysys/__init__.py
+++ b/src/lib/displaysys/__init__.py
@@ -42,10 +42,13 @@ __all__ = [
     "color565",
     "color565_swapped",
     "color_rgb",
+    "desktop_work_area",
     "env_bool",
     "env_get",
     "env_int",
     "env_set",
+    "fit_scale_to_desktop",
+    "notify_board_config_scale_override",
 ]
 
 _DEFAULT_AUTO_REFRESH_PERIOD = 33
@@ -233,7 +236,14 @@ def fit_scale_to_desktop(
 
 
 def notify_board_config_scale_override(driver_name, requested, fitted, *, quiet=False):
-    """Tell the user when a desktop driver reduces board_config scale to fit the screen."""
+    """Tell the user when a desktop driver reduces board_config scale to fit the screen.
+
+    Args:
+        driver_name: Display class name for the log line (e.g. ``"SDLDisplay"``).
+        requested: Scale requested by board_config / constructor.
+        fitted: Scale after :func:`fit_scale_to_desktop`.
+        quiet: When True, skip printing.
+    """
     if quiet or fitted == requested:
         return
     print(
@@ -435,6 +445,11 @@ class DisplayDriver:
         return None
 
     def __init__(self, *, quiet=False):
+        """Initialize shared display state and call subclass :meth:`init`.
+
+        Args:
+            quiet: When True, suppress init / rotation chatter.
+        """
         self._quiet = quiet
         if not self._quiet:
             print(f"Initializing {self.__class__.__name__}...")
@@ -722,9 +737,19 @@ class DisplayDriver:
         return x, y
 
     def scroll_by(self, value):
+        """Scroll vertically by ``value`` pixels relative to the current offset.
+
+        Args:
+            value: Signed pixel delta applied to :attr:`vscroll`.
+        """
         self.vscroll += value
 
     def scroll_to(self, value):
+        """Set the absolute vertical scroll offset.
+
+        Args:
+            value: New :attr:`vscroll` position.
+        """
         self.vscroll = value
 
     @property

--- a/src/lib/displaysys/epaperdisplay.py
+++ b/src/lib/displaysys/epaperdisplay.py
@@ -25,13 +25,20 @@ _ACEP_PALETTE_RGB = (
 
 
 class EPaperDisplay(DisplayDriver):
-    """
-    ``DisplayDriver`` wrapper around a CircuitPython ``EPaperDisplay`` chip driver.
+    """``DisplayDriver`` wrapper around a CircuitPython ``EPaperDisplay`` chip driver.
 
     Packed buffer depths:
     - ``color_depth=1`` — monochrome (1 bit per pixel)
     - ``color_depth=2`` — tri-color or 4-gray (2 bits per pixel: 0=white, 1=black, 2=accent)
     - ``color_depth=4`` — ACeP / advanced color (4 bits per pixel, 2 per byte)
+
+    Args:
+        epaper: CircuitPython ``EPaperDisplay`` (or compatible) chip driver.
+        width: Panel width; defaults to ``epaper.width``.
+        height: Panel height; defaults to ``epaper.height``.
+        buffer: Optional preallocated RAM buffer; allocated when depth ≤ 8.
+        color_depth: Bits per pixel; defaults to ``epaper.color_depth`` or 1.
+        quiet: Suppress init chatter when True.
     """
 
     def __init__(
@@ -104,9 +111,24 @@ class EPaperDisplay(DisplayDriver):
         return int.from_bytes(self._buffer[begin : begin + bpp], "little")
 
     def init(self) -> None:
-        pass
+        """No-op init hook (epaper chip drivers are already initialized)."""
 
     def fill_rect(self, x, y, w, h, c):
+        """Fill a rectangle in the RAM buffer.
+
+        Args:
+            x: Left edge.
+            y: Top edge.
+            w: Width in pixels.
+            h: Height in pixels.
+            c: Packed color value for the configured ``color_depth``.
+
+        Returns:
+            tuple: ``(x, y, w, h)`` of the filled area.
+
+        Raises:
+            NotImplementedError: When no RAM buffer is allocated.
+        """
         if self._buffer is None:
             raise NotImplementedError("EPaperDisplay requires a RAM buffer")
         if self.color_depth <= 4:
@@ -125,6 +147,21 @@ class EPaperDisplay(DisplayDriver):
         return (x, y, w, h)
 
     def blit_rect(self, buf, x, y, w, h):
+        """Blit packed pixel bytes into the RAM buffer.
+
+        Args:
+            buf: Source buffer matching ``color_depth`` packing.
+            x: Destination left edge.
+            y: Destination top edge.
+            w: Width in pixels.
+            h: Height in pixels.
+
+        Returns:
+            tuple: ``(x, y, w, h)`` of the blitted area.
+
+        Raises:
+            NotImplementedError: When no RAM buffer is allocated.
+        """
         if self._buffer is None:
             raise NotImplementedError("EPaperDisplay requires a RAM buffer")
         if self.color_depth == 1:
@@ -156,6 +193,16 @@ class EPaperDisplay(DisplayDriver):
         return (x, y, w, h)
 
     def pixel(self, x, y, c):
+        """Set a single pixel in the RAM buffer.
+
+        Args:
+            x: X coordinate.
+            y: Y coordinate.
+            c: Packed color value.
+
+        Returns:
+            tuple: ``(x, y, 1, 1)``.
+        """
         return self.fill_rect(x, y, 1, 1, c)
 
     def _panel_buffer(self):
@@ -276,6 +323,11 @@ class EPaperDisplay(DisplayDriver):
         return True
 
     def show(self, _timer=None) -> None:
+        """Push the RAM buffer to the panel and call ``epaper.refresh()``.
+
+        Prefers a displayio root-group path; falls back to ``bus.send`` when
+        displayio is unavailable.
+        """
         if self._buffer is not None:
             try:
                 self._push_buffer_displayio()

--- a/src/lib/displaysys/jndisplay.py
+++ b/src/lib/displaysys/jndisplay.py
@@ -266,24 +266,25 @@ class JNDevices:
 
 
 class JNDisplay(DisplayDriver):
-    needs_refresh = True
-
-    """
-    A class to emulate a display on Jupyter Notebook.
+    """Emulate a display in a Jupyter Notebook output cell.
 
     Supports ILI9341-style vertical scroll emulation (same band compositing as
     SDL/PG/PS). Interactive output uses :class:`JNDevices`; static notebooks can
     call :meth:`show` without a device.
 
     Args:
-        width (int): The width of the display.
-        height (int): The height of the display.
+        width (int): Panel width in pixels.
+        height (int): Panel height in pixels.
+        quiet (bool): Suppress init chatter when True.
 
     Attributes:
-        color_depth (int): The color depth of the display
+        color_depth (int): Bits per pixel (16).
         touch_scale (float): Pointer scale for ``QueueDevice`` (always ``1.0``).
         quit_chord: Keyboard chord for quit (default CTRL+Q); ``None`` disables.
+        needs_refresh (bool): True — ``eventsys.Runtime`` drives periodic ``show()``.
     """
+
+    needs_refresh = True
 
     _next_display_id = 0
 
@@ -414,10 +415,12 @@ class JNDisplay(DisplayDriver):
     ############### Scrolling (ILI9341-style, like PG/PS/SDL) ################
 
     def vscrdef(self, tfa: int, vsa: int, bfa: int) -> None:
+        """Set vertical scroll bands and recompose the visible frame."""
         super().vscrdef(tfa, vsa, bfa)
         self.render()
 
     def vscsad(self, vssa=None) -> int:
+        """Get or set the vertical scroll start address and recompose when set."""
         if vssa is not None:
             super().vscsad(vssa)
             self.render()

--- a/src/lib/displaysys/pgdisplay.py
+++ b/src/lib/displaysys/pgdisplay.py
@@ -215,26 +215,29 @@ def _init_joysticks() -> None:
 
 
 class PGDisplay(DisplayDriver):
-    needs_refresh = True
+    """Emulate an LCD window with pygame-ce.
 
-    """
-    A class to emulate an LCD using pygame.
-    Provides scrolling and rotation functions similar to an LCD.  The .texture
-    object functions as the LCD's internal memory.
+    Provides scrolling and rotation similar to a panel driver. The off-screen
+    ``.texture`` / surface acts as the LCD's internal memory. Scale is reduced
+    automatically when the window would not fit the desktop work area.
 
     Args:
-        width (int, optional): The width of the display. Defaults to 320.
-        height (int, optional): The height of the display. Defaults to 240.
-        rotation (int, optional): The rotation of the display. Defaults to 0.
-        color_depth (int, optional): The color depth of the display. Defaults to 16.
-        title (str, optional): The title of the display window. Defaults to "displaysys".
-        scale (float, optional): The scale of the display. Defaults to 1.0.
-        window_flags (int, optional): The flags for creating the display window. Defaults to pg.SHOWN
+        width (int, optional): Panel width in pixels. Defaults to 320.
+        height (int, optional): Panel height in pixels. Defaults to 240.
+        rotation (int, optional): Rotation in degrees. Defaults to 0.
+        color_depth (int, optional): Bits per pixel. Defaults to 16.
+        title (str, optional): Window title. Defaults to ``"displaysys"``.
+        scale (float, optional): Window scale factor. Defaults to 1.0.
+        window_flags (int, optional): pygame display flags. Defaults to ``pg.SHOWN``.
+        quiet (bool): Suppress init chatter when True.
 
     Attributes:
-        color_depth (int): The color depth of the display.
-        touch_scale (float): The touch scale of the display.
+        color_depth (int): Bits per pixel.
+        touch_scale (float): Scale used to map host pointer coords into panel space.
+        needs_refresh (bool): True — ``eventsys.Runtime`` drives periodic ``show()``.
     """
+
+    needs_refresh = True
 
     def __init__(
         self,

--- a/src/lib/displaysys/pixeldisplay.py
+++ b/src/lib/displaysys/pixeldisplay.py
@@ -18,8 +18,9 @@ except ImportError:
         return x
 
 
-from displaysys import DisplayDriver, color_rgb
 import pygraphics
+
+from displaysys import DisplayDriver, color_rgb
 
 
 def _color888_from_565(c):
@@ -127,6 +128,20 @@ class PixelFramebuffer(pygraphics.FrameBuffer):
         bottom=0,
         rotation=0,
     ):
+        """Build a grid framebuffer mapped onto an addressable LED strip.
+
+        Args:
+            pixels: NeoPixel / DotStar-like object with ``__setitem__`` and ``show()``.
+            width: Logical grid width.
+            height: Logical grid height.
+            orientation: :data:`HORIZONTAL` or :data:`VERTICAL` strip layout.
+            alternating: Zigzag rows/columns when True.
+            reverse_x: Mirror X before mapping.
+            reverse_y: Mirror Y before mapping.
+            top: Optional ``(x, y)`` origin of the active sub-grid.
+            bottom: Optional ``(x, y)`` exclusive end of the active sub-grid.
+            rotation: Stored rotation attribute (degrees).
+        """
         self._pixels = pixels
         grid_width, grid_height, self._indices = _build_grid_mapper(
             width,
@@ -147,9 +162,11 @@ class PixelFramebuffer(pygraphics.FrameBuffer):
 
     @property
     def stride(self):
+        """Pixels per row in the logical framebuffer."""
         return self._width
 
     def blit(self):
+        """Not implemented — use :meth:`display` to flush the strip."""
         raise NotImplementedError
 
     def display(self) -> None:
@@ -188,12 +205,39 @@ class PixelDisplay(DisplayDriver):
         super().__init__(quiet=quiet)
 
     def init(self) -> None:
-        pass
+        """No-op init hook (LED strip is already configured)."""
 
     def fill_rect(self, x, y, w, h, c):
+        """Fill a rectangle with an RGB565 color (converted to RGB888).
+
+        Args:
+            x: Left edge.
+            y: Top edge.
+            w: Width.
+            h: Height.
+            c: RGB565 color.
+
+        Returns:
+            Result of the inner framebuffer ``fill_rect``.
+        """
         return self._raw_buffer.fill_rect(x, y, w, h, _color888_from_565(c))
 
     def blit_rect(self, buf, x, y, w, h):
+        """Blit RGB565 bytes into the LED framebuffer.
+
+        Args:
+            buf: Source buffer of ``w * h * 2`` bytes.
+            x: Destination left edge.
+            y: Destination top edge.
+            w: Width in pixels.
+            h: Height in pixels.
+
+        Returns:
+            tuple: ``(x, y, w, h)``.
+
+        Raises:
+            ValueError: When ``buf`` length does not match dimensions.
+        """
         bpp = self.color_depth // 8
         expected = w * h * bpp
         if len(buf) != expected:
@@ -209,7 +253,18 @@ class PixelDisplay(DisplayDriver):
         return (x, y, w, h)
 
     def pixel(self, x, y, c):
+        """Set a single RGB565 pixel (converted to RGB888).
+
+        Args:
+            x: X coordinate.
+            y: Y coordinate.
+            c: RGB565 color.
+
+        Returns:
+            Result of the inner framebuffer ``pixel``.
+        """
         return self._raw_buffer.pixel(x, y, _color888_from_565(c))
 
     def show(self, _timer=None) -> None:
+        """Flush dirty pixels to the LED strip via ``pixel_buffer.display()``."""
         self._raw_buffer.display()

--- a/src/lib/displaysys/psdisplay.py
+++ b/src/lib/displaysys/psdisplay.py
@@ -265,16 +265,19 @@ class PSDevices:
 
 
 class PSDisplay(DisplayDriver):
-    needs_refresh = True
-
-    """
-    A class to emulate a display on PyScript.
+    """Emulate a display on a PyScript HTML canvas.
 
     Args:
-        id (str): The id of the canvas element.
-        width (int, optional): The width of the display. Defaults to None.
-        height (int, optional): The height of the display. Defaults to None.
+        id (str): DOM id of the canvas element.
+        width (int, optional): Panel width; defaults to the canvas width.
+        height (int, optional): Panel height; defaults to the canvas height.
+        quiet (bool): Suppress init chatter when True.
+
+    Attributes:
+        needs_refresh (bool): True — ``eventsys.Runtime`` drives periodic ``show()``.
     """
+
+    needs_refresh = True
 
     def __init__(self, id, width=None, height=None, *, quiet=False):
         self._canvas = document.getElementById(id)
@@ -395,10 +398,12 @@ class PSDisplay(DisplayDriver):
     ############### Scrolling (ILI9341-style, like SDLDisplay / PGDisplay) ################
 
     def vscrdef(self, tfa: int, vsa: int, bfa: int) -> None:
+        """Set vertical scroll bands and re-render the canvas."""
         super().vscrdef(tfa, vsa, bfa)
         self.render()
 
     def vscsad(self, vssa=None) -> int:
+        """Get or set the vertical scroll start address and re-render when set."""
         if vssa is not None:
             super().vscsad(vssa)
             self.render()
@@ -434,6 +439,7 @@ class PSDisplay(DisplayDriver):
             vis.drawImage(buf, 0, tfa + vsa, w, bfa, 0, tfa + vsa, w, bfa)
 
     def show(self, _timer=None) -> None:
+        """Present the offscreen canvas (alias of :meth:`render`)."""
         self.render()
 
     def _pointer_scale(self):

--- a/src/lib/displaysys/sdldisplay.py
+++ b/src/lib/displaysys/sdldisplay.py
@@ -341,25 +341,30 @@ def _hard_process_exit(code: int = 0) -> None:
 
 
 class SDLDisplay(DisplayDriver):
-    needs_refresh = True
+    """Emulate an LCD window with SDL2 (via ``usdl2``).
 
-    """
-    A class to emulate an LCD using SDL2.
-    Provides scrolling and rotation functions similar to an LCD.  The .texture
-    object functions as the LCD's internal memory.
+    Provides scrolling and rotation similar to a panel driver. The SDL texture
+    acts as the LCD's internal memory. Scale is reduced automatically when the
+    window would not fit the desktop work area.
 
     Args:
-        width (int, optional): The width of the display. Defaults to 320.
-        height (int, optional): The height of the display. Defaults to 240.
-        rotation (int, optional): The rotation of the display. Defaults to 0.
-        color_depth (int, optional): The color depth of the display. Defaults to 16.
-        title (str, optional): The title of the display window. Defaults to "SDL2 Display".
-        scale (float, optional): The scale of the display. Defaults to 1.0.
-        window_flags (int, optional): The flags for creating the display window. Defaults to SDL_WINDOW_SHOWN.
-        render_flags (int, optional): The flags for creating the renderer. Defaults to SDL_RENDERER_ACCELERATED | SDL_RENDERER_PRESENTVSYNC.
-        x (int, optional): The x-coordinate of the display window's position. Defaults to SDL_WINDOWPOS_CENTERED.
-        y (int, optional): The y-coordinate of the display window's position. Defaults to SDL_WINDOWPOS_CENTERED.
+        width (int, optional): Panel width in pixels. Defaults to 320.
+        height (int, optional): Panel height in pixels. Defaults to 240.
+        rotation (int, optional): Rotation in degrees. Defaults to 0.
+        color_depth (int, optional): Bits per pixel (16/24/32). Defaults to 16.
+        title (str, optional): Window title. Defaults to ``"SDL2 Display"``.
+        scale (float, optional): Window scale factor. Defaults to 1.0.
+        window_flags (int, optional): ``SDL_WINDOW_*`` flags.
+        render_flags (int, optional): ``SDL_RENDERER_*`` flags.
+        x (int, optional): Window X (default centered).
+        y (int, optional): Window Y (default centered).
+        quiet (bool): Suppress init chatter when True.
+
+    Attributes:
+        needs_refresh (bool): True — ``eventsys.Runtime`` drives periodic ``show()``.
     """
+
+    needs_refresh = True
 
     def __init__(
         self,

--- a/src/lib/eventsys/_device.py
+++ b/src/lib/eventsys/_device.py
@@ -37,6 +37,14 @@ class Device:
     responses = events.filter
 
     def __init__(self, read=None, data=None, read2=None, data2=None):
+        """Create a device with optional read callables and opaque data slots.
+
+        Args:
+            read: Primary poll callable (subclass-specific return shape).
+            data: Opaque primary data (often a display reference).
+            read2: Optional secondary poll callable.
+            data2: Opaque secondary data (e.g. touch rotation table).
+        """
         self._event_callbacks = {}
         self._read = read if read else lambda: None
         self._data = data
@@ -63,6 +71,16 @@ class Device:
         return eventlist
 
     def subscribe(self, callback, event_types=None):
+        """Subscribe ``callback`` to events this device can emit.
+
+        Args:
+            callback: Callable ``callback(event, *poll_args)``.
+            event_types: Iterable of event types; defaults to :attr:`responses`.
+
+        Raises:
+            ValueError: ``callback`` not callable, or an event type not in
+                :attr:`responses`.
+        """
         event_types = event_types or self.responses
         if not callable(callback):
             raise ValueError("callback is not callable.")
@@ -74,6 +92,12 @@ class Device:
             self._event_callbacks[event_type] = callback_set
 
     def unsubscribe(self, callback, event_types=None):
+        """Remove ``callback`` from the given event types (default: all responses).
+
+        Args:
+            callback: Previously registered callable.
+            event_types: Iterable of event types; defaults to :attr:`responses`.
+        """
         event_types = event_types or self.responses
         for event_type in event_types:
             if callback_set := self._event_callbacks.get(event_type):
@@ -81,6 +105,7 @@ class Device:
 
     @property
     def runtime(self):
+        """Owning :class:`Runtime`, or ``None`` when not registered."""
         return self._runtime
 
     @runtime.setter
@@ -89,6 +114,7 @@ class Device:
 
     @property
     def user_data(self):
+        """Application-owned opaque value (unused by eventsys itself)."""
         return self._user_data
 
     @user_data.setter

--- a/src/lib/eventsys/_joystick.py
+++ b/src/lib/eventsys/_joystick.py
@@ -11,30 +11,55 @@ class JoystickDriver:
     """PyGame/SDL-style joystick polling interface."""
 
     def get_instance_id(self):
+        """Return the SDL/PyGame instance id for this joystick."""
         raise NotImplementedError("JoystickDriver.get_instance_id() not implemented")
 
     def get_numaxes(self):
+        """Return the number of axes."""
         raise NotImplementedError("JoystickDriver.get_numaxes() not implemented")
 
     def get_axis(self, axis):
+        """Return the axis value in ``[-1.0, 1.0]``.
+
+        Args:
+            axis: Zero-based axis index.
+        """
         raise NotImplementedError("JoystickDriver.get_axis() not implemented")
 
     def get_numballs(self):
+        """Return the number of trackballs."""
         raise NotImplementedError("JoystickDriver.get_numballs() not implemented")
 
     def get_ball(self, ball):
+        """Return ``(dx, dy)`` relative motion for a trackball.
+
+        Args:
+            ball: Zero-based trackball index.
+        """
         raise NotImplementedError("JoystickDriver.get_ball() not implemented")
 
     def get_numbuttons(self):
+        """Return the number of buttons."""
         raise NotImplementedError("JoystickDriver.get_numbuttons() not implemented")
 
     def get_button(self, button):
+        """Return whether a button is pressed.
+
+        Args:
+            button: Zero-based button index.
+        """
         raise NotImplementedError("JoystickDriver.get_button() not implemented")
 
     def get_numhats(self):
+        """Return the number of hats (D-pads)."""
         raise NotImplementedError("JoystickDriver.get_numhats() not implemented")
 
     def get_hat(self, hat):
+        """Return ``(x, y)`` hat position with each component in ``{-1, 0, 1}``.
+
+        Args:
+            hat: Zero-based hat index.
+        """
         raise NotImplementedError("JoystickDriver.get_hat() not implemented")
 
 
@@ -58,6 +83,16 @@ class JoystickDevice(Device):
         digital_threshold: float = 0.5,
         **kwargs,
     ):
+        """Create a joystick device backed by ``joystick_driver``.
+
+        Args:
+            *args: Forwarded to :class:`Device`.
+            joystick_driver: Object implementing :class:`JoystickDriver`.
+            emulate_digital: Optional sequence of ``(axis_x, axis_y)`` pairs to
+                synthesize extra hat events from analog axes.
+            digital_threshold: Absolute axis magnitude for :meth:`emulate`.
+            **kwargs: Forwarded to :class:`Device`.
+        """
         super().__init__(*args, **kwargs)
         self.joystick_driver = joystick_driver
         self.emulate_digital = emulate_digital
@@ -72,6 +107,14 @@ class JoystickDevice(Device):
             self._state.append([0] * len(self.emulate_digital))
 
     def emulate(self, value):
+        """Map an analog axis value to ``-1``, ``0``, or ``1`` by threshold.
+
+        Args:
+            value: Axis sample in approximately ``[-1.0, 1.0]``.
+
+        Returns:
+            int: Digitized hat component.
+        """
         return (
             -1 if value < -self.digital_threshold else 1 if value > self.digital_threshold else 0
         )

--- a/src/lib/eventsys/_runtime.py
+++ b/src/lib/eventsys/_runtime.py
@@ -169,6 +169,26 @@ class Runtime:
         refresh_period=None,
         timer_async=False,
     ):
+        """Create a board runtime and optionally wire host/touch devices.
+
+        Args:
+            display: displaysys driver used for refresh, quit, and touch mapping.
+            host_read: Callable returning host events (mouse/keyboard); requires
+                ``display``.
+            touch_read: Callable returning touch points; requires ``display``.
+            touch_rotation_table: Optional 4-item rotation mask table for touch.
+            refresh_period: Milliseconds between ``display.show()`` ticks. ``None``
+                uses :data:`DEFAULT_REFRESH_MS` when ``display.needs_refresh``.
+                ``0`` or negative disables periodic refresh.
+            timer_async: When ``True``, use :class:`multimer.AsyncTimer` and
+                asyncio-oriented entry (:meth:`run` / :meth:`run_forever`).
+
+        Raises:
+            TypeError: ``host_read`` / ``touch_read`` not callable, or invalid
+                ``touch_rotation_table`` type.
+            ValueError: ``host_read`` / ``touch_read`` without ``display``, or
+                ``touch_rotation_table`` length not 4.
+        """
         self.devices = []
         self._event_callbacks = {}
         self._device_callbacks = {}
@@ -235,6 +255,7 @@ class Runtime:
 
     @property
     def timer_async(self):
+        """Whether this runtime uses async timers (``AsyncTimer`` / asyncio)."""
         return self._timer_async
 
     @staticmethod
@@ -394,6 +415,7 @@ class Runtime:
 
     @property
     def quit_requested(self):
+        """True after a QUIT event or :meth:`request_quit` (teardown pending/done)."""
         return self._quit_requested
 
     def request_quit(self, code=None):
@@ -420,6 +442,10 @@ class Runtime:
 
     @property
     def before_quit(self):
+        """Optional callable invoked once during teardown, before ``display.quit``.
+
+        Set to a zero-arg callable (e.g. ``lv.deinit``) or ``None``.
+        """
         return self._before_quit
 
     @before_quit.setter
@@ -430,6 +456,7 @@ class Runtime:
 
     @property
     def display_refresh(self):
+        """Subscription handle for the periodic ``display.show`` tick, or ``None``."""
         return self._refresh_subscription
 
     def on(self, event_type, callback):
@@ -478,6 +505,17 @@ class Runtime:
             self._event_callbacks[event_type] = callback_set
 
     def unsubscribe(self, callback, event_types=None, device_types=None):
+        """Remove ``callback`` from event-type or device-type subscriptions.
+
+        Args:
+            callback: Previously registered callable.
+            event_types: Iterable of event type constants to unsubscribe from.
+            device_types: Iterable of device type constants; mutually exclusive
+                with ``event_types``.
+
+        Raises:
+            ValueError: Both or neither of ``event_types`` / ``device_types`` set.
+        """
         if device_types is not None:
             if event_types is not None:
                 raise ValueError("set one of device_types or event_types but not both.")
@@ -502,12 +540,30 @@ class Runtime:
             dev.runtime = None
 
     def add_keypad(self, read):
+        """Create, register, and return a :class:`KeypadDevice`.
+
+        Args:
+            read: Callable returning the current pressed-key collection.
+
+        Returns:
+            KeypadDevice: The registered device (also stored as ``keypad_dev``).
+        """
         _validate_callable(read, "read")
         self.keypad_dev = KeypadDevice(read=read)
         self.register(self.keypad_dev)
         return self.keypad_dev
 
     def add_encoder(self, read, *, button_read=None, button=2):
+        """Create, register, and return an :class:`EncoderDevice`.
+
+        Args:
+            read: Callable returning encoder position / delta.
+            button_read: Optional callable for a push-button state.
+            button: Mouse button index used when synthesizing button events.
+
+        Returns:
+            EncoderDevice: The registered device (also stored as ``encoder_dev``).
+        """
         _validate_callable(read, "read")
         if button_read is not None:
             _validate_callable(button_read, "button_read")
@@ -516,6 +572,16 @@ class Runtime:
         return self.encoder_dev
 
     def add_joystick(self, *, joystick_driver=None, **kwargs):
+        """Create, register, and return a :class:`JoystickDevice`.
+
+        Args:
+            joystick_driver: Object implementing :class:`JoystickDriver`.
+            **kwargs: Extra :class:`JoystickDevice` options (e.g.
+                ``emulate_digital``, ``digital_threshold``).
+
+        Returns:
+            JoystickDevice: The registered device (also stored as ``joystick_dev``).
+        """
         self.joystick_dev = JoystickDevice(joystick_driver=joystick_driver, **kwargs)
         self.register(self.joystick_dev)
         return self.joystick_dev

--- a/src/lib/eventsys/_touch.py
+++ b/src/lib/eventsys/_touch.py
@@ -51,6 +51,20 @@ class TouchDevice(Device):
     def __init__(
         self, *args, read=None, data=None, data2=None, display=None, rotation_table=None, **kwargs
     ):
+        """Create a touch device bound to a display.
+
+        Args:
+            *args: Optional positional ``read`` as the first argument.
+            read: Callable returning touch points (see class docstring).
+            data: Alternate for ``display`` (display object).
+            data2: Alternate for ``rotation_table``.
+            display: Display providing ``width``, ``height``, and ``rotation``.
+            rotation_table: 4-item mask table for 0/90/180/270°; default is built-in.
+            **kwargs: Forwarded to :class:`Device`.
+
+        Raises:
+            ValueError: When no display is provided.
+        """
         read = read if read is not None else (args[0] if args else None)
         data = display if display is not None else data
         data2 = rotation_table if rotation_table is not None else data2
@@ -69,6 +83,7 @@ class TouchDevice(Device):
 
     @property
     def rotation(self):
+        """Display rotation in degrees (``0``, ``90``, ``180``, or ``270``)."""
         return self._rotation
 
     @rotation.setter
@@ -78,6 +93,7 @@ class TouchDevice(Device):
 
     @property
     def rotation_table(self):
+        """Four-entry table of bitmasks selecting swap/reverse for each quadrant."""
         return self._data2
 
     @rotation_table.setter

--- a/src/lib/eventsys/keys.py
+++ b/src/lib/eventsys/keys.py
@@ -16,20 +16,45 @@ except ImportError:
 
 
 class Keys:
-    """
-    A container for key codes and names.  Similar to a C enum and struct.
+    """Container for SDL-style key codes, names, and modifier masks.
+
+    Provides ``K_*`` key constants, ``KMOD_*`` modifiers, and lookup helpers.
     """
 
     def keyname(x):
+        """Return the human-readable name for key code ``x``."""
         return Keys._keytable.get(x, "Unknown")
 
     def key(x):
+        """Return the key code whose name is ``x``.
+
+        Args:
+            x: A name from :meth:`keyname` (e.g. ``"Return"``).
+
+        Returns:
+            int: Matching ``Keys.K_*`` code.
+
+        Raises:
+            ValueError: When ``x`` is not a known key name.
+        """
         return list(Keys._keytable.keys())[list(Keys._keytable.values()).index(x)]
 
     def modname(x):
+        """Return the human-readable name for modifier mask ``x``."""
         return Keys._modtable.get(x, "Unknown")
 
     def mod(x):
+        """Return the modifier mask whose name is ``x``.
+
+        Args:
+            x: A name from :meth:`modname` (e.g. ``"Ctrl"``).
+
+        Returns:
+            int: Matching ``Keys.KMOD_*`` mask.
+
+        Raises:
+            ValueError: When ``x`` is not a known modifier name.
+        """
         return list(Keys._modtable.keys())[list(Keys._modtable.values()).index(x)]
 
     K_UNKNOWN = _const(0)

--- a/src/lib/multimer/__init__.py
+++ b/src/lib/multimer/__init__.py
@@ -2,7 +2,17 @@
 #
 # SPDX-License-Identifier: MIT
 """
-multimer — cross-platform machine.Timer for CPython, MicroPython, and CircuitPython.
+multimer — cross-platform ``machine.Timer`` for CPython, MicroPython, and CircuitPython.
+
+Public surface::
+
+    from multimer import Timer, AsyncTimer, schedule, sleep_ms, ticks_ms
+    from multimer import ticks_add, ticks_diff, ticks_less, monotonic, uses_signals
+
+``Timer`` selects a platform backend (librt, win32 APC, SDL2, threading, or
+``machine.Timer``). On async-only hosts (PyScript / Jupyter), ``Timer`` is an
+alias of :class:`AsyncTimer`. Soft callbacks (``hard=False``) use
+:func:`schedule`. See also: https://pydisplay.readthedocs.io/en/latest/concepts/multimer/
 """
 
 from ._async_timer import AsyncTimer
@@ -39,6 +49,17 @@ def _select_sleep_ms():
 
 
 sleep_ms = _select_sleep_ms()
+
+if not getattr(sleep_ms, "__doc__", None):
+    sleep_ms.__doc__ = """Sleep for ``ms`` milliseconds, pumping timers when the backend requires it.
+
+    Signal backends sleep without an extra pump; pump backends drain the
+    cooperative scheduler around the wait. Async-only hosts expose an awaitable.
+
+    Args:
+        ms: Duration to sleep, in milliseconds.
+    """
+
 
 
 def uses_signals():

--- a/src/lib/multimer/_async_timer.py
+++ b/src/lib/multimer/_async_timer.py
@@ -29,7 +29,27 @@ def _loop_running(aio):
 
 
 class AsyncTimer(_TimerCore):
+    """``asyncio``-backed timer with the same API as ``machine.Timer`` / :class:`Timer`.
+
+    Use when ``runtime.timer_async`` is True (PyScript, Jupyter, desktop async).
+    :meth:`init` requires a running event loop — prefer constructing at import
+    time and calling :meth:`init` (or passing kwargs) only after the loop starts,
+    or let ``eventsys.Runtime`` defer arming via ``arm_async_refresh``.
+
+    Inherited: :attr:`ONE_SHOT`, :attr:`PERIODIC`, :meth:`init`, :meth:`deinit`.
+    """
+
     def __init__(self, id=-1, **kwargs):
+        """Create an async timer, optionally calling :meth:`init` when kwargs are given.
+
+        Args:
+            id: Timer id (kept for API parity; async tasks are not hardware-bound).
+            **kwargs: Forwarded to :meth:`init` when non-empty.
+
+        Raises:
+            ImportError: No ``asyncio`` / ``uasyncio`` available.
+            RuntimeError: :meth:`init` called with no running event loop.
+        """
         self._running = False
         self._task = None
         super().__init__(id, **kwargs)

--- a/src/lib/multimer/_core.py
+++ b/src/lib/multimer/_core.py
@@ -16,12 +16,30 @@ from ._ticks import _sleep_ms, ticks_diff, ticks_ms
 
 
 class _TimerCore:
-    """Internal base matching MicroPython machine.Timer semantics."""
+    """Internal base matching MicroPython ``machine.Timer`` semantics.
+
+    Public ``Timer`` / ``AsyncTimer`` inherit this API. Documented members are
+    exposed on those classes via mkdocstrings ``inherited_members``.
+
+    Attributes:
+        ONE_SHOT: Mode constant — fire once then disarm (value ``0``).
+        PERIODIC: Mode constant — repeat until :meth:`deinit` (value ``1``).
+    """
 
     ONE_SHOT = const(0)
+    """Fire once then disarm."""
+
     PERIODIC = const(1)
+    """Repeat until :meth:`deinit`."""
 
     def __init__(self, id=-1, **kwargs):
+        """Create a timer, optionally calling :meth:`init` when kwargs are given.
+
+        Args:
+            id: Virtual or hardware timer id (``-1`` = auto-allocate when supported).
+            **kwargs: Forwarded to :meth:`init` when non-empty
+                (``mode``, ``freq``, ``period``, ``callback``, ``hard``).
+        """
         self.id = id
         self._mode = None
         self._period_ms = 0
@@ -47,6 +65,21 @@ class _TimerCore:
             self.init(**kwargs)
 
     def init(self, *, mode=PERIODIC, freq=-1, period=-1, callback=None, hard=True):
+        """Arm or re-arm the timer with MicroPython ``machine.Timer`` semantics.
+
+        Args:
+            mode: :attr:`ONE_SHOT` or :attr:`PERIODIC` (default ``PERIODIC``).
+            freq: Frequency in Hz. When ``freq > 0``, period is ``1000 // freq`` ms.
+            period: Period in milliseconds (used when ``freq`` is not positive).
+            callback: Callable invoked as ``callback(timer)`` on each fire.
+            hard: When ``True``, call ``callback`` directly from the backend
+                delivery path. When ``False``, deliver via :func:`schedule`
+                (safe for heap-allocating callbacks under locked-heap ISRs).
+
+        Raises:
+            ValueError: Invalid ``mode``, or neither ``freq`` nor ``period``
+                yields a period of at least 1 ms.
+        """
         if mode not in (self.ONE_SHOT, self.PERIODIC):
             raise ValueError("Invalid timer mode")
 
@@ -69,6 +102,11 @@ class _TimerCore:
         self._armed = True
 
     def deinit(self):
+        """Stop the timer and clear mode, period, and callback.
+
+        Waits until any in-flight callback finishes, then disarms the backend.
+        Safe to call repeatedly.
+        """
         self._wait_idle()
         if self._armed:
             self._disarm()

--- a/src/lib/multimer/_schedule.py
+++ b/src/lib/multimer/_schedule.py
@@ -85,6 +85,22 @@ if sys.implementation.name in ("cpython", "circuitpython"):
             _draining = False
 
     def schedule(cb, arg):
+        """Queue ``cb(arg)`` for the main thread (``micropython.schedule`` compatible).
+
+        On CPython / CircuitPython: if called off the main thread, append to a
+        pending queue drained by the next main-thread :func:`schedule` or by
+        the timer sleep pump. On the main thread, drain pending work then
+        invoke ``cb(arg)`` immediately.
+
+        On MicroPython, this is the built-in ``micropython.schedule``.
+
+        Args:
+            cb: Zero-or-one-arg callable invoked as ``cb(arg)``.
+            arg: Argument passed to ``cb`` (often the timer instance).
+
+        Raises:
+            RuntimeError: On MicroPython when the schedule queue is full.
+        """
         if not _is_main_thread():
             _queue(cb, arg)
             return

--- a/src/lib/multimer/_ticks.py
+++ b/src/lib/multimer/_ticks.py
@@ -218,3 +218,62 @@ async def _sleep_ms_async(ms):
 # rebinds the public ``sleep_ms`` per active backend (signal / pump / async).
 sleep_ms = _sleep_ms_pump
 _sleep_ms = _sleep_ms_pump
+
+# Ensure public helpers always carry Google-style docs for mkdocstrings, even
+# when the binding came from a host ``time``/``supervisor`` symbol without one.
+if not getattr(ticks_ms, "__doc__", None):
+    ticks_ms.__doc__ = """Return a wrapping millisecond tick counter (period ``2**29`` ms).
+
+    Compatible with MicroPython ``time.ticks_ms`` / CircuitPython
+    ``supervisor.ticks_ms``. Pair with :func:`ticks_diff` and :func:`ticks_add`.
+
+    Returns:
+        int: Milliseconds since an arbitrary epoch, masked to 29 bits.
+    """
+
+if not getattr(monotonic, "__doc__", None):
+    monotonic.__doc__ = """Return a monotonic clock in seconds (float).
+
+    Prefer this over wall-clock ``time.time()`` for intervals. On CircuitPython
+    with ``supervisor.ticks_ms``, returns ``ticks_ms() / 1000``.
+
+    Returns:
+        float: Seconds since an arbitrary epoch (monotonic).
+    """
+
+if not getattr(sleep_ms, "__doc__", None):
+    sleep_ms.__doc__ = """Sleep for ``ms`` milliseconds, pumping timers when the backend requires it.
+
+    Signal backends (librt / ``machine.Timer``) sleep without an extra pump.
+    Pump backends (win32 APC, SDL2, threading) drain the cooperative scheduler
+    and backend event queue around the wait. Async-only hosts expose an
+    awaitable variant.
+
+    Args:
+        ms: Duration to sleep, in milliseconds.
+    """
+
+if not getattr(ticks_add, "__doc__", None):
+    ticks_add.__doc__ = """Add a delta to a ticks value with wraparound at ``2**29`` ms.
+
+    Args:
+        ticks: Base ticks value from :func:`ticks_ms`.
+        delta: Signed offset in milliseconds (must fit in half the ticks period).
+
+    Returns:
+        int: ``(ticks + delta)`` wrapped to the ticks period.
+
+    Raises:
+        OverflowError: When ``delta`` is outside ``(-2**28, 2**28)``.
+    """
+
+if not getattr(ticks_diff, "__doc__", None):
+    ticks_diff.__doc__ = """Compute the signed difference between two ticks values.
+
+    Args:
+        ticks1: Later (or minuend) ticks value.
+        ticks2: Earlier (or subtrahend) ticks value.
+
+    Returns:
+        int: Signed ``ticks1 - ticks2`` in milliseconds, handling wraparound.
+    """


### PR DESCRIPTION
## Summary

- Google-style docstrings for `multimer`, `eventsys`, `displaysys`, and key `add_ons`
- gen-files: skip underscore path segments (`multimer/_backends`), drop stale `pygraphics` from path entries
- Refresh `docs/contributing/docstrings.md` priority tiers

Verified local `mkdocs build`: `Runtime.timer_async`, `Device.subscribe`, `AsyncTimer.init`/`deinit` appear; no `_backends` pages.